### PR TITLE
Show full desktop layout on mobile via fixed 1280px viewport

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+<meta name="viewport" content="width=1280, viewport-fit=cover">
 <meta name="mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">


### PR DESCRIPTION
Previously the viewport used width=device-width, which caused the
@media (max-width: 768px) and (max-width: 480px) rules in index.html
to reorder and collapse the layout on phones (hamburger menu, stacked
metrics, truncated header). Auditors opening the tool on mobile
couldn't see the full information.

Setting the viewport to a fixed 1280px tells the browser to render the
page at desktop width and auto-scale it to fit the physical screen.
Effects:

- Every card, metric, and RACI column renders in its desktop position.
- The mobile @media blocks never trigger (innerWidth reports 1280), so
  the existing CSS is untouched and all collapse/hide rules stay
  dormant — zero design change.
- MobileResponsive.isMobile() in mobile-responsive.js also returns
  false, so the hamburger stays hidden and the desktop tab bar shows.
- Pinch-to-zoom is still enabled (no user-scalable=no), letting users
  zoom into small text when needed.

Trade-off: initial text size is small on narrow screens (~30% on a
390px iPhone), which is the expected cost of "show the full desktop
layout without redesigning it".

https://claude.ai/code/session_01NkwEgYDKQMLpcyBQKJGtyn