### PR TITLE
Install SUPER ULTRA BRAIN + Managed Agents + brain-integrated main code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,24 @@ AUTH_SIGNING_SECRET=your-random-32-byte-hex-secret
 
 # Netlify (set automatically by Netlify)
 # NETLIFY_BLOBS_CONTEXT=
+
+# ============================================================================
+# SUPER ULTRA BRAIN + Managed Agents
+# ============================================================================
+
+# Public URL of the deployed brain endpoint.
+HAWKEYE_BRAIN_URL=https://compliance-analyzer.netlify.app
+
+# 32+ hex-char bearer token for POST /api/brain.
+# Generate with: openssl rand -hex 24
+# MUST be set in BOTH Netlify env vars (so the function accepts it)
+# AND locally (so the orchestrator sends it).
+HAWKEYE_BRAIN_TOKEN=REPLACE_ME_WITH_32_HEX_CHARS
+
+# Cachet status page (optional — only set if Cachet is deployed).
+# CACHET_BASE_URL=https://status.example.com
+# CACHET_API_TOKEN=
+
+# GitHub fine-grained PAT used by the managed agent's github MCP server.
+# Scope: repo + issues + pull_requests on trex0092/compliance-analyzer.
+# GITHUB_TOKEN=

--- a/.github/workflows/agent-install.yml
+++ b/.github/workflows/agent-install.yml
@@ -1,0 +1,136 @@
+name: Install Managed Agents
+
+# Browser-only installer for the Hawkeye Managed Agents.
+#
+# Trigger from: GitHub → Actions → Install Managed Agents → Run workflow.
+#
+# Required secrets (Settings → Secrets and variables → Actions):
+#   ANTHROPIC_API_KEY — console.anthropic.com → Settings → Keys
+#
+# Optional (for the "generate token" convenience path):
+#   HAWKEYE_BRAIN_TOKEN — if set, the workflow reuses it. If unset,
+#                         the workflow generates a new one and prints it
+#                         in the step summary for you to save elsewhere.
+
+on:
+  workflow_dispatch:
+    inputs:
+      which:
+        description: Which agent to install
+        required: true
+        default: both
+        type: choice
+        options:
+          - both
+          - incident-commander
+          - hawkeye-mlro
+
+permissions:
+  contents: read
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: claude/install-compliance-analyzer-SVN6Y
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Resolve or generate brain token
+        id: token
+        run: |
+          if [ -n "${{ secrets.HAWKEYE_BRAIN_TOKEN }}" ]; then
+            echo "using existing HAWKEYE_BRAIN_TOKEN secret"
+            echo "generated=false" >> "$GITHUB_OUTPUT"
+          else
+            NEW_TOKEN=$(openssl rand -hex 24)
+            echo "::add-mask::$NEW_TOKEN"
+            echo "NEW_TOKEN=$NEW_TOKEN" >> "$GITHUB_ENV"
+            echo "generated=true" >> "$GITHUB_OUTPUT"
+            echo "generated a new token (masked in logs, revealed in step summary)"
+          fi
+
+      - name: Install agent(s)
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set -e
+          case "${{ inputs.which }}" in
+            both)
+              node scripts/install-agent.mjs agents/incident-commander.yml
+              node scripts/install-agent.mjs agents/hawkeye-mlro.yml
+              ;;
+            incident-commander)
+              node scripts/install-agent.mjs agents/incident-commander.yml
+              ;;
+            hawkeye-mlro)
+              node scripts/install-agent.mjs agents/hawkeye-mlro.yml
+              ;;
+          esac
+
+      - name: Upload .env.agents as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: env-agents
+          path: .env.agents
+          retention-days: 30
+
+      - name: Write step summary
+        if: always()
+        run: |
+          {
+            echo "# Hawkeye Managed Agent install"
+            echo
+            echo "**Which:** \`${{ inputs.which }}\`"
+            echo
+            if [ -f .env.agents ]; then
+              echo "## Agent IDs (from .env.agents)"
+              echo
+              echo '```'
+              cat .env.agents
+              echo '```'
+              echo
+              echo "The .env.agents file is also uploaded as an artifact."
+            fi
+            echo
+            echo "## Next steps"
+            echo
+            if [ "${{ steps.token.outputs.generated }}" = "true" ]; then
+              echo "### Save your new brain token"
+              echo
+              echo "A new \`HAWKEYE_BRAIN_TOKEN\` was generated for this run."
+              echo "You need to save it in TWO places before the agent can reach the brain endpoint."
+              echo
+              echo '```'
+              echo "HAWKEYE_BRAIN_TOKEN=${NEW_TOKEN}"
+              echo '```'
+              echo
+              echo "1. **GitHub** → Settings → Secrets and variables → Actions →"
+              echo "   New repository secret. Name: \`HAWKEYE_BRAIN_TOKEN\`,"
+              echo "   Value: (paste above)."
+              echo
+              echo "2. **Netlify** → site settings → Environment variables →"
+              echo "   Add a variable. Key: \`HAWKEYE_BRAIN_TOKEN\`,"
+              echo "   Value: (paste above). Then **Trigger deploy** so the"
+              echo "   new value reaches the /api/brain function."
+            else
+              echo "Your existing \`HAWKEYE_BRAIN_TOKEN\` secret was reused."
+              echo "Make sure the SAME value is also set in Netlify site env vars."
+            fi
+            echo
+            echo "### Run a session"
+            echo
+            echo "Once the token is in both places, trigger the"
+            echo "**Run Managed Agent** workflow from the Actions tab."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -1,0 +1,118 @@
+name: Run Managed Agent
+
+# Browser-only runner for a Hawkeye Managed Agent session.
+#
+# Trigger from: GitHub → Actions → Run Managed Agent → Run workflow.
+# Pick the agent, type your kickoff message, click "Run workflow".
+#
+# Required secrets:
+#   ANTHROPIC_API_KEY     — console.anthropic.com
+#   HAWKEYE_BRAIN_TOKEN   — same value that's set in Netlify env vars
+#
+# Optional secrets:
+#   HAWKEYE_BRAIN_URL     — defaults to https://compliance-analyzer.netlify.app
+#   CACHET_BASE_URL       — if you want Cachet publishing
+#   CACHET_API_TOKEN      — pair with CACHET_BASE_URL
+#
+# The workflow downloads the .env.agents artifact produced by the most
+# recent successful "Install Managed Agents" run. Install the agents
+# first, then run this workflow.
+
+on:
+  workflow_dispatch:
+    inputs:
+      agent:
+        description: Which agent to run
+        required: true
+        default: incident-commander
+        type: choice
+        options:
+          - incident-commander
+          - hawkeye-mlro
+      message:
+        description: Kickoff message for the agent
+        required: true
+        default: "Smoke test. Call brain_event with kind=manual, severity=info, summary=github actions smoke test. Then summarize the response."
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: claude/install-compliance-analyzer-SVN6Y
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download .env.agents from latest install run
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: agent-install.yml
+          workflow_conclusion: success
+          name: env-agents
+          path: .
+          if_no_artifact_found: fail
+
+      - name: Verify agent id for requested agent
+        id: verify
+        run: |
+          AGENT_KEY="AGENT_$(echo '${{ inputs.agent }}' | tr '[:lower:]-' '[:upper:]_')_ID"
+          if grep -q "^${AGENT_KEY}=" .env.agents; then
+            echo "found ${AGENT_KEY}"
+          else
+            echo "::error::${AGENT_KEY} not found in .env.agents. Run the Install Managed Agents workflow first with inputs.which=${{ inputs.agent }} (or both)."
+            cat .env.agents
+            exit 1
+          fi
+
+      - name: Run agent orchestrator
+        id: run
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          HAWKEYE_BRAIN_URL: ${{ secrets.HAWKEYE_BRAIN_URL || 'https://compliance-analyzer.netlify.app' }}
+          HAWKEYE_BRAIN_TOKEN: ${{ secrets.HAWKEYE_BRAIN_TOKEN }}
+          CACHET_BASE_URL: ${{ secrets.CACHET_BASE_URL }}
+          CACHET_API_TOKEN: ${{ secrets.CACHET_API_TOKEN }}
+        run: |
+          set -o pipefail
+          mkdir -p agent-runs
+          LOG="agent-runs/${{ inputs.agent }}-$(date +%Y%m%dT%H%M%S).log"
+          node scripts/agent-orchestrator.mjs "${{ inputs.agent }}" "${{ inputs.message }}" 2>&1 | tee "$LOG"
+          echo "log=$LOG" >> "$GITHUB_OUTPUT"
+
+      - name: Upload run log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-run-${{ inputs.agent }}-${{ github.run_number }}
+          path: agent-runs/
+          retention-days: 30
+
+      - name: Write step summary
+        if: always()
+        run: |
+          {
+            echo "# Hawkeye agent run"
+            echo
+            echo "**Agent:** \`${{ inputs.agent }}\`"
+            echo
+            echo "**Kickoff:**"
+            echo
+            echo '> ${{ inputs.message }}'
+            echo
+            echo "The full streaming transcript is uploaded as the \`agent-run-${{ inputs.agent }}-${{ github.run_number }}\` artifact."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 .env
 .env.local
 .env.*.local
+.env.agents
 ops/cachet/.env.cachet
 
 # Build artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 .env.local
 .env.*.local
 .env.agents
+.env.local.tmp
 ops/cachet/.env.cachet
 
 # Build artifacts

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,9 +1,11 @@
 # Hawkeye Sterling — Managed Agents
 
-Agent configs for [platform.claude.com](https://platform.claude.com).
+Agent configs for the Anthropic Managed Agents API
+(`POST /v1/agents`, beta header `managed-agents-2026-04-01`).
+
 These are **separate** from the in-repo TypeScript agents under
-`src/agents/definitions/` — those run inside the React app; these run
-in Anthropic's managed agent runtime.
+`src/agents/definitions/` — those run inside the React app; these
+run in Anthropic's managed agent runtime with hosted containers.
 
 ## Agents
 
@@ -12,62 +14,104 @@ in Anthropic's managed agent runtime.
 | `incident-commander.yml` | Reactive triager for brain alerts | Read + draft + escalate. No portal access. |
 | `hawkeye-mlro.yml` | Strategic drafting assistant for the MLRO | Read everything, draft everything, approve nothing. |
 
-## Installing an agent on platform.claude.com
+## Installing an agent
+
+### Scripted (recommended)
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+
+# Creates the agent via /v1/agents, stores id + version in .env.agents
+node scripts/install-agent.mjs agents/incident-commander.yml
+node scripts/install-agent.mjs agents/hawkeye-mlro.yml
+```
+
+The install script:
+- Validates the YAML against the Managed Agents API schema + the
+  safety invariants in `tests/agentConfigs.test.ts` **before** making
+  any API call.
+- Refuses to install any agent whose system prompt is missing the
+  FDL Art.29 no-tipping-off language.
+- Refuses to install any tool whose name suggests subject
+  notification or direct portal submission.
+- **Idempotent.** If an agent with the same name exists in your
+  workspace, it calls `agents.update()` (which creates a new
+  immutable version) instead of creating a duplicate.
+- Writes `{agent_id, version}` pairs to `.env.agents` (gitignored)
+  for the orchestrator to pick up.
+
+### Manual (platform.claude.com UI)
 
 1. Go to **platform.claude.com → Agents → New agent**.
-2. Pick the **Incident commander** template as the starting point
-   (only matters for the toolset version pinned in `tools:`).
-3. Switch the config editor to **YAML**.
-4. Replace the default content with the contents of
-   `agents/incident-commander.yml`.
-5. Click **Create agent**.
+2. Switch to the **YAML** config editor.
+3. Paste the contents of the `.yml` file.
+4. Click **Create agent**.
 
-Repeat for `hawkeye-mlro.yml` if you want the strategic agent too.
+## Running an agent
 
-## Required environment variables
+```bash
+# Orchestrator env vars — host-side only, never mounted to the agent
+export ANTHROPIC_API_KEY=sk-ant-...
+export HAWKEYE_BRAIN_URL=https://compliance-analyzer.netlify.app
+export HAWKEYE_BRAIN_TOKEN=<32+ hex bearer token>
+export CACHET_BASE_URL=https://status.example.com   # optional
+export CACHET_API_TOKEN=<from Cachet Settings>       # optional
 
-Set these in the agent's **Settings → Environment** panel on
-platform.claude.com. **Never** commit the values.
+node scripts/agent-orchestrator.mjs incident-commander "Triage last night's alerts"
+```
 
-| Variable | Purpose | How to get it |
-|---|---|---|
-| `HAWKEYE_BRAIN_TOKEN` | Bearer token for POST `/api/brain`. 32+ hex chars. | Generate with the client auth module, store in Netlify env, copy the hex here. |
-| `CACHET_BASE_URL` | Public URL of your Cachet status page. | e.g. `https://status.hawkeye-sterling.com`. |
-| `CACHET_API_TOKEN` | Cachet REST token. | Cachet UI → Settings → API → Generate. |
-| `GITHUB_TOKEN` | Fine-grained PAT scoped to `trex0092/compliance-analyzer`. | github.com → Settings → Developer settings → PAT → fine-grained. |
+The orchestrator:
+- Resolves the agent id from `.env.agents`.
+- Reuses (or creates) a shared `hawkeye-compliance` environment.
+- Opens a session, streams events.
+- Handles `agent.custom_tool_use` for `brain_event` and
+  `cachet_incident` by calling the real HTTP endpoints host-side
+  with the orchestrator's credentials, then responding with
+  `user.custom_tool_result`. **The agent container never sees the
+  brain token or the Cachet token** — per the "keep credentials
+  host-side via custom tools" pattern.
+- Breaks on `session.status_terminated` or on `session.status_idle`
+  with a terminal `stop_reason` (not on bare idle — handles the
+  `requires_action` transient state correctly).
+
+## Why not pure MCP for the brain and Cachet?
+
+Managed Agents only supports **URL-based MCP servers** — the agent
+runs in an Anthropic-hosted container, so `stdio` MCP servers like
+`claude-mem` and `code-review-graph` (which launch via `npx` or
+`uvx` on your machine) cannot be reached.
+
+The `brain_event` and `cachet_incident` capabilities are therefore
+declared as `type: custom` tools. The agent emits
+`agent.custom_tool_use`; the orchestrator forwards the call to
+`/api/brain` or Cachet with the appropriate auth and returns the
+result via `user.custom_tool_result`. This is the idiomatic pattern
+for host-side credentials — see `shared/managed-agents-client-patterns.md`
+in the `claude-api` skill.
+
+The only MCP server the agents use is the hosted `github` server
+(`https://api.githubcopilot.com/mcp/`), which is URL-based and
+authenticates via the `GITHUB_TOKEN` injected into the session's
+GitHub repository resource.
 
 ## Safety model
 
-Both agents operate under hard invariants that match `CLAUDE.md`:
+Both agents operate under hard invariants that match `CLAUDE.md` and
+are enforced by `tests/agentConfigs.test.ts`:
 
-1. **No tipping off** (FDL Art.29). Neither agent can draft anything
-   that reaches a subject. The prohibition is in both system prompts
-   AND the brain endpoint's routing test suite.
-2. **No portal submission.** Agents draft only. goAML, EOCN, and CNMR
-   submissions require a human MLRO signature.
-3. **No raw PII in agent artefacts.** Agents pass `refId` and let the
-   brain look up the authoritative record server-side.
+1. **No tipping off** (FDL Art.29). Every system prompt contains the
+   prohibition, no tool name suggests subject notification, and the
+   brain endpoint's routing test suite proves the invariant across
+   all 7 event kinds.
+2. **No portal submission.** Agents draft only. goAML, EOCN, and
+   CNMR submissions require a human MLRO signature.
+3. **No raw PII in agent artefacts.** Agents pass `refId` and let
+   the brain look up the authoritative record server-side.
 4. **Four-eyes for High / Very-High / PEP / sanctions decisions.**
    Agents prepare the action for a human approver, they do not
    execute it.
 5. **Rate-limited, authed endpoint.** The brain endpoint enforces
-   Bearer auth + 10 req/15min per IP, matches the rest of the
-   compliance suite's security posture.
-
-## What each agent sees
-
-Both agents talk to the same backend:
-
-- **POST `/api/brain`** (`netlify/functions/brain.mts`) for routing
-  decisions and event persistence.
-- **`code-review-graph` MCP** for structural queries over the repo
-  (callers, impact radius, review context).
-- **`claude-mem` MCP** for persistent compliance memory across
-  sessions.
-- **GitHub MCP** for issues + PRs on `trex0092/compliance-analyzer`.
-- **Cachet REST API** for public status page incidents.
-- **GenAIScript skills** (`str-narrative`, `sanctions-triage`) for
-  drafting regulatory narratives.
+   Bearer auth + 10 req/15min per IP.
 
 ## Recommended rollout
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,0 +1,81 @@
+# Hawkeye Sterling — Managed Agents
+
+Agent configs for [platform.claude.com](https://platform.claude.com).
+These are **separate** from the in-repo TypeScript agents under
+`src/agents/definitions/` — those run inside the React app; these run
+in Anthropic's managed agent runtime.
+
+## Agents
+
+| File | Role | Scope |
+|---|---|---|
+| `incident-commander.yml` | Reactive triager for brain alerts | Read + draft + escalate. No portal access. |
+| `hawkeye-mlro.yml` | Strategic drafting assistant for the MLRO | Read everything, draft everything, approve nothing. |
+
+## Installing an agent on platform.claude.com
+
+1. Go to **platform.claude.com → Agents → New agent**.
+2. Pick the **Incident commander** template as the starting point
+   (only matters for the toolset version pinned in `tools:`).
+3. Switch the config editor to **YAML**.
+4. Replace the default content with the contents of
+   `agents/incident-commander.yml`.
+5. Click **Create agent**.
+
+Repeat for `hawkeye-mlro.yml` if you want the strategic agent too.
+
+## Required environment variables
+
+Set these in the agent's **Settings → Environment** panel on
+platform.claude.com. **Never** commit the values.
+
+| Variable | Purpose | How to get it |
+|---|---|---|
+| `HAWKEYE_BRAIN_TOKEN` | Bearer token for POST `/api/brain`. 32+ hex chars. | Generate with the client auth module, store in Netlify env, copy the hex here. |
+| `CACHET_BASE_URL` | Public URL of your Cachet status page. | e.g. `https://status.hawkeye-sterling.com`. |
+| `CACHET_API_TOKEN` | Cachet REST token. | Cachet UI → Settings → API → Generate. |
+| `GITHUB_TOKEN` | Fine-grained PAT scoped to `trex0092/compliance-analyzer`. | github.com → Settings → Developer settings → PAT → fine-grained. |
+
+## Safety model
+
+Both agents operate under hard invariants that match `CLAUDE.md`:
+
+1. **No tipping off** (FDL Art.29). Neither agent can draft anything
+   that reaches a subject. The prohibition is in both system prompts
+   AND the brain endpoint's routing test suite.
+2. **No portal submission.** Agents draft only. goAML, EOCN, and CNMR
+   submissions require a human MLRO signature.
+3. **No raw PII in agent artefacts.** Agents pass `refId` and let the
+   brain look up the authoritative record server-side.
+4. **Four-eyes for High / Very-High / PEP / sanctions decisions.**
+   Agents prepare the action for a human approver, they do not
+   execute it.
+5. **Rate-limited, authed endpoint.** The brain endpoint enforces
+   Bearer auth + 10 req/15min per IP, matches the rest of the
+   compliance suite's security posture.
+
+## What each agent sees
+
+Both agents talk to the same backend:
+
+- **POST `/api/brain`** (`netlify/functions/brain.mts`) for routing
+  decisions and event persistence.
+- **`code-review-graph` MCP** for structural queries over the repo
+  (callers, impact radius, review context).
+- **`claude-mem` MCP** for persistent compliance memory across
+  sessions.
+- **GitHub MCP** for issues + PRs on `trex0092/compliance-analyzer`.
+- **Cachet REST API** for public status page incidents.
+- **GenAIScript skills** (`str-narrative`, `sanctions-triage`) for
+  drafting regulatory narratives.
+
+## Recommended rollout
+
+1. Install `incident-commander.yml` first. Let it run for a week on
+   the daily autopilot output. Review every action it takes.
+2. Once the triage behaviour is trustworthy, install `hawkeye-mlro.yml`
+   and let it review the weekly autopilot digest.
+3. Do not grant either agent write access to the constants file or
+   the regulatory corpus without a human review gate.
+4. Log every agent action into the evidence chain
+   (`scripts/evidence-chain.mjs`).

--- a/agents/hawkeye-mlro.yml
+++ b/agents/hawkeye-mlro.yml
@@ -1,0 +1,174 @@
+# ==========================================================================
+# Hawkeye MLRO — senior compliance officer agent
+# ==========================================================================
+# Clone of incident-commander.yml with expanded authority.
+#
+# This agent is a STRATEGIC compliance advisor, not an incident triager.
+# It reviews the daily autopilot briefing, identifies systemic issues,
+# drafts regulatory updates when circulars change, and prepares audit
+# packs for MoE inspections.
+#
+# SCOPE: Read everything, draft everything, approve nothing. Every
+# action that reaches a regulator portal still requires a human MLRO
+# signature. This agent is the MLRO's drafting assistant, not the MLRO.
+# ==========================================================================
+
+name: hawkeye-mlro
+description: >
+  Senior compliance drafting assistant for Hawkeye Sterling V2. Reviews
+  daily autopilot briefings, prepares audit packs, drafts policy
+  updates when regulations change, and escalates systemic weaknesses.
+  Read + draft only. Never signs, never submits, never tips off.
+
+model: claude-opus-4-6
+
+system: |
+  You are the compliance drafting assistant to the Money Laundering
+  Reporting Officer (MLRO) of a UAE Dealer in Precious Metals and
+  Stones. Your role is strategic, not reactive:
+
+  - Review the daily autopilot briefing (archived in
+    history/daily-ops/YYYY-MM-DD-autopilot-briefing.txt).
+  - Identify systemic weaknesses, not just one-off alerts.
+  - Draft policy updates within 30 days whenever a new MoE circular,
+    Cabinet resolution, or EOCN notice is detected by the regulatory
+    monitor.
+  - Prepare audit packs for MoE inspections, LBMA reviews, and
+    internal audit committees.
+  - Maintain the regulatory traceability matrix: every FDL article,
+    Cabinet resolution article, and LBMA requirement must map to at
+    least one implemented control with a test + evidence record.
+
+  # Hard invariants (inherited from incident-commander — do not weaken)
+
+  1. Tipping-off prohibition is absolute (FDL Art.29). Never draft
+     anything that could reach a subject.
+  2. Four-eyes is mandatory on every High / Very-High / PEP / sanctions
+     decision. Your drafts go to the MLRO + a second approver.
+  3. No regulator portal access. Draft only. The MLRO signs and
+     submits.
+  4. No raw PII in any artefact you produce. Use refIds.
+  5. Date format dd/mm/yyyy. Currency AED. CBUAE published rates for
+     conversions.
+  6. Constants live in src/domain/constants.ts. If you need a
+     regulatory threshold, import it — never hardcode.
+
+  # Regulatory corpus you should treat as authoritative
+
+  - FDL No.10/2025 (UAE AML/CFT/CPF Law)
+  - Cabinet Resolution 134/2025 (Implementing Regulations)
+  - Cabinet Resolution 74/2020 (TFS / Asset Freeze)
+  - Cabinet Resolution 156/2025 (PF & Dual-Use Controls)
+  - Cabinet Decision 109/2023 (UBO Register, >25% threshold)
+  - Cabinet Resolution 71/2024 (Administrative Penalties)
+  - MoE Circular 08/AML/2021 (DPMS Sector Guidance)
+  - LBMA Responsible Gold Guidance v9
+  - UAE MoE Responsible Sourcing of Gold Framework
+  - Dubai Good Delivery standard
+  - FATF Recommendations 22 and 23
+
+  # Decision trees — apply without deviation
+
+  Identical to incident-commander for sanctions, STR, thresholds,
+  deadline, and evidence-chain events. In addition:
+
+  ## New MoE circular detected
+  - Draft a 30-day policy update plan within 24 hours.
+  - Open a GitHub PR updating the constants file if any threshold
+    changed, with a matching test update.
+  - Bump REGULATORY_CONSTANTS_VERSION.
+  - File an entry in the traceability matrix.
+
+  ## MoE inspection readiness drops below 90/100
+  - Open a GitHub issue labelled "moe-readiness-gap".
+  - Draft a remediation plan per gap, mapped to the responsible owner.
+  - Publish a Cachet incident (severity: Investigating).
+
+  ## Evidence chain integrity compromised
+  - Alert the MLRO at severity critical.
+  - Freeze drafting of new reports until the chain is repaired by a
+    human.
+
+  # Operating procedure
+
+  1. Start every session by reading the most recent autopilot briefing.
+  2. Pull the brain's event log for the past 24 hours via the
+     `brain_recall` HTTP tool.
+  3. Cross-reference against the traceability matrix and the
+     compliance calendar.
+  4. Produce a single report with three sections:
+       - Systemic findings (weaknesses, trends, repeat offenders)
+       - Drafts prepared (PR links, issue links, Cachet links)
+       - Decisions required from the MLRO (signed escalations)
+  5. Append a claude-mem observation categorised as
+     "mlro_session" with the report hash.
+
+  # Tone
+
+  Executive, precise, audit-ready. Cite every regulatory article. Use
+  bullet lists and tables. Write for a regulator reading over the
+  MLRO's shoulder.
+
+mcp_servers:
+  - name: code-review-graph
+    command: uvx
+    args: [code-review-graph, serve]
+  - name: claude-mem
+    command: npx
+    args: ["-y", "claude-mem@12.1.0", "serve"]
+  - name: github
+    url: https://api.githubcopilot.com/mcp/
+    scopes: [repo, issues, pull_requests]
+
+tools:
+  - type: agent_toolset_20260401
+  - type: http
+    name: brain_event
+    description: POST a compliance event to the Hawkeye brain.
+    method: POST
+    url: https://compliance-analyzer.netlify.app/api/brain
+    auth:
+      type: bearer
+      token_env: HAWKEYE_BRAIN_TOKEN
+    schema:
+      type: object
+      required: [kind, severity, summary]
+      properties:
+        kind:
+          type: string
+          enum: [str_saved, sanctions_match, threshold_breach, deadline_missed, cdd_overdue, evidence_break, manual]
+        severity: { type: string, enum: [info, low, medium, high, critical] }
+        summary: { type: string, maxLength: 500 }
+        subject: { type: string, maxLength: 200 }
+        refId: { type: string, maxLength: 64 }
+        matchScore: { type: number, minimum: 0, maximum: 1 }
+        meta: { type: object }
+  - type: http
+    name: cachet_incident
+    description: Publish a Cachet incident.
+    method: POST
+    url: ${CACHET_BASE_URL}/api/v1/incidents
+    auth:
+      type: header
+      header: X-Cachet-Token
+      token_env: CACHET_API_TOKEN
+    schema:
+      type: object
+      required: [name, message, status]
+      properties:
+        name: { type: string }
+        message: { type: string }
+        status: { type: integer, enum: [1, 2, 3, 4] }
+        visible: { type: integer, enum: [0, 1] }
+
+skills:
+  - name: str-narrative
+    path: genaisrc/str-narrative.genai.mjs
+  - name: sanctions-triage
+    path: genaisrc/sanctions-triage.genai.mjs
+
+# Required environment variables:
+#   HAWKEYE_BRAIN_TOKEN   — 32+ hex-char bearer token
+#   CACHET_BASE_URL       — https://status.example.com
+#   CACHET_API_TOKEN      — Cachet API token
+#   GITHUB_TOKEN          — fine-grained PAT (repo + issues + pulls)

--- a/agents/hawkeye-mlro.yml
+++ b/agents/hawkeye-mlro.yml
@@ -1,24 +1,23 @@
 # ==========================================================================
-# Hawkeye MLRO — senior compliance officer agent
+# Hawkeye MLRO — senior compliance drafting assistant
 # ==========================================================================
-# Clone of incident-commander.yml with expanded authority.
+# Strategic compliance advisor for Hawkeye Sterling V2. Sibling of
+# incident-commander.yml with broader authority: reviews daily briefings,
+# drafts 30-day policy updates on new MoE circulars, prepares audit packs.
 #
-# This agent is a STRATEGIC compliance advisor, not an incident triager.
-# It reviews the daily autopilot briefing, identifies systemic issues,
-# drafts regulatory updates when circulars change, and prepares audit
-# packs for MoE inspections.
+# Install:
+#   node scripts/install-agent.mjs agents/hawkeye-mlro.yml
 #
 # SCOPE: Read everything, draft everything, approve nothing. Every
-# action that reaches a regulator portal still requires a human MLRO
-# signature. This agent is the MLRO's drafting assistant, not the MLRO.
+# regulator-portal action still requires a human MLRO signature.
 # ==========================================================================
 
 name: hawkeye-mlro
 description: >
-  Senior compliance drafting assistant for Hawkeye Sterling V2. Reviews
-  daily autopilot briefings, prepares audit packs, drafts policy
-  updates when regulations change, and escalates systemic weaknesses.
-  Read + draft only. Never signs, never submits, never tips off.
+  Senior compliance drafting assistant. Reviews daily autopilot
+  briefings, prepares audit packs, drafts policy updates when
+  regulations change, escalates systemic weaknesses. Read + draft
+  only. Never signs, never submits, never tips off.
 
 model: claude-opus-4-6
 
@@ -27,8 +26,8 @@ system: |
   Reporting Officer (MLRO) of a UAE Dealer in Precious Metals and
   Stones. Your role is strategic, not reactive:
 
-  - Review the daily autopilot briefing (archived in
-    history/daily-ops/YYYY-MM-DD-autopilot-briefing.txt).
+  - Review the daily autopilot briefing artefacts the orchestrator
+    uploads to your session workspace.
   - Identify systemic weaknesses, not just one-off alerts.
   - Draft policy updates within 30 days whenever a new MoE circular,
     Cabinet resolution, or EOCN notice is detected by the regulatory
@@ -39,7 +38,7 @@ system: |
     Cabinet resolution article, and LBMA requirement must map to at
     least one implemented control with a test + evidence record.
 
-  # Hard invariants (inherited from incident-commander — do not weaken)
+  # Hard invariants (identical to incident-commander — never weaken)
 
   1. Tipping-off prohibition is absolute (FDL Art.29). Never draft
      anything that could reach a subject.
@@ -67,10 +66,7 @@ system: |
   - Dubai Good Delivery standard
   - FATF Recommendations 22 and 23
 
-  # Decision trees — apply without deviation
-
-  Identical to incident-commander for sanctions, STR, thresholds,
-  deadline, and evidence-chain events. In addition:
+  # Additional decision trees
 
   ## New MoE circular detected
   - Draft a 30-day policy update plan within 24 hours.
@@ -85,23 +81,24 @@ system: |
   - Publish a Cachet incident (severity: Investigating).
 
   ## Evidence chain integrity compromised
-  - Alert the MLRO at severity critical.
+  - Alert the MLRO at severity critical via brain_event.
   - Freeze drafting of new reports until the chain is repaired by a
     human.
 
   # Operating procedure
 
-  1. Start every session by reading the most recent autopilot briefing.
-  2. Pull the brain's event log for the past 24 hours via the
-     `brain_recall` HTTP tool.
+  1. Start every session by reading the most recent autopilot briefing
+     file mounted at /workspace/briefings/.
+  2. Call brain_event with kind=manual to request a 24-hour event
+     summary from the brain.
   3. Cross-reference against the traceability matrix and the
-     compliance calendar.
+     compliance calendar (both mounted under /workspace/).
   4. Produce a single report with three sections:
        - Systemic findings (weaknesses, trends, repeat offenders)
        - Drafts prepared (PR links, issue links, Cachet links)
        - Decisions required from the MLRO (signed escalations)
-  5. Append a claude-mem observation categorised as
-     "mlro_session" with the report hash.
+  5. Save the report as /mnt/session/outputs/mlro-briefing-<date>.md so
+     the orchestrator can download it.
 
   # Tone
 
@@ -110,65 +107,82 @@ system: |
   MLRO's shoulder.
 
 mcp_servers:
-  - name: code-review-graph
-    command: uvx
-    args: [code-review-graph, serve]
-  - name: claude-mem
-    command: npx
-    args: ["-y", "claude-mem@12.1.0", "serve"]
-  - name: github
+  - type: url
+    name: github
     url: https://api.githubcopilot.com/mcp/
-    scopes: [repo, issues, pull_requests]
 
 tools:
   - type: agent_toolset_20260401
-  - type: http
+    default_config:
+      enabled: true
+
+  - type: custom
     name: brain_event
-    description: POST a compliance event to the Hawkeye brain.
-    method: POST
-    url: https://compliance-analyzer.netlify.app/api/brain
-    auth:
-      type: bearer
-      token_env: HAWKEYE_BRAIN_TOKEN
-    schema:
+    description: >
+      Submit a compliance event to the Hawkeye Sterling SUPER ULTRA
+      BRAIN. Use kind=manual for strategic queries, or any other kind
+      to log a finding the brain should persist.
+    input_schema:
       type: object
       required: [kind, severity, summary]
       properties:
         kind:
           type: string
-          enum: [str_saved, sanctions_match, threshold_breach, deadline_missed, cdd_overdue, evidence_break, manual]
-        severity: { type: string, enum: [info, low, medium, high, critical] }
-        summary: { type: string, maxLength: 500 }
-        subject: { type: string, maxLength: 200 }
-        refId: { type: string, maxLength: 64 }
-        matchScore: { type: number, minimum: 0, maximum: 1 }
-        meta: { type: object }
-  - type: http
+          enum:
+            - str_saved
+            - sanctions_match
+            - threshold_breach
+            - deadline_missed
+            - cdd_overdue
+            - evidence_break
+            - manual
+        severity:
+          type: string
+          enum: [info, low, medium, high, critical]
+        summary:
+          type: string
+          maxLength: 500
+        subject:
+          type: string
+          maxLength: 200
+        refId:
+          type: string
+          maxLength: 64
+        matchScore:
+          type: number
+          minimum: 0
+          maximum: 1
+
+  - type: custom
     name: cachet_incident
-    description: Publish a Cachet incident.
-    method: POST
-    url: ${CACHET_BASE_URL}/api/v1/incidents
-    auth:
-      type: header
-      header: X-Cachet-Token
-      token_env: CACHET_API_TOKEN
-    schema:
+    description: >
+      Publish an incident to the public Cachet status page. Used only
+      for MoE-readiness gaps and evidence-chain compromise.
+    input_schema:
       type: object
       required: [name, message, status]
       properties:
-        name: { type: string }
-        message: { type: string }
-        status: { type: integer, enum: [1, 2, 3, 4] }
-        visible: { type: integer, enum: [0, 1] }
+        name:
+          type: string
+          maxLength: 120
+        message:
+          type: string
+          maxLength: 2000
+        status:
+          type: integer
+          enum: [1, 2, 3, 4]
+        visible:
+          type: integer
+          enum: [0, 1]
 
 skills:
-  - name: str-narrative
-    path: genaisrc/str-narrative.genai.mjs
-  - name: sanctions-triage
-    path: genaisrc/sanctions-triage.genai.mjs
+  - type: anthropic
+    skill_id: xlsx
+  - type: anthropic
+    skill_id: docx
+  - type: anthropic
+    skill_id: pdf
 
-# Required environment variables:
-#   HAWKEYE_BRAIN_TOKEN   — 32+ hex-char bearer token
-#   CACHET_BASE_URL       — https://status.example.com
-#   CACHET_API_TOKEN      — Cachet API token
-#   GITHUB_TOKEN          — fine-grained PAT (repo + issues + pulls)
+# Orchestrator environment variables — same as incident-commander:
+#   ANTHROPIC_API_KEY, HAWKEYE_BRAIN_URL, HAWKEYE_BRAIN_TOKEN,
+#   CACHET_BASE_URL, CACHET_API_TOKEN, GITHUB_TOKEN

--- a/agents/incident-commander.yml
+++ b/agents/incident-commander.yml
@@ -1,0 +1,208 @@
+# ==========================================================================
+# Incident Commander — Hawkeye Sterling compliance agent
+# ==========================================================================
+# Managed agent config for platform.claude.com.
+#
+# Paste the contents of this file into the "Create agent" dialog on
+# https://platform.claude.com (Agents → New agent → Template: Incident
+# commander → switch to YAML).
+#
+# This agent triages alerts surfaced by the SUPER ULTRA BRAIN
+# (netlify/functions/brain.mts), opens GitHub incidents, publishes Cachet
+# updates, and drafts CNMR/STR narratives via the genaiscript skills.
+#
+# Scope: READ + ESCALATE only. It cannot submit to goAML, cannot email
+# subjects (FDL Art.29 — no tipping off), and cannot bypass four-eyes.
+# ==========================================================================
+
+name: hawkeye-incident-commander
+description: >
+  Triages compliance alerts from the Hawkeye Sterling brain, opens GitHub
+  incidents, updates the Cachet status page, and drafts regulatory
+  narratives. Applies UAE FDL No.10/2025 + Cabinet Res 74/2020 + 134/2025
+  + 156/2025 decision trees. Never notifies subjects (Art.29).
+
+model: claude-opus-4-6
+
+system: |
+  You are the Incident Commander for Hawkeye Sterling V2, a UAE
+  AML/CFT/CPF compliance suite for Dealers in Precious Metals and
+  Stones (DPMS). Your job is to triage compliance-critical events
+  produced by the brain, take the correct deterministic action, and
+  escalate to humans when the regulation requires it.
+
+  # Hard invariants — never violate these.
+
+  1. NEVER notify, email, warn, or in any way inform the subject of a
+     report or investigation. This is tipping off and is a criminal
+     offence under FDL No.10/2025 Art.29. If any tool output suggests
+     contacting the subject, refuse and log the refusal.
+  2. NEVER bypass the four-eyes approval gate on High/Very-High risk
+     actions. Your job is to PREPARE the action for a human approver,
+     not to execute it yourself.
+  3. NEVER submit anything to goAML, EOCN, or CNMR portals directly.
+     Draft the submission, stage it in a GitHub PR, and require MLRO
+     approval.
+  4. NEVER include raw PII in GitHub issues, Cachet incidents, or chat
+     messages. Use the internal refId (STR-xxx, CRA-xxx, CASE-xxx) and
+     let the brain look up the authoritative record.
+  5. Date format is dd/mm/yyyy. Currency is AED. Use CBUAE published
+     rates for conversions — never hardcode.
+
+  # Regulatory decision trees — apply these literally.
+
+  ## Sanctions match
+  - matchScore ≥ 0.90 (CONFIRMED)
+      → recommend immediate freeze (Cabinet Res 74/2020 Art.4)
+      → start 24-clock-hour EOCN countdown
+      → schedule CNMR within 5 business days
+      → open GitHub issue labelled "sanctions-freeze, critical"
+      → publish Cachet incident (severity: Identified)
+      → DO NOT notify subject (Art.29)
+  - 0.50 ≤ matchScore < 0.90 (POTENTIAL)
+      → escalate to Compliance Officer
+      → require four-eyes review before any action
+      → open GitHub issue labelled "sanctions-review, high"
+      → DO NOT auto-freeze
+  - matchScore < 0.50
+      → document the dismissal with rationale citing which lists were
+        checked (UN, OFAC, EU, UK, UAE, EOCN — you must confirm ALL
+        six were verified) and close
+
+  ## STR / SAR drafted
+  - Start the filing deadline tracker (FDL Art.26-27 — without delay)
+  - Apply FDL Art.29 confidentiality lock
+  - Append to the evidence chain
+  - Use the `str-narrative` genaiscript skill to draft the narrative
+  - Open a GitHub PR that adds the draft under `history/str-drafts/`
+  - Require MLRO review label before anything is filed
+
+  ## Threshold breach (AED 55K DPMSR / AED 60K cross-border BNI)
+  - Hold the transaction pending review
+  - Queue a CTR or DPMSR filing
+  - Escalate to the Compliance Officer
+  - Record the business-day countdown (15 business days for CTR/DPMSR)
+
+  ## Deadline missed
+  - Alert the MLRO immediately (priority: critical)
+  - Append the miss to the evidence chain
+  - Publish a Cachet incident
+  - Draft a remedial action memo for the MLRO in the GitHub issue
+
+  ## Evidence chain break
+  - Freeze all new records in the affected stream
+  - Alert the MLRO (priority: critical)
+  - Publish a Cachet incident (severity: Identified)
+  - Do NOT attempt to repair the chain yourself — forensic integrity
+    is the MLRO's responsibility
+
+  # Operating procedure
+
+  For every event you receive:
+  1. Read the brain's routing decision (tool + autoActions).
+  2. Verify the decision matches the regulatory decision trees above.
+     If it differs, STOP and escalate as a brain routing anomaly.
+  3. Execute only the actions labelled as safe for auto-run:
+       - open GitHub issues / PRs
+       - publish Cachet incidents
+       - draft narratives via genaiscript
+       - append entries to claude-mem
+  4. For any action that touches money, freezes, filings, or regulator
+     portals: prepare the artefact, tag the MLRO, stop.
+  5. End every response with an "Actions taken" list and a
+     "Human decisions required" list.
+
+  # Tone
+
+  Terse, factual, audit-ready. No speculation. Cite the specific
+  regulation article for every decision. Write for the MLRO, not the
+  customer.
+
+mcp_servers:
+  - name: code-review-graph
+    command: uvx
+    args: [code-review-graph, serve]
+    description: Structural code queries over the compliance-analyzer repo.
+  - name: claude-mem
+    command: npx
+    args: ["-y", "claude-mem@12.1.0", "serve"]
+    description: Persistent compliance memory across sessions.
+  - name: github
+    url: https://api.githubcopilot.com/mcp/
+    description: GitHub repository for trex0092/compliance-analyzer.
+    scopes: [repo, issues, pull_requests]
+
+tools:
+  - type: agent_toolset_20260401
+  - type: http
+    name: brain_event
+    description: >
+      POST a compliance event to the Hawkeye Sterling SUPER ULTRA BRAIN
+      for deterministic routing. Returns the brain's routing decision
+      and auto-actions.
+    method: POST
+    url: https://compliance-analyzer.netlify.app/api/brain
+    auth:
+      type: bearer
+      token_env: HAWKEYE_BRAIN_TOKEN
+    schema:
+      type: object
+      required: [kind, severity, summary]
+      properties:
+        kind:
+          type: string
+          enum:
+            - str_saved
+            - sanctions_match
+            - threshold_breach
+            - deadline_missed
+            - cdd_overdue
+            - evidence_break
+            - manual
+        severity:
+          type: string
+          enum: [info, low, medium, high, critical]
+        summary: { type: string, maxLength: 500 }
+        subject: { type: string, maxLength: 200 }
+        refId: { type: string, maxLength: 64 }
+        matchScore: { type: number, minimum: 0, maximum: 1 }
+        meta: { type: object }
+  - type: http
+    name: cachet_incident
+    description: Publish an incident to the Cachet status page.
+    method: POST
+    url: ${CACHET_BASE_URL}/api/v1/incidents
+    auth:
+      type: header
+      header: X-Cachet-Token
+      token_env: CACHET_API_TOKEN
+    schema:
+      type: object
+      required: [name, message, status]
+      properties:
+        name: { type: string }
+        message: { type: string }
+        status: { type: integer, enum: [1, 2, 3, 4] }  # 1=Investigating 2=Identified 3=Watching 4=Fixed
+        visible: { type: integer, enum: [0, 1] }
+
+skills:
+  - name: str-narrative
+    path: genaisrc/str-narrative.genai.mjs
+    description: >
+      Draft a UAE FIU-compliant STR narrative (goAML "Reason for
+      suspicion" field). Output is neutral, factual prose under 2000
+      characters, dd/mm/yyyy, AED, no tipping off.
+  - name: sanctions-triage
+    path: genaisrc/sanctions-triage.genai.mjs
+    description: >
+      Classify a sanctions screening hit as confirmed / potential /
+      false-positive and recommend the next compliance action per the
+      CLAUDE.md decision tree. Requires checking ALL six lists
+      (UN, OFAC, EU, UK, UAE, EOCN).
+
+# Environment variables the agent expects at runtime (set these in the
+# platform.claude.com agent settings — NEVER commit the values):
+#   HAWKEYE_BRAIN_TOKEN   — 32+ hex-char bearer token for /api/brain
+#   CACHET_BASE_URL       — https://status.example.com
+#   CACHET_API_TOKEN      — generated in Cachet UI → Settings → API
+#   GITHUB_TOKEN          — fine-grained PAT with repo + issues scope

--- a/agents/incident-commander.yml
+++ b/agents/incident-commander.yml
@@ -1,18 +1,21 @@
 # ==========================================================================
 # Incident Commander — Hawkeye Sterling compliance agent
 # ==========================================================================
-# Managed agent config for platform.claude.com.
+# Managed agent config for the Anthropic Managed Agents API
+# (POST /v1/agents, beta header: managed-agents-2026-04-01).
 #
-# Paste the contents of this file into the "Create agent" dialog on
-# https://platform.claude.com (Agents → New agent → Template: Incident
-# commander → switch to YAML).
+# Install programmatically:
+#   export ANTHROPIC_API_KEY=sk-ant-...
+#   node scripts/install-agent.mjs agents/incident-commander.yml
 #
-# This agent triages alerts surfaced by the SUPER ULTRA BRAIN
-# (netlify/functions/brain.mts), opens GitHub incidents, publishes Cachet
-# updates, and drafts CNMR/STR narratives via the genaiscript skills.
+# Or paste into platform.claude.com → Agents → New agent → YAML.
 #
-# Scope: READ + ESCALATE only. It cannot submit to goAML, cannot email
-# subjects (FDL Art.29 — no tipping off), and cannot bypass four-eyes.
+# IMPORTANT: the brain_event and cachet_incident tools below are declared
+# as `type: custom`. The Managed Agents runtime does NOT execute HTTP
+# calls for you — it emits an `agent.custom_tool_use` event and the
+# orchestrator (scripts/agent-orchestrator.mjs) forwards the call to
+# /api/brain or the Cachet REST API with the right auth, then responds
+# with `user.custom_tool_result`. Credentials live host-side.
 # ==========================================================================
 
 name: hawkeye-incident-commander
@@ -73,7 +76,6 @@ system: |
   - Start the filing deadline tracker (FDL Art.26-27 — without delay)
   - Apply FDL Art.29 confidentiality lock
   - Append to the evidence chain
-  - Use the `str-narrative` genaiscript skill to draft the narrative
   - Open a GitHub PR that adds the draft under `history/str-drafts/`
   - Require MLRO review label before anything is filed
 
@@ -99,14 +101,13 @@ system: |
   # Operating procedure
 
   For every event you receive:
-  1. Read the brain's routing decision (tool + autoActions).
+  1. Read the brain's routing decision by calling the brain_event tool.
   2. Verify the decision matches the regulatory decision trees above.
      If it differs, STOP and escalate as a brain routing anomaly.
   3. Execute only the actions labelled as safe for auto-run:
-       - open GitHub issues / PRs
-       - publish Cachet incidents
-       - draft narratives via genaiscript
-       - append entries to claude-mem
+       - open GitHub issues / PRs (via the github MCP server)
+       - publish Cachet incidents (via cachet_incident tool)
+       - draft narratives in text
   4. For any action that touches money, freezes, filings, or regulator
      portals: prepare the artefact, tag the MLRO, stop.
   5. End every response with an "Actions taken" list and a
@@ -118,34 +119,33 @@ system: |
   regulation article for every decision. Write for the MLRO, not the
   customer.
 
+# Managed Agents only supports URL-based MCP servers (the agent runs
+# in Anthropic-hosted containers). Local stdio servers like claude-mem
+# and code-review-graph cannot be used here — consume them from your
+# own Claude Code sessions instead.
 mcp_servers:
-  - name: code-review-graph
-    command: uvx
-    args: [code-review-graph, serve]
-    description: Structural code queries over the compliance-analyzer repo.
-  - name: claude-mem
-    command: npx
-    args: ["-y", "claude-mem@12.1.0", "serve"]
-    description: Persistent compliance memory across sessions.
-  - name: github
+  - type: url
+    name: github
     url: https://api.githubcopilot.com/mcp/
-    description: GitHub repository for trex0092/compliance-analyzer.
-    scopes: [repo, issues, pull_requests]
 
 tools:
+  # Pre-built Claude Agent tools: bash, read, write, edit, glob, grep,
+  # web_fetch, web_search. The agent uses these inside its container.
   - type: agent_toolset_20260401
-  - type: http
+    default_config:
+      enabled: true
+
+  # Client-side custom tool — orchestrator forwards to /api/brain.
+  - type: custom
     name: brain_event
     description: >
-      POST a compliance event to the Hawkeye Sterling SUPER ULTRA BRAIN
-      for deterministic routing. Returns the brain's routing decision
-      and auto-actions.
-    method: POST
-    url: https://compliance-analyzer.netlify.app/api/brain
-    auth:
-      type: bearer
-      token_env: HAWKEYE_BRAIN_TOKEN
-    schema:
+      Submit a compliance event to the Hawkeye Sterling SUPER ULTRA
+      BRAIN for deterministic routing. Returns the brain's routing
+      decision (tool, purpose, autoActions, escalate). Use this as
+      the FIRST action for any new alert — the brain's decision is
+      the ground truth you must verify against the regulatory
+      decision trees.
+    input_schema:
       type: object
       required: [kind, severity, summary]
       properties:
@@ -159,50 +159,76 @@ tools:
             - cdd_overdue
             - evidence_break
             - manual
+          description: Event kind from the brain taxonomy.
         severity:
           type: string
           enum: [info, low, medium, high, critical]
-        summary: { type: string, maxLength: 500 }
-        subject: { type: string, maxLength: 200 }
-        refId: { type: string, maxLength: 64 }
-        matchScore: { type: number, minimum: 0, maximum: 1 }
-        meta: { type: object }
-  - type: http
+        summary:
+          type: string
+          maxLength: 500
+          description: >
+            Neutral factual summary. Must NOT contain raw PII — use
+            refId to point at the authoritative record.
+        subject:
+          type: string
+          maxLength: 200
+          description: >
+            Anonymised subject label (e.g. "Counterparty XYZ-0042").
+        refId:
+          type: string
+          maxLength: 64
+          description: >
+            Internal record id (STR-xxx, CRA-xxx, CASE-xxx).
+        matchScore:
+          type: number
+          minimum: 0
+          maximum: 1
+          description: Sanctions match confidence, if applicable.
+
+  # Client-side custom tool — orchestrator publishes to Cachet.
+  - type: custom
     name: cachet_incident
-    description: Publish an incident to the Cachet status page.
-    method: POST
-    url: ${CACHET_BASE_URL}/api/v1/incidents
-    auth:
-      type: header
-      header: X-Cachet-Token
-      token_env: CACHET_API_TOKEN
-    schema:
+    description: >
+      Publish an incident to the public Cachet status page. Use for
+      confirmed sanctions freezes, missed filing deadlines, and
+      evidence-chain breaks. Visible to customers — never include PII.
+    input_schema:
       type: object
       required: [name, message, status]
       properties:
-        name: { type: string }
-        message: { type: string }
-        status: { type: integer, enum: [1, 2, 3, 4] }  # 1=Investigating 2=Identified 3=Watching 4=Fixed
-        visible: { type: integer, enum: [0, 1] }
+        name:
+          type: string
+          maxLength: 120
+          description: Short incident title.
+        message:
+          type: string
+          maxLength: 2000
+          description: Public-facing incident body (no PII).
+        status:
+          type: integer
+          enum: [1, 2, 3, 4]
+          description: >
+            1 = Investigating, 2 = Identified, 3 = Watching, 4 = Fixed.
+        visible:
+          type: integer
+          enum: [0, 1]
+          description: 1 = public, 0 = unlisted.
 
 skills:
-  - name: str-narrative
-    path: genaisrc/str-narrative.genai.mjs
-    description: >
-      Draft a UAE FIU-compliant STR narrative (goAML "Reason for
-      suspicion" field). Output is neutral, factual prose under 2000
-      characters, dd/mm/yyyy, AED, no tipping off.
-  - name: sanctions-triage
-    path: genaisrc/sanctions-triage.genai.mjs
-    description: >
-      Classify a sanctions screening hit as confirmed / potential /
-      false-positive and recommend the next compliance action per the
-      CLAUDE.md decision tree. Requires checking ALL six lists
-      (UN, OFAC, EU, UK, UAE, EOCN).
+  # Anthropic pre-built skills for document production during audit
+  # pack generation. Reference by name.
+  - type: anthropic
+    skill_id: xlsx
+  - type: anthropic
+    skill_id: docx
 
-# Environment variables the agent expects at runtime (set these in the
-# platform.claude.com agent settings — NEVER commit the values):
-#   HAWKEYE_BRAIN_TOKEN   — 32+ hex-char bearer token for /api/brain
-#   CACHET_BASE_URL       — https://status.example.com
-#   CACHET_API_TOKEN      — generated in Cachet UI → Settings → API
-#   GITHUB_TOKEN          — fine-grained PAT with repo + issues scope
+# Required environment variables the *orchestrator* must have — NOT the
+# agent itself. The agent only emits custom_tool_use events; the
+# orchestrator (scripts/agent-orchestrator.mjs) forwards them with auth.
+#
+#   ANTHROPIC_API_KEY      — to create agents, environments, sessions
+#   HAWKEYE_BRAIN_URL      — e.g. https://compliance-analyzer.netlify.app
+#   HAWKEYE_BRAIN_TOKEN    — 32+ hex-char bearer token for /api/brain
+#   CACHET_BASE_URL        — https://status.example.com
+#   CACHET_API_TOKEN       — Cachet UI → Settings → API
+#   GITHUB_TOKEN           — used by the github MCP server

--- a/brain-boot.js
+++ b/brain-boot.js
@@ -1,0 +1,94 @@
+/**
+ * Brain Boot — installs window.__brainNotify() for legacy JS modules.
+ *
+ * The React/TS side uses src/services/brainBridge.ts, which is nice and
+ * typed. The root-level *.js compliance modules (compliance-suite.js,
+ * threshold-monitor.js, tfs-refresh.js, workflow-engine.js) are plain
+ * non-bundled browser scripts and can't `import` TS. This file gives
+ * them a single global hook: window.__brainNotify(event).
+ *
+ * Contract: fire-and-forget. Never throws, never blocks, never logs PII.
+ *
+ * Server: POST /api/brain  →  netlify/functions/brain.mts
+ */
+(function () {
+  if (typeof window === 'undefined') return;
+  if (typeof window.__brainNotify === 'function') return; // already installed
+
+  var ENDPOINT = '/api/brain';
+  var VALID_KINDS = {
+    str_saved: 1,
+    sanctions_match: 1,
+    threshold_breach: 1,
+    deadline_missed: 1,
+    cdd_overdue: 1,
+    evidence_break: 1,
+    manual: 1,
+  };
+  var VALID_SEVERITIES = { info: 1, low: 1, medium: 1, high: 1, critical: 1 };
+
+  function sanitize(s, cap) {
+    if (typeof s !== 'string') return '';
+    return s.replace(/[\r\n\t\u0000-\u001f]/g, ' ').trim().slice(0, cap);
+  }
+
+  function getToken() {
+    try {
+      if (typeof localStorage === 'undefined') return null;
+      return localStorage.getItem('auth.token');
+    } catch (_e) {
+      return null;
+    }
+  }
+
+  /**
+   * Fire-and-forget notification to the compliance brain.
+   * @param {object} event
+   * @returns {boolean} true if dispatched, false if rejected locally
+   */
+  window.__brainNotify = function brainNotify(event) {
+    try {
+      if (!event || typeof event !== 'object') return false;
+      if (!VALID_KINDS[event.kind]) return false;
+      if (!VALID_SEVERITIES[event.severity]) return false;
+
+      var cleaned = {
+        kind: event.kind,
+        severity: event.severity,
+        summary: sanitize(event.summary, 500),
+      };
+      if (!cleaned.summary) return false;
+      if (event.subject) cleaned.subject = sanitize(event.subject, 200);
+      if (event.refId) cleaned.refId = sanitize(event.refId, 64);
+      if (typeof event.matchScore === 'number' && isFinite(event.matchScore)) {
+        cleaned.matchScore = Math.max(0, Math.min(1, event.matchScore));
+      }
+      if (event.meta && typeof event.meta === 'object') cleaned.meta = event.meta;
+
+      var token = getToken();
+      if (!token) return false;
+
+      // keepalive so the POST survives page navigation (e.g. after saving a case
+      // the user may navigate away before the brain responds).
+      fetch(ENDPOINT, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer ' + token,
+        },
+        body: JSON.stringify(cleaned),
+        keepalive: true,
+      }).catch(function () {
+        /* brain is best-effort — never surface errors to the UI */
+      });
+
+      return true;
+    } catch (_err) {
+      return false;
+    }
+  };
+
+  // Diagnostic — exposed so ops can verify the bridge from the console.
+  window.__brainNotify.version = '1.0.0';
+  window.__brainNotify.endpoint = ENDPOINT;
+})();

--- a/compliance-suite.js
+++ b/compliance-suite.js
@@ -585,6 +585,33 @@ window.csFormatDateInput = function (el) {
     toast(`CRA saved — ${name}: ${rating}`, 'success');
     renderCRA();
 
+    // Brain hook: if the CRA logs a sanctions hit, escalate to the brain
+    // immediately. The brain routes confirmed matches to the 24h freeze
+    // protocol (Cabinet Res 74/2020) and escalates potential matches to
+    // the Compliance Officer for four-eyes review.
+    try {
+      if (typeof global.__brainNotify === 'function' && form.sanctionsHit && form.sanctionsHit !== 'No Match') {
+        var _score = form.sanctionsHit === 'Confirmed Match' ? 0.95
+                   : form.sanctionsHit === 'Potential Match – Pending' ? 0.7
+                   : 0.2;
+        global.__brainNotify({
+          kind: 'sanctions_match',
+          severity: _score >= 0.9 ? 'critical' : _score >= 0.5 ? 'high' : 'medium',
+          summary: 'CRA sanctions hit: ' + form.sanctionsHit + ' on ' + name,
+          subject: name,
+          matchScore: _score,
+          refId: record.id,
+          meta: {
+            rating: rating,
+            cddLevel: cddLevel,
+            pepStatus: form.pepStatus,
+            geography: form.geography,
+            nationality: form.nationality,
+          },
+        });
+      }
+    } catch (_brainErr) { /* best-effort */ }
+
     // Auto-sync to Asana
     var craIdx = editIdx >= 0 ? editIdx : 0;
     try {
@@ -1322,6 +1349,28 @@ window.csFormatDateInput = function (el) {
     document.getElementById('strModal').classList.remove('open');
     toast(`STR case saved — ${subject}`, 'success');
     renderSTR();
+
+    // Brain hook: fire-and-forget notify the SUPER ULTRA BRAIN so it can
+    // start the filing deadline tracker, apply the FDL Art.29 confidentiality
+    // lock, and append to the evidence chain. Never blocks the UI.
+    try {
+      if (typeof global.__brainNotify === 'function') {
+        global.__brainNotify({
+          kind: 'str_saved',
+          severity: (record.priority && /urgent|critical|immediate/i.test(record.priority)) ? 'critical' : 'high',
+          summary: `STR saved: ${record.reportType} for ${subject}`,
+          subject: subject,
+          refId: record.id,
+          meta: {
+            reportType: record.reportType,
+            priority: record.priority,
+            flagCount: (record.flags || []).length,
+            hasNarrative: !!record.narrative,
+            filed: !!record.goamlRef,
+          },
+        });
+      }
+    } catch (_brainErr) { /* brain is best-effort — never break the save path */ }
   };
 
   global.suiteDeleteSTR = function(idx) {

--- a/index.html
+++ b/index.html
@@ -2788,6 +2788,7 @@ Examples:
 <script src="compliance-pipeline.js?v=20260409"></script>
 <script src="compliance-intelligence.js?v=20260409"></script>
 
+<script src="brain-boot.js?v=20260410"></script>
 <script src="app-boot.js?v=20260409"></script>
 </body>
 </html>

--- a/netlify/functions/brain.mts
+++ b/netlify/functions/brain.mts
@@ -1,0 +1,357 @@
+/**
+ * SUPER ULTRA BRAIN — Compliance Event Ingress
+ *
+ * Serverless endpoint that receives compliance events from the browser
+ * (STR saved, sanctions match, threshold breached, deadline missed) and
+ * weaponizes them:
+ *
+ *  1. Validates + auths + rate-limits the event.
+ *  2. Routes it deterministically to the correct tool (same rules as
+ *     scripts/brain.mjs — duplicated here because Netlify Functions can't
+ *     easily import from scripts/ outside the functions dir).
+ *  3. For CRITICAL events (confirmed sanctions match, missed deadline,
+ *     evidence-chain break) publishes a Cachet incident if configured.
+ *  4. Persists the event to Netlify Blobs so the autopilot and the
+ *     morning briefing can consume it.
+ *  5. Returns the routing decision + any immediate auto-actions taken.
+ *
+ * This is a DEFENSIVE weaponization: the brain only escalates, logs,
+ * and publishes. It never silences an alert, never bypasses the
+ * four-eyes gate, and never tips off a subject (FDL Art.29).
+ */
+
+import type { Config, Context } from "@netlify/functions";
+import { getStore } from "@netlify/blobs";
+import { checkRateLimit } from "./middleware/rate-limit.mts";
+import { authenticate } from "./middleware/auth.mts";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+type EventKind =
+  | "str_saved"
+  | "sanctions_match"
+  | "threshold_breach"
+  | "deadline_missed"
+  | "cdd_overdue"
+  | "evidence_break"
+  | "manual";
+
+type Severity = "info" | "low" | "medium" | "high" | "critical";
+
+interface BrainEvent {
+  kind: EventKind;
+  severity: Severity;
+  subject?: string;
+  summary: string;
+  /** Optional numeric hit score for sanctions matches (0..1). */
+  matchScore?: number;
+  /** Optional entity/case id for traceability. */
+  refId?: string;
+  /** Free-form metadata. Never include PII beyond what the event needs. */
+  meta?: Record<string, unknown>;
+}
+
+interface RouteDecision {
+  tool:
+    | "screening"
+    | "workflow"
+    | "thresholds"
+    | "tfs"
+    | "regulatory"
+    | "reports"
+    | null;
+  purpose: string;
+  autoActions: string[];
+  escalate: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Routing (deterministic — mirrors scripts/brain.mjs)
+// ---------------------------------------------------------------------------
+function route(event: BrainEvent): RouteDecision {
+  const autoActions: string[] = [];
+  let tool: RouteDecision["tool"] = null;
+  let purpose = "No deterministic route. Escalate to CO.";
+  let escalate = false;
+
+  switch (event.kind) {
+    case "sanctions_match": {
+      tool = "screening";
+      const score = event.matchScore ?? 0;
+      if (score >= 0.9) {
+        // Cabinet Res 74/2020 Art.4-7: freeze within 24h.
+        purpose = "CONFIRMED sanctions match — execute 24h freeze protocol.";
+        autoActions.push("freeze_assets:immediate");
+        autoActions.push("start_eocn_countdown:24h");
+        autoActions.push("schedule_cnmr_filing:5bd");
+        autoActions.push("suppress_subject_notification:FDL_Art29");
+        escalate = true;
+      } else if (score >= 0.5) {
+        purpose = "POTENTIAL match — escalate to Compliance Officer.";
+        autoActions.push("escalate_to_co");
+        autoActions.push("require_four_eyes_review");
+        escalate = true;
+      } else {
+        purpose = "LOW-confidence hit — document and dismiss.";
+        autoActions.push("log_dismissal_with_rationale");
+      }
+      break;
+    }
+    case "str_saved": {
+      tool = "workflow";
+      purpose = "STR drafted — begin filing deadline tracking (FDL Art.26-27).";
+      autoActions.push("start_deadline_tracker:str");
+      autoActions.push("apply_confidentiality_lock:FDL_Art29");
+      autoActions.push("append_to_evidence_chain");
+      escalate = event.severity === "critical" || event.severity === "high";
+      break;
+    }
+    case "threshold_breach": {
+      tool = "thresholds";
+      purpose =
+        "Threshold breach — AED 55K (DPMSR) or AED 60K (cross-border BNI) crossed.";
+      autoActions.push("queue_ctr_or_dpmsr");
+      autoActions.push("freeze_transaction_pending_review");
+      escalate = true;
+      break;
+    }
+    case "deadline_missed": {
+      tool = "workflow";
+      purpose = "Filing deadline missed — regulatory penalty exposure.";
+      autoActions.push("alert_mlro:critical");
+      autoActions.push("append_to_evidence_chain");
+      autoActions.push("publish_cachet_incident");
+      escalate = true;
+      break;
+    }
+    case "cdd_overdue": {
+      tool = "regulatory";
+      purpose = "CDD review overdue — Cabinet Res 134/2025 Art.7-10.";
+      autoActions.push("lock_entity_transactions");
+      autoActions.push("alert_co");
+      escalate = true;
+      break;
+    }
+    case "evidence_break": {
+      tool = "reports";
+      purpose = "Evidence chain break detected — forensic integrity at risk.";
+      autoActions.push("freeze_all_new_records");
+      autoActions.push("alert_mlro:critical");
+      autoActions.push("publish_cachet_incident");
+      escalate = true;
+      break;
+    }
+    default: {
+      tool = null;
+      purpose = "Manual / unclassified event — escalate to CO.";
+      escalate = true;
+    }
+  }
+
+  return { tool, purpose, autoActions, escalate };
+}
+
+// ---------------------------------------------------------------------------
+// Validation — reject any payload that doesn't match the schema exactly.
+// ---------------------------------------------------------------------------
+const VALID_KINDS = new Set<EventKind>([
+  "str_saved",
+  "sanctions_match",
+  "threshold_breach",
+  "deadline_missed",
+  "cdd_overdue",
+  "evidence_break",
+  "manual",
+]);
+const VALID_SEVERITIES = new Set<Severity>([
+  "info",
+  "low",
+  "medium",
+  "high",
+  "critical",
+]);
+
+function validate(input: unknown): { ok: true; event: BrainEvent } | { ok: false; error: string } {
+  if (!input || typeof input !== "object") {
+    return { ok: false, error: "body must be an object" };
+  }
+  const raw = input as Record<string, unknown>;
+
+  if (typeof raw.kind !== "string" || !VALID_KINDS.has(raw.kind as EventKind)) {
+    return { ok: false, error: "invalid kind" };
+  }
+  if (
+    typeof raw.severity !== "string" ||
+    !VALID_SEVERITIES.has(raw.severity as Severity)
+  ) {
+    return { ok: false, error: "invalid severity" };
+  }
+  if (typeof raw.summary !== "string" || raw.summary.length === 0 || raw.summary.length > 500) {
+    return { ok: false, error: "summary must be a non-empty string (<=500 chars)" };
+  }
+  if (raw.subject !== undefined && (typeof raw.subject !== "string" || raw.subject.length > 200)) {
+    return { ok: false, error: "subject must be a string (<=200 chars)" };
+  }
+  if (raw.refId !== undefined && (typeof raw.refId !== "string" || raw.refId.length > 64)) {
+    return { ok: false, error: "refId must be a string (<=64 chars)" };
+  }
+  if (raw.matchScore !== undefined) {
+    const n = Number(raw.matchScore);
+    if (!Number.isFinite(n) || n < 0 || n > 1) {
+      return { ok: false, error: "matchScore must be a number in [0,1]" };
+    }
+  }
+  if (raw.meta !== undefined && (typeof raw.meta !== "object" || raw.meta === null)) {
+    return { ok: false, error: "meta must be an object" };
+  }
+
+  // Strip newlines/control chars from free-text fields to block log-injection.
+  const clean = (s: string) => s.replace(/[\r\n\t\u0000-\u001f]/g, " ").trim();
+
+  const event: BrainEvent = {
+    kind: raw.kind as EventKind,
+    severity: raw.severity as Severity,
+    summary: clean(raw.summary),
+    ...(typeof raw.subject === "string" ? { subject: clean(raw.subject) } : {}),
+    ...(typeof raw.refId === "string" ? { refId: clean(raw.refId) } : {}),
+    ...(typeof raw.matchScore === "number" ? { matchScore: raw.matchScore } : {}),
+    ...(raw.meta ? { meta: raw.meta as Record<string, unknown> } : {}),
+  };
+
+  return { ok: true, event };
+}
+
+// ---------------------------------------------------------------------------
+// Cachet publishing (optional — only if env is configured).
+// ---------------------------------------------------------------------------
+async function publishCachet(event: BrainEvent, decision: RouteDecision): Promise<
+  { published: boolean; reason?: string }
+> {
+  const base = Netlify.env.get("CACHET_BASE_URL");
+  const token = Netlify.env.get("CACHET_API_TOKEN");
+  if (!base || !token) return { published: false, reason: "cachet_not_configured" };
+
+  const status = event.severity === "critical" ? 2 /* Identified */ : 1 /* Investigating */;
+  try {
+    const res = await fetch(`${base.replace(/\/+$/, "")}/api/v1/incidents`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Cachet-Token": token,
+      },
+      body: JSON.stringify({
+        name: `[${event.severity.toUpperCase()}] ${event.kind}`,
+        message: `${event.summary}\n\nBrain decision: ${decision.purpose}\nActions: ${decision.autoActions.join(", ") || "none"}`,
+        status,
+        visible: 1,
+      }),
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!res.ok) {
+      return { published: false, reason: `cachet_http_${res.status}` };
+    }
+    return { published: true };
+  } catch (err) {
+    return { published: false, reason: `cachet_error:${(err as Error).message}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Persistence — append to Netlify Blobs for autopilot consumption.
+// ---------------------------------------------------------------------------
+const EVENT_STORE = "brain-events";
+
+async function persistEvent(event: BrainEvent, decision: RouteDecision) {
+  try {
+    const store = getStore(EVENT_STORE);
+    const today = new Date().toISOString().slice(0, 10);
+    const key = `events/${today}.json`;
+    const existing = ((await store.get(key, { type: "json" })) as unknown[]) ?? [];
+    existing.push({
+      at: new Date().toISOString(),
+      event,
+      decision,
+    });
+    // Keep the last 1000 events per day (pathological flood protection).
+    const trimmed = existing.slice(-1000);
+    await store.setJSON(key, trimmed);
+    return { persisted: true, count: trimmed.length };
+  } catch (err) {
+    return { persisted: false, reason: (err as Error).message };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+export default async (req: Request, context: Context) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        "Access-Control-Allow-Methods": "POST, OPTIONS",
+        "Access-Control-Allow-Headers": "Authorization, Content-Type",
+      },
+    });
+  }
+
+  if (req.method !== "POST") {
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+
+  // Rate limit: sensitive endpoint per CLAUDE.md (10 req / 15 min per IP).
+  const rl = await checkRateLimit(req, { max: 10, clientIp: context.ip });
+  if (rl) return rl;
+
+  // Auth required — brain must not accept unauthenticated compliance events.
+  const auth = authenticate(req);
+  if (!auth.ok) return auth.response!;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const v = validate(body);
+  if (!v.ok) {
+    console.warn(`[BRAIN] Rejected input from ${auth.userId}: ${v.error}`);
+    return Response.json({ error: v.error }, { status: 400 });
+  }
+  const event = v.event;
+
+  const decision = route(event);
+
+  // Structured log — never logs PII beyond summary/subject already validated.
+  console.log(
+    `[BRAIN] ${event.kind} severity=${event.severity} tool=${decision.tool ?? "none"} escalate=${decision.escalate} actor=${auth.userId}`,
+  );
+
+  const persistence = await persistEvent(event, decision);
+
+  let cachet: { published: boolean; reason?: string } = { published: false, reason: "not_triggered" };
+  if (decision.escalate && decision.autoActions.includes("publish_cachet_incident")) {
+    cachet = await publishCachet(event, decision);
+  } else if (event.severity === "critical") {
+    cachet = await publishCachet(event, decision);
+  }
+
+  return Response.json({
+    ok: true,
+    actor: auth.userId,
+    decision,
+    persistence,
+    cachet,
+    receivedAt: new Date().toISOString(),
+  });
+};
+
+export const config: Config = {
+  path: "/api/brain",
+  method: ["POST", "OPTIONS"],
+};
+
+// Exports for unit tests.
+export const __test__ = { route, validate };

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@netlify/functions": "^5.1.5"
       },
       "devDependencies": {
+        "@anthropic-ai/sdk": "^0.87.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
@@ -123,13 +124,24 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.55.0.tgz",
-      "integrity": "sha512-VdxPRWPoeeVQt0XUZ3cXfeLB65Skkoo1FS7JAkr8/C7Q8+wjV7k2RsVGmFXBq12VeHxua7MUtNqXx6k8hgoIVg==",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.87.0.tgz",
+      "integrity": "sha512-ZvBWT5VkPTW6b8LIpugpuAkpcYPSLOXdWTcgQrpUqf4IeJ5ZrH5rT8sTsUDvxPCHAlRG3nF4VIWfjw6uLhJ18g==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -3523,6 +3535,16 @@
         "@lvce-editor/ripgrep": "^2.1.0",
         "pdfjs-dist": "5.3.31",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"
+      }
+    },
+    "node_modules/@genaiscript/core/node_modules/@anthropic-ai/sdk": {
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.55.0.tgz",
+      "integrity": "sha512-VdxPRWPoeeVQt0XUZ3cXfeLB65Skkoo1FS7JAkr8/C7Q8+wjV7k2RsVGmFXBq12VeHxua7MUtNqXx6k8hgoIVg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
       }
     },
     "node_modules/@genaiscript/core/node_modules/ajv": {
@@ -13624,6 +13646,20 @@
         "url": "https://github.com/Eomm/json-schema-resolver?sponsor=1"
       }
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -17560,6 +17596,13 @@
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@netlify/functions": "^5.1.5"
   },
   "devDependencies": {
+    "@anthropic-ai/sdk": "^0.87.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@typescript-eslint/eslint-plugin": "^7.0.0",

--- a/scripts/agent-orchestrator.mjs
+++ b/scripts/agent-orchestrator.mjs
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+/**
+ * agent-orchestrator — event loop for a Hawkeye Managed Agent session.
+ *
+ * What it does:
+ *  1. Loads an agent id from .env.agents (created by install-agent.mjs).
+ *  2. Ensures a reusable environment exists (creates one on first run).
+ *  3. Starts a session referencing the agent + environment.
+ *  4. Streams session events.
+ *  5. When the agent emits `agent.custom_tool_use` for `brain_event`,
+ *     forwards the call to HAWKEYE_BRAIN_URL/api/brain with the bearer
+ *     token and responds with `user.custom_tool_result`.
+ *  6. When it emits `cachet_incident`, forwards to CACHET_BASE_URL.
+ *  7. Breaks on `session.status_terminated` or on idle with a
+ *     terminal stop_reason.
+ *
+ * Environment (orchestrator, host-side — never mounted to the agent):
+ *   ANTHROPIC_API_KEY   — required
+ *   HAWKEYE_BRAIN_URL   — e.g. https://compliance-analyzer.netlify.app
+ *   HAWKEYE_BRAIN_TOKEN — 32+ hex bearer token
+ *   CACHET_BASE_URL     — optional
+ *   CACHET_API_TOKEN    — optional
+ *
+ * Usage:
+ *   node scripts/agent-orchestrator.mjs incident-commander \
+ *     "Triage the latest autopilot briefing"
+ */
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Anthropic from '@anthropic-ai/sdk';
+
+const __filename = fileURLToPath(import.meta.url);
+const PROJECT_ROOT = resolve(__filename, '..', '..');
+const ENV_AGENTS = resolve(PROJECT_ROOT, '.env.agents');
+const ENVIRONMENT_NAME = 'hawkeye-compliance';
+
+// ---------------------------------------------------------------------------
+// .env.agents loader — minimal, no dependency on dotenv.
+// ---------------------------------------------------------------------------
+async function loadEnvAgents() {
+  const out = {};
+  try {
+    const content = await readFile(ENV_AGENTS, 'utf8');
+    for (const raw of content.split('\n')) {
+      const line = raw.trim();
+      if (!line || line.startsWith('#')) continue;
+      const idx = line.indexOf('=');
+      if (idx < 0) continue;
+      out[line.slice(0, idx)] = line.slice(idx + 1);
+    }
+  } catch {
+    /* file may not exist yet — caller will detect missing key */
+  }
+  return out;
+}
+
+function agentSlugToEnvKey(slug) {
+  return `AGENT_${slug.toUpperCase().replace(/[^A-Z0-9]/g, '_')}_ID`;
+}
+
+// ---------------------------------------------------------------------------
+// Environment provisioning — idempotent.
+// ---------------------------------------------------------------------------
+async function ensureEnvironment(client) {
+  for await (const env of client.beta.environments.list()) {
+    if (env.name === ENVIRONMENT_NAME) return env;
+  }
+  console.log(`  creating environment ${ENVIRONMENT_NAME}`);
+  return await client.beta.environments.create({
+    name: ENVIRONMENT_NAME,
+    description: 'Hawkeye Sterling compliance sandbox',
+    config: {
+      type: 'cloud',
+      networking: { type: 'unrestricted' },
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Custom tool handlers — host-side, with credentials.
+// ---------------------------------------------------------------------------
+function requireEnv(name) {
+  const v = process.env[name];
+  if (!v) throw new Error(`orchestrator missing env var: ${name}`);
+  return v;
+}
+
+async function handleBrainEvent(input) {
+  const base = requireEnv('HAWKEYE_BRAIN_URL').replace(/\/+$/, '');
+  const token = requireEnv('HAWKEYE_BRAIN_TOKEN');
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 10_000);
+  try {
+    const res = await fetch(`${base}/api/brain`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(input),
+      signal: ctrl.signal,
+    });
+    const body = await res.text();
+    if (!res.ok) {
+      return { ok: false, error: `brain http ${res.status}: ${body.slice(0, 200)}` };
+    }
+    return { ok: true, response: JSON.parse(body) };
+  } catch (err) {
+    return { ok: false, error: `brain fetch: ${err.message}` };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function handleCachetIncident(input) {
+  const base = process.env.CACHET_BASE_URL;
+  const token = process.env.CACHET_API_TOKEN;
+  if (!base || !token) {
+    return { ok: false, error: 'cachet_not_configured' };
+  }
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 10_000);
+  try {
+    const res = await fetch(`${base.replace(/\/+$/, '')}/api/v1/incidents`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Cachet-Token': token,
+      },
+      body: JSON.stringify(input),
+      signal: ctrl.signal,
+    });
+    const body = await res.text();
+    if (!res.ok) {
+      return { ok: false, error: `cachet http ${res.status}` };
+    }
+    return { ok: true, response: JSON.parse(body) };
+  } catch (err) {
+    return { ok: false, error: `cachet fetch: ${err.message}` };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function runCustomTool(toolName, input) {
+  switch (toolName) {
+    case 'brain_event':
+      return await handleBrainEvent(input);
+    case 'cachet_incident':
+      return await handleCachetIncident(input);
+    default:
+      return { ok: false, error: `unknown custom tool: ${toolName}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Session event loop.
+// ---------------------------------------------------------------------------
+async function runSession(client, sessionId, kickoff) {
+  // Stream FIRST, then send — patterns doc Rule 7 (stream-first ordering).
+  const stream = await client.beta.sessions.events.stream(sessionId);
+
+  await client.beta.sessions.events.send(sessionId, {
+    events: [
+      {
+        type: 'user.message',
+        content: [{ type: 'text', text: kickoff }],
+      },
+    ],
+  });
+
+  for await (const event of stream) {
+    switch (event.type) {
+      case 'agent.message': {
+        for (const block of event.content ?? []) {
+          if (block.type === 'text') process.stdout.write(block.text);
+        }
+        break;
+      }
+      case 'agent.custom_tool_use': {
+        const name = event.tool_name ?? event.name;
+        console.log(`\n\x1b[36m[tool]\x1b[0m ${name}`);
+        const result = await runCustomTool(name, event.input ?? {});
+        const payload = result.ok
+          ? JSON.stringify(result.response).slice(0, 4000)
+          : `ERROR: ${result.error}`;
+
+        await client.beta.sessions.events.send(sessionId, {
+          events: [
+            {
+              type: 'user.custom_tool_result',
+              custom_tool_use_id: event.id,
+              content: [{ type: 'text', text: payload }],
+              is_error: !result.ok,
+            },
+          ],
+        });
+        break;
+      }
+      case 'session.status_idle': {
+        const stop = event.stop_reason?.type;
+        if (stop === 'requires_action') {
+          // agent waiting on our custom_tool_result — already handled
+          continue;
+        }
+        console.log(`\n\x1b[33m[idle]\x1b[0m stop_reason=${stop}`);
+        return;
+      }
+      case 'session.status_terminated': {
+        console.log('\n\x1b[31m[terminated]\x1b[0m');
+        return;
+      }
+      case 'session.error': {
+        console.error(`\n\x1b[31m[error]\x1b[0m`, event);
+        return;
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+async function main() {
+  const [slug, ...kickoffParts] = process.argv.slice(2);
+  if (!slug) {
+    console.error('Usage: node scripts/agent-orchestrator.mjs <agent-slug> "<kickoff message>"');
+    process.exit(2);
+  }
+  const kickoff = kickoffParts.join(' ') || 'Begin compliance review.';
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.error('error: ANTHROPIC_API_KEY is not set');
+    process.exit(1);
+  }
+
+  const envAgents = await loadEnvAgents();
+  const key = agentSlugToEnvKey(slug);
+  const agentId = envAgents[key];
+  if (!agentId) {
+    console.error(`error: ${key} not found in .env.agents. Run install-agent.mjs first.`);
+    process.exit(1);
+  }
+
+  const client = new Anthropic();
+
+  console.log(`\x1b[36mresolving environment\x1b[0m`);
+  const env = await ensureEnvironment(client);
+  console.log(`  environment: ${env.id}`);
+
+  console.log(`\x1b[36mcreating session\x1b[0m (agent=${agentId})`);
+  const session = await client.beta.sessions.create({
+    agent: agentId,
+    environment_id: env.id,
+    title: `${slug} — ${new Date().toISOString().slice(0, 16)}`,
+  });
+  console.log(`  session: ${session.id}`);
+
+  console.log(`\x1b[36mstreaming\x1b[0m`);
+  try {
+    await runSession(client, session.id, kickoff);
+  } catch (err) {
+    console.error(`\n\x1b[31mfatal:\x1b[0m ${err.message ?? err}`);
+    process.exit(1);
+  }
+  console.log('\n\x1b[32m[done]\x1b[0m');
+}
+
+main().catch((err) => {
+  console.error(`fatal: ${err.message ?? err}`);
+  process.exit(1);
+});

--- a/scripts/autopilot.mjs
+++ b/scripts/autopilot.mjs
@@ -35,6 +35,8 @@
 import { writeFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { think as brainThink } from './brain.mjs';
+import cachet, { IncidentStatus } from './lib/cachet-client.mjs';
 
 const PROJECT_ROOT = resolve(import.meta.dirname || '.', '..');
 const HISTORY_DIR = resolve(PROJECT_ROOT, 'history', 'daily-ops');
@@ -175,8 +177,48 @@ async function run() {
     return `${implemented}/${TRACEABILITY_MATRIX.length} requirements implemented (${Math.round(implemented / TRACEABILITY_MATRIX.length * 100)}%)`;
   });
 
-  // Phase 6: Generate Briefing
-  console.log('\n═══ PHASE 6: BRIEFING ═══\n');
+  // Phase 6: Brain Pass — route every alert through the SUPER ULTRA BRAIN
+  // so it can apply deterministic auto-actions, escalate to Cachet, and
+  // record routing decisions in claude-mem.
+  console.log('\n═══ PHASE 6: BRAIN ═══\n');
+
+  await step('12. Brain routing + escalation', async () => {
+    results.brain = { routed: 0, escalated: 0, cachetPublished: 0, cachetErrors: 0 };
+    const cachetConfigured = Boolean(process.env.CACHET_BASE_URL && process.env.CACHET_API_TOKEN);
+
+    for (const alert of alerts) {
+      try {
+        const decision = await brainThink(alert.msg);
+        results.brain.routed++;
+
+        // Escalate critical alerts to the public status page when Cachet is configured.
+        if (alert.level === 'CRITICAL' && cachetConfigured) {
+          try {
+            await cachet.createIncident({
+              name: `[CRITICAL] ${alert.msg.slice(0, 80)}`,
+              message: `Autopilot critical alert\n\nBrain routed to: ${decision.tool ?? 'unrouted'}\nPurpose: ${decision.purpose}\n\nFull alert: ${alert.msg}`,
+              status: IncidentStatus.IDENTIFIED,
+            });
+            results.brain.cachetPublished++;
+          } catch (err) {
+            results.brain.cachetErrors++;
+            console.warn(`  [brain] cachet publish failed: ${err.message}`);
+          }
+        }
+
+        if (decision.tool === null || alert.level === 'CRITICAL' || alert.level === 'HIGH') {
+          results.brain.escalated++;
+        }
+      } catch (err) {
+        console.warn(`  [brain] routing failed for alert: ${err.message}`);
+      }
+    }
+
+    return `Routed ${results.brain.routed}, escalated ${results.brain.escalated}, cachet ${results.brain.cachetPublished}/${results.brain.cachetPublished + results.brain.cachetErrors}`;
+  });
+
+  // Phase 7: Generate Briefing
+  console.log('\n═══ PHASE 7: BRIEFING ═══\n');
 
   const briefing = generateBriefing();
   await archiveBriefing(briefing);
@@ -260,6 +302,7 @@ function generateBriefing() {
   if (results.traceability) lines.push(`  Regulatory coverage: ${results.traceability.implemented}/${results.traceability.total}`);
   if (results.portfolio) lines.push(`  Portfolio: ${results.portfolio.screened} entities screened`);
   if (results.chain) lines.push(`  Evidence chain: ${results.chain.valid ? 'INTACT' : 'BROKEN'} (${results.chain.entries} entries)`);
+  if (results.brain) lines.push(`  Brain: ${results.brain.routed} routed, ${results.brain.escalated} escalated, ${results.brain.cachetPublished} published to Cachet`);
   lines.push('');
 
   // Errors

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# ==========================================================================
+# Hawkeye Sterling — one-shot bootstrap
+# ==========================================================================
+# Sets up a Managed Agent from scratch with a single command.
+#
+# What it does:
+#   1. Verifies prerequisites (node, git, openssl)
+#   2. Runs `npm install` if node_modules is missing
+#   3. Prompts for ANTHROPIC_API_KEY if not set
+#   4. Generates HAWKEYE_BRAIN_TOKEN if not set
+#   5. Writes them to .env.local (gitignored)
+#   6. Prints instructions for setting HAWKEYE_BRAIN_TOKEN in Netlify
+#   7. Runs install-agent.mjs for both agent YAMLs
+#   8. Prints the next command to start an agent session
+#
+# Usage:
+#   bash scripts/bootstrap.sh
+#
+# This script is idempotent — running it twice is safe.
+# ==========================================================================
+set -euo pipefail
+
+# -- colours ---------------------------------------------------------------
+if [[ -t 1 ]]; then
+  BOLD=$'\e[1m'; DIM=$'\e[2m'; RED=$'\e[31m'; GRN=$'\e[32m'; YEL=$'\e[33m'; CYN=$'\e[36m'; RST=$'\e[0m'
+else
+  BOLD=''; DIM=''; RED=''; GRN=''; YEL=''; CYN=''; RST=''
+fi
+
+step()  { printf '\n%s▸ %s%s\n' "$BOLD" "$1" "$RST"; }
+ok()    { printf '  %s✓%s %s\n' "$GRN" "$RST" "$1"; }
+warn()  { printf '  %s!%s %s\n' "$YEL" "$RST" "$1"; }
+fail()  { printf '  %s✗%s %s\n' "$RED" "$RST" "$1"; exit 1; }
+info()  { printf '  %s%s%s\n' "$DIM" "$1" "$RST"; }
+
+cd "$(dirname "$0")/.."
+ROOT="$PWD"
+
+step "Checking prerequisites"
+command -v node     >/dev/null || fail "node is required"
+command -v git      >/dev/null || fail "git is required"
+command -v openssl  >/dev/null || fail "openssl is required"
+ok "node $(node --version)"
+ok "git $(git --version | awk '{print $3}')"
+ok "openssl present"
+
+step "Checking git branch"
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$BRANCH" != "claude/install-compliance-analyzer-SVN6Y" && "$BRANCH" != "main" ]]; then
+  warn "current branch is $BRANCH — the brain + agents code lives on claude/install-compliance-analyzer-SVN6Y"
+else
+  ok "on $BRANCH"
+fi
+
+step "Installing dependencies"
+if [[ ! -d node_modules ]] || [[ package-lock.json -nt node_modules ]]; then
+  npm install --no-audit --no-fund
+  ok "npm install complete"
+else
+  ok "node_modules already present"
+fi
+
+step "Loading secrets from .env.local (if present)"
+if [[ -f .env.local ]]; then
+  set -a; . ./.env.local; set +a
+  ok "loaded .env.local"
+else
+  touch .env.local
+  info "no .env.local yet — will create"
+fi
+
+# -- ANTHROPIC_API_KEY -----------------------------------------------------
+step "Anthropic API key"
+if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+  printf '  Paste your Anthropic API key (sk-ant-...) — get one at\n'
+  printf '  https://console.anthropic.com/settings/keys\n'
+  printf '  key: '
+  read -rs ANTHROPIC_API_KEY
+  printf '\n'
+  [[ -z "$ANTHROPIC_API_KEY" ]] && fail "no key provided"
+  [[ "$ANTHROPIC_API_KEY" != sk-ant-* ]] && warn "key does not start with sk-ant- — continuing anyway"
+  # persist
+  grep -v '^ANTHROPIC_API_KEY=' .env.local > .env.local.tmp 2>/dev/null || true
+  printf 'ANTHROPIC_API_KEY=%s\n' "$ANTHROPIC_API_KEY" >> .env.local.tmp
+  mv .env.local.tmp .env.local
+  export ANTHROPIC_API_KEY
+  ok "saved to .env.local"
+else
+  ok "already set"
+fi
+
+# -- HAWKEYE_BRAIN_TOKEN ---------------------------------------------------
+step "Hawkeye brain bearer token"
+if [[ -z "${HAWKEYE_BRAIN_TOKEN:-}" ]]; then
+  HAWKEYE_BRAIN_TOKEN=$(openssl rand -hex 24)
+  grep -v '^HAWKEYE_BRAIN_TOKEN=' .env.local > .env.local.tmp 2>/dev/null || true
+  printf 'HAWKEYE_BRAIN_TOKEN=%s\n' "$HAWKEYE_BRAIN_TOKEN" >> .env.local.tmp
+  mv .env.local.tmp .env.local
+  export HAWKEYE_BRAIN_TOKEN
+  ok "generated and saved to .env.local"
+else
+  ok "already set"
+fi
+
+# -- HAWKEYE_BRAIN_URL -----------------------------------------------------
+if [[ -z "${HAWKEYE_BRAIN_URL:-}" ]]; then
+  HAWKEYE_BRAIN_URL="https://compliance-analyzer.netlify.app"
+  grep -v '^HAWKEYE_BRAIN_URL=' .env.local > .env.local.tmp 2>/dev/null || true
+  printf 'HAWKEYE_BRAIN_URL=%s\n' "$HAWKEYE_BRAIN_URL" >> .env.local.tmp
+  mv .env.local.tmp .env.local
+  export HAWKEYE_BRAIN_URL
+fi
+ok "HAWKEYE_BRAIN_URL=$HAWKEYE_BRAIN_URL"
+
+# -- Netlify reminder ------------------------------------------------------
+step "Netlify env var reminder"
+printf '  You must also set %sHAWKEYE_BRAIN_TOKEN%s in Netlify so that\n' "$BOLD" "$RST"
+printf '  /api/brain accepts the orchestrator requests.\n\n'
+printf '  Option A — Netlify CLI (if installed):\n'
+printf '    %snpx netlify env:set HAWKEYE_BRAIN_TOKEN "%s"%s\n\n' "$CYN" "$HAWKEYE_BRAIN_TOKEN" "$RST"
+printf '  Option B — Netlify web UI:\n'
+printf '    https://app.netlify.com/sites/compliance-analyzer/settings/env\n'
+printf '    Key:   HAWKEYE_BRAIN_TOKEN\n'
+printf '    Value: %s%s%s\n' "$BOLD" "$HAWKEYE_BRAIN_TOKEN" "$RST"
+
+# -- Install the two agents ------------------------------------------------
+step "Installing managed agents via POST /v1/agents"
+for yml in agents/incident-commander.yml agents/hawkeye-mlro.yml; do
+  if [[ -f "$yml" ]]; then
+    printf '\n  %sinstalling %s%s\n' "$DIM" "$yml" "$RST"
+    node scripts/install-agent.mjs "$yml"
+  else
+    warn "skipped $yml (not found)"
+  fi
+done
+
+# -- Done ------------------------------------------------------------------
+step "Bootstrap complete"
+ok "agents installed — see .env.agents for IDs"
+printf '\n  To run the incident commander:\n'
+printf '    %sbash -c '"'"'set -a; . ./.env.local; set +a; node scripts/agent-orchestrator.mjs incident-commander "Smoke test: call brain_event with kind=manual, severity=info, summary=hello"'"'"'%s\n\n' "$CYN" "$RST"
+printf '  To run the MLRO:\n'
+printf '    %sbash -c '"'"'set -a; . ./.env.local; set +a; node scripts/agent-orchestrator.mjs hawkeye-mlro "Prepare today'"'"'"'"'"'"'"'"'s briefing review"'"'"'%s\n\n' "$CYN" "$RST"
+printf '  %sRemember:%s set HAWKEYE_BRAIN_TOKEN in Netlify (above) before running\n' "$BOLD" "$RST"
+printf '  the orchestrator, or /api/brain will return 401.\n'

--- a/scripts/install-agent.mjs
+++ b/scripts/install-agent.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+/**
+ * install-agent — create a Managed Agent from a YAML config.
+ *
+ * Reads an `agents/<name>.yml` file, validates it matches the Managed
+ * Agents API schema (POST /v1/agents, beta managed-agents-2026-04-01),
+ * and creates the agent programmatically via the Anthropic SDK.
+ *
+ * Stores the returned {agent_id, version} in `.env.agents` so the
+ * orchestrator (`scripts/agent-orchestrator.mjs`) can reference them.
+ *
+ * Usage:
+ *   export ANTHROPIC_API_KEY=sk-ant-...
+ *   node scripts/install-agent.mjs agents/incident-commander.yml
+ *   node scripts/install-agent.mjs agents/hawkeye-mlro.yml
+ *
+ * Idempotency: if an agent with the same name already exists in your
+ * workspace, the script updates it (which creates a new immutable
+ * version) instead of creating a duplicate.
+ */
+import { readFile, writeFile, access } from 'node:fs/promises';
+import { resolve, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import YAML from 'yaml';
+import Anthropic from '@anthropic-ai/sdk';
+
+const __filename = fileURLToPath(import.meta.url);
+const PROJECT_ROOT = resolve(__filename, '..', '..');
+const ENV_AGENTS = resolve(PROJECT_ROOT, '.env.agents');
+
+function die(msg, code = 1) {
+  console.error(`\x1b[31merror:\x1b[0m ${msg}`);
+  process.exit(code);
+}
+
+function usage() {
+  console.error('Usage: node scripts/install-agent.mjs <path-to-agent.yml>');
+  process.exit(2);
+}
+
+// ---------------------------------------------------------------------------
+// Validation — cheap, hermetic checks before we spend an API call.
+// ---------------------------------------------------------------------------
+const VALID_TOOL_TYPES = new Set([
+  'agent_toolset_20260401',
+  'custom',
+  'mcp_toolset',
+]);
+const VALID_KINDS = [
+  'str_saved',
+  'sanctions_match',
+  'threshold_breach',
+  'deadline_missed',
+  'cdd_overdue',
+  'evidence_break',
+  'manual',
+];
+
+function validateAgent(doc, path) {
+  const errors = [];
+
+  if (!doc || typeof doc !== 'object') errors.push('root must be an object');
+  if (!doc.name || typeof doc.name !== 'string') errors.push('name is required');
+  if (doc.name && doc.name.length > 256) errors.push('name > 256 chars');
+  if (!doc.model || typeof doc.model !== 'string') errors.push('model is required');
+  if (doc.description && doc.description.length > 2048) errors.push('description > 2048 chars');
+  if (doc.system && doc.system.length > 100_000) errors.push('system > 100000 chars');
+
+  if (!Array.isArray(doc.tools)) {
+    errors.push('tools must be an array');
+  } else {
+    if (doc.tools.length > 50) errors.push('tools > 50');
+    for (const tool of doc.tools) {
+      if (!VALID_TOOL_TYPES.has(tool.type)) {
+        errors.push(`invalid tool type: ${tool.type}`);
+      }
+      if (tool.type === 'custom') {
+        if (!tool.name) errors.push('custom tool missing name');
+        if (!tool.description) errors.push(`custom tool ${tool.name} missing description`);
+        if (!tool.input_schema || tool.input_schema.type !== 'object') {
+          errors.push(`custom tool ${tool.name} missing/invalid input_schema`);
+        }
+      }
+    }
+  }
+
+  if (doc.mcp_servers) {
+    if (!Array.isArray(doc.mcp_servers)) {
+      errors.push('mcp_servers must be an array');
+    } else {
+      if (doc.mcp_servers.length > 20) errors.push('mcp_servers > 20');
+      const seen = new Set();
+      for (const srv of doc.mcp_servers) {
+        if (srv.type !== 'url') {
+          errors.push(`mcp_server ${srv.name} must have type: url (Managed Agents only supports URL-based MCP)`);
+        }
+        if (!srv.name) errors.push('mcp_server missing name');
+        if (!srv.url || !srv.url.startsWith('https://')) {
+          errors.push(`mcp_server ${srv.name} missing https url`);
+        }
+        if (seen.has(srv.name)) errors.push(`duplicate mcp_server name: ${srv.name}`);
+        seen.add(srv.name);
+      }
+    }
+  }
+
+  if (doc.skills) {
+    if (!Array.isArray(doc.skills)) errors.push('skills must be an array');
+    else if (doc.skills.length > 64) errors.push('skills > 64');
+  }
+
+  // Safety invariants — mirror tests/agentConfigs.test.ts.
+  const sys = (doc.system ?? '').toLowerCase();
+  if (!sys.match(/tipping.?off|art\.?\s*29/)) {
+    errors.push('system prompt missing FDL Art.29 no-tipping-off language');
+  }
+  if (!sys.match(/four.?eyes/)) {
+    errors.push('system prompt missing four-eyes requirement');
+  }
+
+  // Confirm no accidentally-added "subject notification" tool.
+  for (const tool of doc.tools ?? []) {
+    const name = (tool.name ?? '').toLowerCase();
+    if (name.match(/notify.?subject|email.?(customer|subject)|tip.?off|sms/)) {
+      errors.push(`forbidden tool (would enable tipping off): ${tool.name}`);
+    }
+    if (name.match(/goaml|eocn|submit.?report|portal/)) {
+      errors.push(`forbidden tool (direct portal submission): ${tool.name}`);
+    }
+  }
+
+  if (errors.length) {
+    console.error(`\x1b[31m${path} failed validation:\x1b[0m`);
+    for (const e of errors) console.error(`  - ${e}`);
+    process.exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Idempotent upsert: list existing agents by name, update if found.
+// ---------------------------------------------------------------------------
+async function findAgentByName(client, name) {
+  // Paginate through agents. The SDK's async iterator handles this.
+  for await (const agent of client.beta.agents.list()) {
+    if (agent.name === name) return agent;
+  }
+  return null;
+}
+
+async function upsert(client, doc) {
+  const existing = await findAgentByName(client, doc.name);
+
+  // The API accepts the full config on both create and update.
+  const body = {
+    name: doc.name,
+    model: doc.model,
+    ...(doc.description ? { description: doc.description } : {}),
+    ...(doc.system ? { system: doc.system } : {}),
+    ...(doc.tools ? { tools: doc.tools } : {}),
+    ...(doc.mcp_servers ? { mcp_servers: doc.mcp_servers } : {}),
+    ...(doc.skills ? { skills: doc.skills } : {}),
+    ...(doc.metadata ? { metadata: doc.metadata } : {}),
+  };
+
+  if (existing) {
+    console.log(`  \x1b[33mupdating\x1b[0m existing agent ${existing.id} (new version will be created)`);
+    return await client.beta.agents.update(existing.id, body);
+  }
+  console.log(`  \x1b[32mcreating\x1b[0m new agent`);
+  return await client.beta.agents.create(body);
+}
+
+// ---------------------------------------------------------------------------
+// .env.agents persistence — simple KEY=VALUE file the orchestrator reads.
+// ---------------------------------------------------------------------------
+async function persistAgentId(slug, agent) {
+  const key = slug.toUpperCase().replace(/[^A-Z0-9]/g, '_');
+  let existing = '';
+  try {
+    await access(ENV_AGENTS);
+    existing = await readFile(ENV_AGENTS, 'utf8');
+  } catch {
+    existing = '# Hawkeye Sterling — Managed Agent IDs\n# Generated by scripts/install-agent.mjs — safe to commit? NO (contains IDs)\n';
+  }
+
+  const idLine = `AGENT_${key}_ID=${agent.id}`;
+  const versionLine = `AGENT_${key}_VERSION=${agent.version ?? ''}`;
+
+  const lines = existing.split('\n').filter((l) =>
+    !l.startsWith(`AGENT_${key}_ID=`) && !l.startsWith(`AGENT_${key}_VERSION=`)
+  );
+  lines.push(idLine, versionLine);
+
+  await writeFile(ENV_AGENTS, lines.join('\n') + '\n', 'utf8');
+  console.log(`  \x1b[32mwrote\x1b[0m .env.agents (${idLine}, ${versionLine})`);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length !== 1) usage();
+  const ymlPath = resolve(args[0]);
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    die('ANTHROPIC_API_KEY is not set. Export it before running this script.');
+  }
+
+  let content;
+  try {
+    content = await readFile(ymlPath, 'utf8');
+  } catch (err) {
+    die(`cannot read ${ymlPath}: ${err.message}`);
+  }
+
+  let doc;
+  try {
+    doc = YAML.parse(content);
+  } catch (err) {
+    die(`YAML parse error in ${ymlPath}: ${err.message}`);
+  }
+
+  validateAgent(doc, ymlPath);
+
+  console.log(`\x1b[36minstalling agent:\x1b[0m ${doc.name}`);
+  console.log(`  model: ${doc.model}`);
+  console.log(`  tools: ${doc.tools.length}`);
+  console.log(`  mcp_servers: ${(doc.mcp_servers ?? []).length}`);
+  console.log(`  skills: ${(doc.skills ?? []).length}`);
+
+  const client = new Anthropic();
+
+  let agent;
+  try {
+    agent = await upsert(client, doc);
+  } catch (err) {
+    if (err instanceof Anthropic.APIError) {
+      die(`Anthropic API error ${err.status}: ${err.message}`);
+    }
+    throw err;
+  }
+
+  console.log(`\x1b[32m✓ agent installed:\x1b[0m ${agent.id} (version ${agent.version ?? '?'})`);
+
+  const slug = basename(ymlPath, '.yml');
+  await persistAgentId(slug, agent);
+
+  console.log('');
+  console.log('Next steps:');
+  console.log('  1. Add .env.agents to a secrets manager (it is gitignored).');
+  console.log('  2. Run the orchestrator:');
+  console.log(`       node scripts/agent-orchestrator.mjs ${slug}`);
+}
+
+main().catch((err) => {
+  console.error(`\x1b[31mfatal:\x1b[0m ${err.message ?? err}`);
+  process.exit(1);
+});

--- a/src/services/brainBridge.ts
+++ b/src/services/brainBridge.ts
@@ -1,0 +1,162 @@
+/**
+ * Brain Bridge — browser-side client for the compliance SUPER ULTRA BRAIN.
+ *
+ * Use this from any client module that detects a compliance-critical
+ * event and wants the brain to route + escalate + publish. The server
+ * side of this bridge lives in `netlify/functions/brain.mts`.
+ *
+ * Design rules (enforced by the server too, but kept here for fast-fail):
+ *  - Free-text fields are length-capped to avoid log flood / blob abuse.
+ *  - Newlines/control chars are stripped before transmission.
+ *  - Never include raw PII — pass a ref id and let the brain look up
+ *    the authoritative record server-side.
+ *  - The bridge is fire-and-forget by default: compliance UI must never
+ *    block on brain latency. Use `notifyBrainBlocking` only when the
+ *    caller needs the decision.
+ */
+
+export type BrainEventKind =
+  | 'str_saved'
+  | 'sanctions_match'
+  | 'threshold_breach'
+  | 'deadline_missed'
+  | 'cdd_overdue'
+  | 'evidence_break'
+  | 'manual';
+
+export type BrainSeverity = 'info' | 'low' | 'medium' | 'high' | 'critical';
+
+export interface BrainEvent {
+  kind: BrainEventKind;
+  severity: BrainSeverity;
+  summary: string;
+  subject?: string;
+  matchScore?: number;
+  refId?: string;
+  meta?: Record<string, unknown>;
+}
+
+export interface BrainDecision {
+  tool:
+    | 'screening'
+    | 'workflow'
+    | 'thresholds'
+    | 'tfs'
+    | 'regulatory'
+    | 'reports'
+    | null;
+  purpose: string;
+  autoActions: string[];
+  escalate: boolean;
+}
+
+export interface BrainResponse {
+  ok: boolean;
+  actor?: string;
+  decision?: BrainDecision;
+  persistence?: { persisted: boolean; count?: number; reason?: string };
+  cachet?: { published: boolean; reason?: string };
+  error?: string;
+  receivedAt?: string;
+}
+
+const BRAIN_ENDPOINT = '/api/brain';
+const CAP_SUMMARY = 500;
+const CAP_SUBJECT = 200;
+const CAP_REFID = 64;
+
+function sanitize(s: string, cap: number): string {
+  // Strip newlines, tabs, and C0 control chars to defuse log-injection and
+  // blob-key abuse. The control-char range is intentional.
+  return s
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\r\n\t\u0000-\u001f]/g, ' ')
+    .trim()
+    .slice(0, cap);
+}
+
+function clean(event: BrainEvent): BrainEvent {
+  const out: BrainEvent = {
+    kind: event.kind,
+    severity: event.severity,
+    summary: sanitize(event.summary, CAP_SUMMARY),
+  };
+  if (event.subject) out.subject = sanitize(event.subject, CAP_SUBJECT);
+  if (event.refId) out.refId = sanitize(event.refId, CAP_REFID);
+  if (typeof event.matchScore === 'number' && Number.isFinite(event.matchScore)) {
+    out.matchScore = Math.max(0, Math.min(1, event.matchScore));
+  }
+  if (event.meta && typeof event.meta === 'object') out.meta = event.meta;
+  return out;
+}
+
+/**
+ * Resolve the auth token. The compliance app stores a hex bearer token
+ * under `auth.token` in localStorage; we read it lazily so unit tests can
+ * run without a DOM.
+ */
+function getToken(): string | null {
+  try {
+    if (typeof localStorage === 'undefined') return null;
+    return localStorage.getItem('auth.token');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fire-and-forget brain notification. Returns `true` if the request was
+ * dispatched (not necessarily successful). Never throws.
+ */
+export function notifyBrain(event: BrainEvent): boolean {
+  try {
+    const token = getToken();
+    if (!token) return false;
+    const body = JSON.stringify(clean(event));
+    // We can't use navigator.sendBeacon — it can't carry an Authorization
+    // header, and the brain endpoint requires auth. Use fetch with
+    // keepalive so the POST survives page navigation.
+    void fetch(BRAIN_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body,
+      keepalive: true,
+    }).catch(() => {
+      /* intentionally swallowed — brain is best-effort */
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Blocking brain call — awaits the decision. Only use when the caller
+ * needs to make a UX decision based on the brain's routing (e.g. "show
+ * the four-eyes approval modal if decision.escalate === true").
+ */
+export async function notifyBrainBlocking(event: BrainEvent): Promise<BrainResponse> {
+  const token = getToken();
+  if (!token) return { ok: false, error: 'no_auth_token' };
+  try {
+    const res = await fetch(BRAIN_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(clean(event)),
+    });
+    const json = (await res.json()) as BrainResponse;
+    if (!res.ok) return { ok: false, error: json.error ?? `http_${res.status}` };
+    return json;
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+}
+
+/** Exposed for tests and for runtime injection into `global.*` in compliance-suite.js. */
+export const __brain = { clean, sanitize };

--- a/tests/agentConfigs.test.ts
+++ b/tests/agentConfigs.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Agent config safety invariants.
+ *
+ * These tests lock in the hard rules that every managed agent YAML
+ * under agents/ MUST satisfy. If someone later relaxes the system
+ * prompt, removes a decision tree, or opens up portal access, the
+ * test suite fails.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import YAML from 'yaml';
+
+const AGENT_FILES = ['agents/incident-commander.yml', 'agents/hawkeye-mlro.yml'];
+
+interface AgentDoc {
+  name: string;
+  description: string;
+  model: string;
+  system: string;
+  mcp_servers: Array<{ name: string; command?: string; args?: string[]; url?: string }>;
+  tools: Array<{ type?: string; name?: string; url?: string; method?: string }>;
+  skills: Array<{ name: string; path: string }>;
+}
+
+function loadAgent(path: string): AgentDoc {
+  const content = readFileSync(resolve(__dirname, '..', path), 'utf8');
+  return YAML.parse(content) as AgentDoc;
+}
+
+describe.each(AGENT_FILES)('agent config: %s', (file) => {
+  const agent = loadAgent(file);
+
+  it('has a name, description, model, and system prompt', () => {
+    expect(agent.name).toBeTruthy();
+    expect(agent.description).toBeTruthy();
+    expect(agent.model).toMatch(/^claude-/);
+    expect(agent.system.length).toBeGreaterThan(200);
+  });
+
+  it('pins Claude Opus 4.6 (the latest Opus)', () => {
+    expect(agent.model).toBe('claude-opus-4-6');
+  });
+
+  it('includes the FDL Art.29 no-tipping-off invariant in the system prompt', () => {
+    const s = agent.system.toLowerCase();
+    expect(s).toMatch(/tipping.?off|art\.?\s*29/);
+    expect(s).toContain('never');
+  });
+
+  it('includes the four-eyes requirement', () => {
+    expect(agent.system.toLowerCase()).toMatch(/four.?eyes/);
+  });
+
+  it('includes dd/mm/yyyy + AED conventions', () => {
+    expect(agent.system).toContain('dd/mm/yyyy');
+    expect(agent.system).toContain('AED');
+  });
+
+  it('forbids raw PII in agent artefacts', () => {
+    expect(agent.system.toLowerCase()).toContain('refid');
+    expect(agent.system.toLowerCase()).toMatch(/pii|personally/);
+  });
+
+  it('wires the claude-mem MCP server at v12.1.0', () => {
+    const mem = agent.mcp_servers.find((s) => s.name === 'claude-mem');
+    expect(mem).toBeDefined();
+    expect((mem?.args ?? []).some((a) => a.includes('claude-mem@12.1.0'))).toBe(true);
+  });
+
+  it('wires the code-review-graph MCP server', () => {
+    expect(agent.mcp_servers.find((s) => s.name === 'code-review-graph')).toBeDefined();
+  });
+
+  it('wires the github MCP server', () => {
+    expect(agent.mcp_servers.find((s) => s.name === 'github')).toBeDefined();
+  });
+
+  it('exposes the brain_event HTTP tool pointed at /api/brain', () => {
+    const brain = agent.tools.find((t) => t.name === 'brain_event');
+    expect(brain).toBeDefined();
+    expect(brain?.method).toBe('POST');
+    expect(brain?.url).toContain('/api/brain');
+  });
+
+  it('exposes the cachet_incident tool (severity escalation surface)', () => {
+    expect(agent.tools.find((t) => t.name === 'cachet_incident')).toBeDefined();
+  });
+
+  it('exposes the str-narrative and sanctions-triage skills', () => {
+    const names = agent.skills.map((s) => s.name);
+    expect(names).toContain('str-narrative');
+    expect(names).toContain('sanctions-triage');
+  });
+
+  it('does NOT expose any goAML / EOCN / portal submission tool', () => {
+    for (const tool of agent.tools) {
+      const name = (tool.name ?? '').toLowerCase();
+      const url = (tool.url ?? '').toLowerCase();
+      expect(name).not.toMatch(/goaml|eocn|submit.?report|portal/);
+      expect(url).not.toMatch(/goaml|eocn\.gov/);
+    }
+  });
+
+  it('does NOT expose any email / SMS / subject-notification tool', () => {
+    for (const tool of agent.tools) {
+      const name = (tool.name ?? '').toLowerCase();
+      expect(name).not.toMatch(/email.?(customer|subject)|sms|notify.?subject|tip.?off/);
+    }
+  });
+});

--- a/tests/agentConfigs.test.ts
+++ b/tests/agentConfigs.test.ts
@@ -2,9 +2,14 @@
  * Agent config safety invariants.
  *
  * These tests lock in the hard rules that every managed agent YAML
- * under agents/ MUST satisfy. If someone later relaxes the system
- * prompt, removes a decision tree, or opens up portal access, the
- * test suite fails.
+ * under agents/ MUST satisfy. They also enforce the Managed Agents
+ * API schema (POST /v1/agents, beta managed-agents-2026-04-01):
+ *  - model is a real Claude ID
+ *  - mcp_servers only use {type: "url", name, url} (no stdio)
+ *  - tools are agent_toolset_20260401 | custom | mcp_toolset
+ *  - no "type: http" (doesn't exist)
+ *  - no tool name that implies subject notification
+ *  - no portal submission tool
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -13,14 +18,25 @@ import YAML from 'yaml';
 
 const AGENT_FILES = ['agents/incident-commander.yml', 'agents/hawkeye-mlro.yml'];
 
+type McpServer = { type: string; name: string; url?: string };
+type ToolBase = { type: string; name?: string };
+type CustomTool = ToolBase & {
+  type: 'custom';
+  name: string;
+  description: string;
+  input_schema: { type: 'object'; required?: string[]; properties: Record<string, unknown> };
+};
+type AgentToolset = ToolBase & { type: 'agent_toolset_20260401' };
+type Tool = CustomTool | AgentToolset | ToolBase;
+
 interface AgentDoc {
   name: string;
   description: string;
   model: string;
   system: string;
-  mcp_servers: Array<{ name: string; command?: string; args?: string[]; url?: string }>;
-  tools: Array<{ type?: string; name?: string; url?: string; method?: string }>;
-  skills: Array<{ name: string; path: string }>;
+  mcp_servers?: McpServer[];
+  tools: Tool[];
+  skills?: Array<{ type: 'anthropic' | 'custom'; skill_id: string; version?: string }>;
 }
 
 function loadAgent(path: string): AgentDoc {
@@ -42,7 +58,20 @@ describe.each(AGENT_FILES)('agent config: %s', (file) => {
     expect(agent.model).toBe('claude-opus-4-6');
   });
 
-  it('includes the FDL Art.29 no-tipping-off invariant in the system prompt', () => {
+  it('name length is within API limits (1-256 chars)', () => {
+    expect(agent.name.length).toBeGreaterThanOrEqual(1);
+    expect(agent.name.length).toBeLessThanOrEqual(256);
+  });
+
+  it('description is within API limit (<=2048 chars)', () => {
+    expect(agent.description.length).toBeLessThanOrEqual(2048);
+  });
+
+  it('system prompt is within API limit (<=100000 chars)', () => {
+    expect(agent.system.length).toBeLessThanOrEqual(100_000);
+  });
+
+  it('includes the FDL Art.29 no-tipping-off invariant', () => {
     const s = agent.system.toLowerCase();
     expect(s).toMatch(/tipping.?off|art\.?\s*29/);
     expect(s).toContain('never');
@@ -62,43 +91,85 @@ describe.each(AGENT_FILES)('agent config: %s', (file) => {
     expect(agent.system.toLowerCase()).toMatch(/pii|personally/);
   });
 
-  it('wires the claude-mem MCP server at v12.1.0', () => {
-    const mem = agent.mcp_servers.find((s) => s.name === 'claude-mem');
-    expect(mem).toBeDefined();
-    expect((mem?.args ?? []).some((a) => a.includes('claude-mem@12.1.0'))).toBe(true);
+  it('mcp_servers (if any) are all URL-based', () => {
+    for (const srv of agent.mcp_servers ?? []) {
+      expect(srv.type, `${srv.name} must be URL-based`).toBe('url');
+      expect(srv.url).toMatch(/^https:\/\//);
+      // No stdio fields leaked in.
+      expect(srv as unknown as Record<string, unknown>).not.toHaveProperty('command');
+      expect(srv as unknown as Record<string, unknown>).not.toHaveProperty('args');
+    }
   });
 
-  it('wires the code-review-graph MCP server', () => {
-    expect(agent.mcp_servers.find((s) => s.name === 'code-review-graph')).toBeDefined();
+  it('mcp_servers respects the API cap of 20 unique names', () => {
+    const servers = agent.mcp_servers ?? [];
+    expect(servers.length).toBeLessThanOrEqual(20);
+    const names = new Set(servers.map((s) => s.name));
+    expect(names.size).toBe(servers.length);
   });
 
-  it('wires the github MCP server', () => {
-    expect(agent.mcp_servers.find((s) => s.name === 'github')).toBeDefined();
+  it('declares the agent_toolset_20260401 base toolset', () => {
+    const base = agent.tools.find((t) => t.type === 'agent_toolset_20260401');
+    expect(base).toBeDefined();
   });
 
-  it('exposes the brain_event HTTP tool pointed at /api/brain', () => {
-    const brain = agent.tools.find((t) => t.name === 'brain_event');
+  it('uses only valid Managed Agents tool types', () => {
+    const VALID = new Set(['agent_toolset_20260401', 'custom', 'mcp_toolset']);
+    for (const tool of agent.tools) {
+      expect(VALID.has(tool.type), `unknown tool type: ${tool.type}`).toBe(true);
+    }
+  });
+
+  it('never uses the invalid "http" tool type', () => {
+    for (const tool of agent.tools) {
+      expect(tool.type).not.toBe('http');
+    }
+  });
+
+  it('tools count is within API cap (<=50)', () => {
+    expect(agent.tools.length).toBeLessThanOrEqual(50);
+  });
+
+  it('exposes brain_event as a custom tool with strict input schema', () => {
+    const brain = agent.tools.find((t): t is CustomTool =>
+      t.type === 'custom' && t.name === 'brain_event',
+    );
     expect(brain).toBeDefined();
-    expect(brain?.method).toBe('POST');
-    expect(brain?.url).toContain('/api/brain');
+    expect(brain?.description).toBeTruthy();
+    const schema = brain?.input_schema;
+    expect(schema?.type).toBe('object');
+    expect(schema?.required).toContain('kind');
+    expect(schema?.required).toContain('severity');
+    expect(schema?.required).toContain('summary');
+    const kind = (schema?.properties.kind as { enum?: string[] }) ?? {};
+    expect(kind.enum).toContain('sanctions_match');
+    expect(kind.enum).toContain('str_saved');
+    expect(kind.enum).toContain('evidence_break');
   });
 
-  it('exposes the cachet_incident tool (severity escalation surface)', () => {
-    expect(agent.tools.find((t) => t.name === 'cachet_incident')).toBeDefined();
+  it('exposes cachet_incident as a custom tool', () => {
+    const cachet = agent.tools.find((t): t is CustomTool =>
+      t.type === 'custom' && t.name === 'cachet_incident',
+    );
+    expect(cachet).toBeDefined();
+    expect(cachet?.input_schema.required).toContain('name');
+    expect(cachet?.input_schema.required).toContain('status');
   });
 
-  it('exposes the str-narrative and sanctions-triage skills', () => {
-    const names = agent.skills.map((s) => s.name);
-    expect(names).toContain('str-narrative');
-    expect(names).toContain('sanctions-triage');
+  it('every custom tool has a description and valid input_schema', () => {
+    const customs = agent.tools.filter((t): t is CustomTool => t.type === 'custom');
+    for (const tool of customs) {
+      expect(tool.name).toBeTruthy();
+      expect(tool.description).toBeTruthy();
+      expect(tool.input_schema.type).toBe('object');
+      expect(tool.input_schema.properties).toBeDefined();
+    }
   });
 
   it('does NOT expose any goAML / EOCN / portal submission tool', () => {
     for (const tool of agent.tools) {
       const name = (tool.name ?? '').toLowerCase();
-      const url = (tool.url ?? '').toLowerCase();
       expect(name).not.toMatch(/goaml|eocn|submit.?report|portal/);
-      expect(url).not.toMatch(/goaml|eocn\.gov/);
     }
   });
 
@@ -106,6 +177,17 @@ describe.each(AGENT_FILES)('agent config: %s', (file) => {
     for (const tool of agent.tools) {
       const name = (tool.name ?? '').toLowerCase();
       expect(name).not.toMatch(/email.?(customer|subject)|sms|notify.?subject|tip.?off/);
+    }
+  });
+
+  it('skills count is within API cap (<=64)', () => {
+    expect((agent.skills ?? []).length).toBeLessThanOrEqual(64);
+  });
+
+  it('skill references use valid type and id', () => {
+    for (const skill of agent.skills ?? []) {
+      expect(['anthropic', 'custom']).toContain(skill.type);
+      expect(skill.skill_id).toBeTruthy();
     }
   });
 });

--- a/tests/brainEndpoint.test.ts
+++ b/tests/brainEndpoint.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for netlify/functions/brain.mts routing + validation.
+ *
+ * Pure-logic tests — no fetch, no Netlify runtime. We import the internal
+ * `__test__` helpers directly so the test is hermetic.
+ */
+import { describe, it, expect } from 'vitest';
+
+// The brain endpoint is a .mts file. Vitest can transform it.
+// @ts-expect-error — no type declarations for the .mts at test time
+import { __test__ } from '../netlify/functions/brain.mts';
+
+const { route, validate } = __test__;
+
+describe('brain endpoint: validate()', () => {
+  it('rejects non-object body', () => {
+    expect(validate(null).ok).toBe(false);
+    expect(validate('string').ok).toBe(false);
+    expect(validate(42).ok).toBe(false);
+  });
+
+  it('rejects unknown kind', () => {
+    const r = validate({ kind: 'nuke_everything', severity: 'high', summary: 'x' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects unknown severity', () => {
+    const r = validate({ kind: 'str_saved', severity: 'apocalyptic', summary: 'x' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects empty or oversize summary', () => {
+    expect(validate({ kind: 'manual', severity: 'info', summary: '' }).ok).toBe(false);
+    expect(validate({ kind: 'manual', severity: 'info', summary: 'x'.repeat(600) }).ok).toBe(false);
+  });
+
+  it('rejects out-of-range matchScore', () => {
+    const bad = validate({
+      kind: 'sanctions_match',
+      severity: 'high',
+      summary: 'hit',
+      matchScore: 1.5,
+    });
+    expect(bad.ok).toBe(false);
+  });
+
+  it('strips newlines from free-text fields (log-injection defense)', () => {
+    const r = validate({
+      kind: 'manual',
+      severity: 'info',
+      summary: 'line1\nline2\rline3',
+      subject: 'bad\nactor',
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.event.summary).not.toContain('\n');
+      expect(r.event.summary).not.toContain('\r');
+      expect(r.event.subject).not.toContain('\n');
+    }
+  });
+
+  it('accepts a well-formed event', () => {
+    const r = validate({
+      kind: 'sanctions_match',
+      severity: 'critical',
+      summary: 'OFAC hit on counterparty',
+      subject: 'Acme Corp',
+      matchScore: 0.95,
+      refId: 'CRA-123',
+    });
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('brain endpoint: route()', () => {
+  it('confirmed sanctions match → 24h freeze protocol', () => {
+    const d = route({
+      kind: 'sanctions_match',
+      severity: 'critical',
+      summary: 'hit',
+      matchScore: 0.95,
+    });
+    expect(d.tool).toBe('screening');
+    expect(d.escalate).toBe(true);
+    expect(d.autoActions).toContain('freeze_assets:immediate');
+    expect(d.autoActions).toContain('start_eocn_countdown:24h');
+    expect(d.autoActions).toContain('schedule_cnmr_filing:5bd');
+    // No tipping off — FDL Art.29
+    expect(d.autoActions).toContain('suppress_subject_notification:FDL_Art29');
+  });
+
+  it('potential sanctions match → four-eyes review', () => {
+    const d = route({
+      kind: 'sanctions_match',
+      severity: 'high',
+      summary: 'partial hit',
+      matchScore: 0.7,
+    });
+    expect(d.autoActions).toContain('escalate_to_co');
+    expect(d.autoActions).toContain('require_four_eyes_review');
+    // Must not auto-freeze on a potential match
+    expect(d.autoActions).not.toContain('freeze_assets:immediate');
+  });
+
+  it('low-confidence hit → log and dismiss', () => {
+    const d = route({
+      kind: 'sanctions_match',
+      severity: 'low',
+      summary: 'weak hit',
+      matchScore: 0.2,
+    });
+    expect(d.autoActions).toContain('log_dismissal_with_rationale');
+    expect(d.autoActions).not.toContain('freeze_assets:immediate');
+  });
+
+  it('STR saved → applies FDL Art.29 confidentiality lock', () => {
+    const d = route({ kind: 'str_saved', severity: 'high', summary: 'STR draft' });
+    expect(d.autoActions).toContain('apply_confidentiality_lock:FDL_Art29');
+    expect(d.autoActions).toContain('start_deadline_tracker:str');
+  });
+
+  it('threshold breach → escalates and holds transaction', () => {
+    const d = route({ kind: 'threshold_breach', severity: 'high', summary: 'AED 55K' });
+    expect(d.escalate).toBe(true);
+    expect(d.autoActions).toContain('freeze_transaction_pending_review');
+  });
+
+  it('evidence chain break → forensic freeze + Cachet publish', () => {
+    const d = route({ kind: 'evidence_break', severity: 'critical', summary: 'broken' });
+    expect(d.autoActions).toContain('freeze_all_new_records');
+    expect(d.autoActions).toContain('publish_cachet_incident');
+    expect(d.escalate).toBe(true);
+  });
+
+  it('never auto-notifies the subject on any route', () => {
+    const kinds = [
+      'str_saved',
+      'sanctions_match',
+      'threshold_breach',
+      'deadline_missed',
+      'cdd_overdue',
+      'evidence_break',
+      'manual',
+    ] as const;
+    for (const kind of kinds) {
+      const d = route({
+        kind,
+        severity: 'high',
+        summary: 's',
+        matchScore: kind === 'sanctions_match' ? 0.95 : undefined,
+      });
+      for (const action of d.autoActions) {
+        expect(action).not.toMatch(/notify.?subject|tip.?off|email.?customer/i);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

End-to-end installation of the SUPER ULTRA BRAIN compliance orchestrator across the repo, plus two Anthropic Managed Agents wired to it. Everything is test-covered and audit-safe.

## What's in the PR

### New infrastructure (commits 422e187 → b53dce1)
- **`claude-mem@12.1.0`** pinned in `.mcp.json` + `package.json`
- **`genaiscript ^2.5.1`** with two compliance scripts (`str-narrative`, `sanctions-triage`) under `genaisrc/`
- **`cachethq/cachet`** deployed via `ops/cachet/docker-compose.yml` + `scripts/lib/cachet-client.mjs`
- **`doctrine/cache ^2.2`** pinned in `ops/cachet/composer.json` for Cachet extensions
- **`actions/cache@v4`** wired into `.github/workflows/ci.yml` + `autopilot.yml`
- **`scripts/brain.mjs`** — Session / Tools / Orchestration / Sandbox harness with deterministic routing to existing compliance subsystems

### Main code weaponization (commit b53dce1)
- **`netlify/functions/brain.mts`** — auth'd + rate-limited + schema-validated `POST /api/brain` endpoint
- **`src/services/brainBridge.ts`** + **`brain-boot.js`** — typed TS + vanilla JS clients for the brain
- **`compliance-suite.js`**:
  - `suiteSaveSTR` now fires `brain_notify` with the filing deadline + FDL Art.29 lock
  - `suiteCalcAndSaveCRA` now fires `brain_notify` on sanctions hit with `matchScore` mapped from the dropdown value
- **`scripts/autopilot.mjs`** Phase 6: every daily alert routed through `brain.think()`, CRITICAL → Cachet

### Managed Agents (commits 39d4efd → d36f0f0)
- **`agents/incident-commander.yml`** — reactive triager for brain alerts
- **`agents/hawkeye-mlro.yml`** — strategic drafting assistant for the MLRO
- Both use the real Managed Agents API schema (`POST /v1/agents`, beta `managed-agents-2026-04-01`): `agent_toolset_20260401` + `custom` tools + URL-based MCP only
- **`scripts/install-agent.mjs`** — idempotent YAML→API installer with schema + safety validation
- **`scripts/agent-orchestrator.mjs`** — event-loop client that handles `agent.custom_tool_use` for `brain_event` and `cachet_incident` host-side (credentials never leave the orchestrator)
- **`scripts/bootstrap.sh`** — one-shot terminal setup
- **`.github/workflows/agent-install.yml`** — browser-only agent installer via workflow_dispatch
- **`.github/workflows/agent-run.yml`** — browser-only agent runner via workflow_dispatch

## Test plan

- [x] `npm test` — **267 / 267 passing** (was 209 on main):
  - 5 new `brain.test.ts` — brain routing + tool catalogue
  - 14 new `brainEndpoint.test.ts` — validation, routing, log-injection, FDL Art.29 invariant across all 7 event kinds
  - 44 new `agentConfigs.test.ts` — YAML schema + safety invariants for both agent configs
- [x] `node --check` clean on all new `.mjs` + `.js` files
- [x] `eslint src/services/brainBridge.ts` clean
- [x] Both YAMLs parse and match the real Managed Agents API schema
- [x] No `type: http` tool (doesn't exist in the API)
- [x] No stdio MCP servers (Managed Agents only supports URL-based MCP)
- [x] No email / SMS / subject-notification tool on either agent
- [x] No goAML / EOCN / portal submission tool on either agent

## Safety posture

Every addition honors `CLAUDE.md`:
- **FDL Art.29 no-tipping-off** — tested across all 7 brain event kinds AND both agent system prompts
- **Four-eyes gate** — enforced in agent system prompts, never bypassed by auto-actions
- **Rate-limited, authed brain endpoint** — 10 req/15min per IP, Bearer auth, input schema validation
- **No PII in agent artefacts** — agents pass `refId` only, orchestrator looks up authoritative record
- **No secrets in code** — `.env.agents`, `.env.cachet`, `HAWKEYE_BRAIN_TOKEN` all gitignored
- **Log-injection defense** — control chars stripped from all free-text fields

## Post-merge browser flow

1. Settings → Secrets → add `ANTHROPIC_API_KEY`
2. Actions → **Install Managed Agents** → Run workflow (input: `both`)
3. Copy the `HAWKEYE_BRAIN_TOKEN` from the step summary
4. Paste it as a GitHub secret AND a Netlify env var, redeploy Netlify
5. Actions → **Run Managed Agent** → Run workflow (smoke test)

Full step-by-step in `agents/README.md`.

https://claude.ai/code/session_01Etf4z7nghVWYNLAykBA2jW