### PR TITLE
Remove name-matching bias against non-Anglo demographics

### DIFF
--- a/src/agents/aiGovernance/selfAudit.ts
+++ b/src/agents/aiGovernance/selfAudit.ts
@@ -44,7 +44,7 @@ export const SELF_AUDIT_EVIDENCE: Readonly<GovernanceEvidence> = Object.freeze({
   // Data governance
   hasDataGovernancePolicy: true, // CLAUDE.md "Seguridad" section
   hasTrainingDataLineage: false, // no centralised training data (no ML training happens in-app)
-  hasBiasAssessment: false, //     TODO: needs explicit bias testing for name-matching / jurisdictions
+  hasBiasAssessment: true, //      src/services/nameMatchingBiasAssessment.ts + tests/nameMatchingBiasAssessment.test.ts (EU AI Act Art.10, NIST AI RMF Measure 2.11)
   hasDataQualityChecks: true, //   src/domain/constants.ts + zod schemas
 
   // Transparency / XAI

--- a/src/services/nameMatching.ts
+++ b/src/services/nameMatching.ts
@@ -347,13 +347,54 @@ function tokenise(s: string): string[] {
  * best matches. Handles surname-first ↔ surname-last permutations.
  */
 export function tokenSetSimilarity(a: string, b: string): number {
+  return tokenSetBreakdown(a, b).mean;
+}
+
+/**
+ * Token-set breakdown — exposes the mean, min, and max of per-token
+ * best matches plus structural metadata. Used by the bias-aware
+ * composite score in matchScore() to detect the "shared one token,
+ * distinct other token" pattern that signals two different people
+ * (e.g. "Wang Wei" vs "Wang Lei", "Imran Khan" vs "Imran Ahmed",
+ * "Rajesh Kumar" vs "Anil Kumar").
+ *
+ * This helper is the foundation of the fairness fix that brings
+ * Chinese / South Asian / Arabic / Persian false-positive rates in
+ * line with Anglo names — the previous arithmetic-mean-only formula
+ * over-flagged demographics whose name distributions naturally share
+ * common tokens.
+ *
+ * See `nameMatchingBiasAssessment.ts` for the regression harness.
+ */
+export interface TokenSetBreakdown {
+  /** Arithmetic mean of per-token best matches. */
+  mean: number;
+  /** Minimum per-token best match — the worst-matched token-pair. */
+  min: number;
+  /** Maximum per-token best match — the best-matched token-pair. */
+  max: number;
+  /** True if both inputs have the same token count. */
+  sameTokenCount: boolean;
+  /** Number of tokens on the shorter side. */
+  shortLen: number;
+  /** Number of tokens on the longer side. */
+  longLen: number;
+}
+
+export function tokenSetBreakdown(a: string, b: string): TokenSetBreakdown {
   const tokensA = tokenise(a);
   const tokensB = tokenise(b);
-  if (tokensA.length === 0 || tokensB.length === 0) return 0;
+  if (tokensA.length === 0 || tokensB.length === 0) {
+    return { mean: 0, min: 0, max: 0, sameTokenCount: false, shortLen: 0, longLen: 0 };
+  }
 
-  const [short, long] = tokensA.length <= tokensB.length ? [tokensA, tokensB] : [tokensB, tokensA];
+  const sameTokenCount = tokensA.length === tokensB.length;
+  const [short, long] =
+    tokensA.length <= tokensB.length ? [tokensA, tokensB] : [tokensB, tokensA];
 
   let total = 0;
+  let minBest = Infinity;
+  let maxBest = -Infinity;
   for (const s of short) {
     let best = 0;
     for (const l of long) {
@@ -362,8 +403,17 @@ export function tokenSetSimilarity(a: string, b: string): number {
       if (best === 1) break;
     }
     total += best;
+    if (best < minBest) minBest = best;
+    if (best > maxBest) maxBest = best;
   }
-  return total / short.length;
+  return {
+    mean: total / short.length,
+    min: minBest,
+    max: maxBest,
+    sameTokenCount,
+    shortLen: short.length,
+    longLen: long.length,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -412,10 +462,56 @@ export function matchScore(rawA: string, rawB: string): MatchBreakdown {
   const normB = normalise(b);
 
   const jw = jaroWinkler(normA, normB);
-  const token = tokenSetSimilarity(normA, normB);
+  const tsb = tokenSetBreakdown(normA, normB);
   const metaA = metaphone(normA);
   const metaB = metaphone(normB);
   const phonetic = metaA.length > 0 && metaA === metaB ? 1 : 0;
+
+  // Distinct-token penalty — fairness fix.
+  //
+  // The arithmetic mean of best-match scores systematically over-
+  // flags multi-token names where ONE token is identical and the
+  // OTHER token is structurally distinct. This pattern dominates
+  // false positives on demographics whose name distributions
+  // naturally share common tokens:
+  //
+  //   - "Wang Wei" vs "Wang Lei"     (Han surname collisions)
+  //   - "Imran Khan" vs "Imran Ahmed" (shared first name)
+  //   - "Rajesh Kumar" vs "Anil Kumar"
+  //   - "Ahmed Ali" vs "Ahmed Hassan"
+  //
+  // Two triggers:
+  //   1. Heavy-distinct: any best-match below 0.6 means the token-
+  //      pair carries no useful similarity → square the min as
+  //      the token signal (catches unrelated names of any token
+  //      count, including the asymmetric "Imran Khan" vs
+  //      "Shah Rukh Khan" pattern).
+  //   2. Shared-single-token: one pair matches perfectly
+  //      (max ≥ 0.999) and the worst pair is below 0.8 → square
+  //      the min. This is the "Wang Wei" / "Imran Khan" vs
+  //      "Shah Rukh Khan" pattern that arithmetic mean alone
+  //      cannot distinguish from a real match. Applies regardless
+  //      of token count, so it catches both same-count cases
+  //      ("Wang Wei" vs "Wang Lei") and asymmetric cases
+  //      ("Imran Khan" vs "Shah Rukh Khan").
+  //
+  // The penalty preserves real matches because it requires either
+  // a clearly weak token-pair (< 0.6) or a structural shared-one-
+  // token signature with a distinct other pair (< 0.8). Cross-
+  // script transliteration matches (e.g. "محمد بن سلمان" /
+  // "Mohammed bin Salman") have NO exact-token match (max < 1.0),
+  // so trigger 2 does not fire, and their min stays above 0.6,
+  // so trigger 1 does not fire either. They route through the
+  // unmodified arithmetic-mean path and remain flagged.
+  //
+  // Regulatory basis: EU AI Act Art.10 (bias mitigation), NIST AI
+  // RMF Measure 2.11 (fairness), UAE AI Charter Principle 3.
+  let token = tsb.mean;
+  const heavilyDistinctToken = tsb.min < 0.6;
+  const sharedSingleTokenWithDistinctOther = tsb.max >= 0.999 && tsb.min < 0.8;
+  if (heavilyDistinctToken || sharedSingleTokenWithDistinctOther) {
+    token = tsb.min * tsb.min;
+  }
 
   // Composite: token-set is the dominant signal because it handles
   // surname-first vs surname-last, middle-name omission, and legal-

--- a/src/services/nameMatchingBiasAssessment.ts
+++ b/src/services/nameMatchingBiasAssessment.ts
@@ -1,0 +1,384 @@
+/**
+ * Name-Matching Bias Assessment.
+ *
+ * Sanctions screening lives or dies on the recall of the underlying
+ * name-matcher. A matcher that is great at Anglo names and weak at
+ * Arabic, Persian, Slavic, South Asian, or Chinese names is not just
+ * embarrassing — it is a fairness failure with real regulatory
+ * exposure:
+ *
+ *   - EU AI Act Art.10 (data governance — bias detection / mitigation)
+ *   - NIST AI RMF Measure 2.11 (fairness, harmful bias, equity)
+ *   - ISO/IEC 42001 A.7.4 (data quality + representativeness)
+ *   - UAE AI Charter Principle 3 (fairness, non-discrimination)
+ *
+ * This module provides:
+ *   1. A curated, deterministic fixture of (positive, negative) name
+ *      pairs grouped by name origin.
+ *   2. An assessor that runs the live `matchScore()` against the
+ *      fixture and returns per-group recall + false-positive rate.
+ *   3. Parity metrics (max-min deltas) so callers can detect
+ *      disparate-impact patterns even when each group passes its own
+ *      floor.
+ *   4. A markdown formatter for the audit pack.
+ *
+ * The fixture is intentionally small and embedded — it is a regression
+ * harness, not a benchmark. The point is to catch the day someone
+ * "optimises" the matcher and the recall on Arabic names silently
+ * collapses by 30 points. A larger labelled corpus belongs in
+ * `tests/fixtures/` if we ever want true generalisation metrics.
+ */
+
+import { classifyMatch, type MatchClassification } from './nameMatching';
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+/**
+ * Name-origin groups we explicitly assess. Chosen to mirror the actual
+ * UAE clientele distribution: GCC nationals + expats from the major
+ * source countries.
+ */
+export type NameOriginGroup =
+  | 'anglo'
+  | 'arabic'
+  | 'persian'
+  | 'slavic'
+  | 'south_asian'
+  | 'chinese';
+
+export interface NamePair {
+  /** Display label so failures point at the offending pair. */
+  label: string;
+  a: string;
+  b: string;
+}
+
+export interface BiasFixtureGroup {
+  group: NameOriginGroup;
+  /** Pairs that refer to the same person — engine SHOULD flag. */
+  positives: readonly NamePair[];
+  /** Pairs that are distinct people — engine SHOULD NOT flag. */
+  negatives: readonly NamePair[];
+}
+
+/**
+ * Curated fixture. Positive pairs cover spelling variants, typos,
+ * surname swap, and (where applicable) script variants. Negative
+ * pairs cover the harder case: distinct people who share a common
+ * given name or surname inside the same name distribution — this is
+ * where Han / Arabic matchers historically over-flag.
+ */
+export const BIAS_FIXTURE: readonly BiasFixtureGroup[] = Object.freeze([
+  {
+    group: 'anglo',
+    positives: [
+      { label: 'identical', a: 'John Smith', b: 'John Smith' },
+      { label: 'surname-first swap', a: 'John Smith', b: 'Smith, John' },
+      { label: 'single-letter typo', a: 'John Smith', b: 'Jhon Smith' },
+      { label: 'apostrophe variant', a: "Catherine O'Brien", b: 'Catherine OBrien' },
+      { label: 'middle-name added', a: 'Sarah Davis', b: 'Sarah J Davis' },
+    ],
+    negatives: [
+      { label: 'unrelated 1', a: 'John Smith', b: 'Mary Jones' },
+      { label: 'unrelated 2', a: 'Liam O Brien', b: 'Sean Murphy' },
+      { label: 'shared first name', a: 'John Smith', b: 'John Anderson' },
+      { label: 'shared surname', a: 'David Brown', b: 'Rachel Brown' },
+    ],
+  },
+  {
+    group: 'arabic',
+    positives: [
+      { label: 'cross-script Mohammed', a: 'محمد بن سلمان', b: 'Mohammed bin Salman' },
+      { label: 'cross-script Muhammad', a: 'محمد بن سلمان', b: 'Muhammad bin Salman' },
+      { label: 'cross-script Ahmed', a: 'أحمد علي', b: 'Ahmed Ali' },
+      { label: 'spelling Ahmad/Ahmed', a: 'Ahmed Ali', b: 'Ahmad Ali' },
+      { label: 'al- prefix variant', a: 'Khalid Al-Mutairi', b: 'Khalid Almutairi' },
+      { label: 'identical Arabic', a: 'عبد الله', b: 'عبد الله' },
+    ],
+    negatives: [
+      { label: 'shared given name 1', a: 'Ahmed Ali', b: 'Ahmed Hassan' },
+      { label: 'shared given name 2', a: 'Mohammed Khalid', b: 'Mohammed Yusuf' },
+      { label: 'shared surname Al-Mutairi', a: 'Khalid Al-Mutairi', b: 'Saeed Al-Mutairi' },
+      { label: 'unrelated GCC', a: 'Fatima Al-Maktoum', b: 'Layla Al-Qasimi' },
+    ],
+  },
+  {
+    group: 'persian',
+    positives: [
+      { label: 'macron variant', a: 'Reza Pahlavi', b: 'Rezā Pahlavī' },
+      { label: 'hyphen variant', a: 'Mahmoud Ahmadinejad', b: 'Mahmoud Ahmadi-Nejad' },
+      { label: 'spelling Hasan/Hassan', a: 'Hassan Rouhani', b: 'Hasan Rouhani' },
+      { label: 'single-letter typo', a: 'Ali Khamenei', b: 'Ali Khameini' },
+      { label: 'identical', a: 'Qasem Soleimani', b: 'Qasem Soleimani' },
+    ],
+    negatives: [
+      { label: 'shared given name', a: 'Ali Khamenei', b: 'Ali Larijani' },
+      { label: 'shared surname', a: 'Hassan Rouhani', b: 'Fereydoon Rouhani' },
+      { label: 'unrelated', a: 'Reza Pahlavi', b: 'Mahmoud Bahmani' },
+    ],
+  },
+  {
+    group: 'slavic',
+    positives: [
+      { label: 'Vladimir/Wladimir', a: 'Vladimir Putin', b: 'Wladimir Putin' },
+      { label: 'Dmitry/Dmitri', a: 'Dmitry Medvedev', b: 'Dmitri Medvedev' },
+      { label: 'Sergey/Sergei', a: 'Sergey Lavrov', b: 'Sergei Lavrov' },
+      { label: 'Yevgeny/Evgeny', a: 'Yevgeny Prigozhin', b: 'Evgeny Prigozhin' },
+      { label: 'identical', a: 'Yuri Ivanov', b: 'Yuri Ivanov' },
+    ],
+    negatives: [
+      { label: 'shared first name', a: 'Vladimir Putin', b: 'Vladimir Zhirinovsky' },
+      { label: 'shared surname Ivanov', a: 'Yuri Ivanov', b: 'Pavel Ivanov' },
+      { label: 'unrelated', a: 'Dmitry Medvedev', b: 'Sergei Shoigu' },
+    ],
+  },
+  {
+    group: 'south_asian',
+    positives: [
+      { label: 'Mohammed/Muhammad spelling', a: 'Mohammed Yousuf', b: 'Muhammad Yusuf' },
+      { label: 'family-name added', a: 'Rajesh Kumar', b: 'Rajesh Kumar Singh' },
+      { label: 'hyphen variant', a: 'Anwar ul-Haq', b: 'Anwar ul Haq' },
+      { label: 'double-vowel variant', a: 'Imran Khan', b: 'Imraan Khan' },
+      { label: 'Pervez/Parvez spelling', a: 'Pervez Musharraf', b: 'Parvez Musharraf' },
+    ],
+    negatives: [
+      { label: 'shared first name', a: 'Imran Khan', b: 'Imran Ahmed' },
+      { label: 'shared surname Khan', a: 'Imran Khan', b: 'Shah Rukh Khan' },
+      { label: 'shared surname Kumar', a: 'Rajesh Kumar', b: 'Anil Kumar' },
+    ],
+  },
+  {
+    group: 'chinese',
+    positives: [
+      { label: 'identical Wang Wei', a: 'Wang Wei', b: 'Wang Wei' },
+      { label: 'identical Li Ming', a: 'Li Ming', b: 'Li Ming' },
+      { label: 'capitalisation', a: 'Chen Hui', b: 'CHEN HUI' },
+      { label: 'hyphen variant', a: 'Sun Yat-sen', b: 'Sun Yat sen' },
+      { label: 'apostrophe variant', a: "Xi'an Liu", b: 'Xian Liu' },
+    ],
+    negatives: [
+      // The hardest fairness case: in Han names, ~85% of the population
+      // shares ~100 surnames. Naive fuzzy matching catastrophically
+      // over-flags. The engine MUST keep these distinct.
+      { label: 'shared surname Wang 1', a: 'Wang Wei', b: 'Wang Lei' },
+      { label: 'shared surname Wang 2', a: 'Wang Wei', b: 'Wang Min' },
+      { label: 'shared surname Li', a: 'Li Ming', b: 'Li Hua' },
+      { label: 'shared surname Chen', a: 'Chen Hui', b: 'Chen Bo' },
+    ],
+  },
+]);
+
+// ---------------------------------------------------------------------------
+// Assessor
+// ---------------------------------------------------------------------------
+
+export interface GroupBiasMetrics {
+  group: NameOriginGroup;
+  positivesTotal: number;
+  positivesFlagged: number;
+  /** TPR — proportion of true matches the engine flagged. */
+  recall: number;
+  negativesTotal: number;
+  negativesFlagged: number;
+  /** FPR — proportion of distinct people the engine wrongly flagged. */
+  falsePositiveRate: number;
+  /** Pairs the engine missed (false negatives). */
+  missedPositives: readonly { label: string; classification: MatchClassification; score: number }[];
+  /** Pairs the engine wrongly flagged (false positives). */
+  spuriousNegatives: readonly { label: string; classification: MatchClassification; score: number }[];
+}
+
+export interface BiasAssessmentReport {
+  /** ISO timestamp of the run. */
+  ranAt: string;
+  /** Per-group metrics, in fixture order. */
+  groups: readonly GroupBiasMetrics[];
+  /** max(recall) - min(recall) across groups — equal-opportunity gap. */
+  recallParityGap: number;
+  /** max(FPR) - min(FPR) across groups — predictive-equality gap. */
+  fprParityGap: number;
+  /** Worst single-group recall. */
+  worstRecall: number;
+  /** Worst single-group FPR. */
+  worstFalsePositiveRate: number;
+  /** True if every bound in BIAS_PARITY_BOUNDS is satisfied. */
+  passesParityBounds: boolean;
+}
+
+/**
+ * Acceptable bounds for the bias assessment. These are intentionally
+ * coarse — the fixture is small and the matcher is heuristic, so
+ * tighter bounds would be theatre. Tighten as the matcher improves.
+ *
+ * The numbers were calibrated against the live engine on the fixture
+ * above. Lowering recall below the floor or raising FPR above the
+ * ceiling indicates a real regression in fairness-relevant behaviour.
+ */
+export const BIAS_PARITY_BOUNDS = Object.freeze({
+  /**
+   * Per-group recall must be at least this. Calibrated against the
+   * post-fix engine: every group hits 100% except Arabic at 83.3%
+   * (one cross-script transliteration miss — `علي` → `ly` instead
+   * of `ali`, a separate gap in `transliterateArabic` that does
+   * not stem from bias). Floor set with 3pp margin.
+   */
+  minRecall: 0.8,
+  /**
+   * Per-group FPR must be at most this. Post-fix every group is at
+   * 0% FPR; the 10pp ceiling is the regression bound that catches
+   * any future change re-introducing the over-flagging pattern.
+   */
+  maxFalsePositiveRate: 0.1,
+  /**
+   * max-min recall delta across groups. Equal-opportunity gap.
+   * Currently 16.7pp (driven entirely by the Arabic transliteration
+   * miss above). Bound at 20pp.
+   */
+  maxRecallParityGap: 0.2,
+  /**
+   * max-min FPR delta across groups. Predictive-equality gap.
+   * Currently 0pp. Bound at 10pp.
+   */
+  maxFprParityGap: 0.1,
+});
+
+/** Counts as "flagged" if classifyMatch returns potential or confirmed. */
+function isFlagged(c: MatchClassification): boolean {
+  return c === 'potential' || c === 'confirmed';
+}
+
+/**
+ * Run the bias fixture against the live name matcher and return
+ * per-group + overall metrics. Pure function — deterministic given the
+ * fixture and the matcher.
+ */
+export function assessNameMatchingBias(
+  fixture: readonly BiasFixtureGroup[] = BIAS_FIXTURE
+): BiasAssessmentReport {
+  const groups: GroupBiasMetrics[] = fixture.map((g) => {
+    const missedPositives: { label: string; classification: MatchClassification; score: number }[] = [];
+    let positivesFlagged = 0;
+    for (const p of g.positives) {
+      const { classification, breakdown } = classifyMatch(p.a, p.b);
+      if (isFlagged(classification)) {
+        positivesFlagged++;
+      } else {
+        missedPositives.push({ label: p.label, classification, score: breakdown.score });
+      }
+    }
+
+    const spuriousNegatives: { label: string; classification: MatchClassification; score: number }[] = [];
+    let negativesFlagged = 0;
+    for (const n of g.negatives) {
+      const { classification, breakdown } = classifyMatch(n.a, n.b);
+      if (isFlagged(classification)) {
+        negativesFlagged++;
+        spuriousNegatives.push({ label: n.label, classification, score: breakdown.score });
+      }
+    }
+
+    return {
+      group: g.group,
+      positivesTotal: g.positives.length,
+      positivesFlagged,
+      recall: g.positives.length === 0 ? 1 : positivesFlagged / g.positives.length,
+      negativesTotal: g.negatives.length,
+      negativesFlagged,
+      falsePositiveRate: g.negatives.length === 0 ? 0 : negativesFlagged / g.negatives.length,
+      missedPositives,
+      spuriousNegatives,
+    };
+  });
+
+  const recalls = groups.map((g) => g.recall);
+  const fprs = groups.map((g) => g.falsePositiveRate);
+  const recallParityGap = Math.max(...recalls) - Math.min(...recalls);
+  const fprParityGap = Math.max(...fprs) - Math.min(...fprs);
+  const worstRecall = Math.min(...recalls);
+  const worstFalsePositiveRate = Math.max(...fprs);
+
+  const passesParityBounds =
+    worstRecall >= BIAS_PARITY_BOUNDS.minRecall &&
+    worstFalsePositiveRate <= BIAS_PARITY_BOUNDS.maxFalsePositiveRate &&
+    recallParityGap <= BIAS_PARITY_BOUNDS.maxRecallParityGap &&
+    fprParityGap <= BIAS_PARITY_BOUNDS.maxFprParityGap;
+
+  return {
+    ranAt: new Date().toISOString(),
+    groups,
+    recallParityGap,
+    fprParityGap,
+    worstRecall,
+    worstFalsePositiveRate,
+    passesParityBounds,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+
+/** Render a bias report as markdown for the audit pack. */
+export function formatBiasReport(report: BiasAssessmentReport): string {
+  const lines: string[] = [];
+  lines.push('# Name-Matching Bias Assessment');
+  lines.push('');
+  lines.push(`Run at: ${report.ranAt}`);
+  lines.push('');
+  lines.push('Regulatory basis:');
+  lines.push('- EU AI Act Art.10 (data governance, bias mitigation)');
+  lines.push('- NIST AI RMF Measure 2.11 (fairness, harmful bias)');
+  lines.push('- ISO/IEC 42001 A.7.4 (data representativeness)');
+  lines.push('- UAE AI Charter Principle 3 (fairness)');
+  lines.push('');
+  lines.push('## Per-group metrics');
+  lines.push('');
+  lines.push('| Group | Recall | FPR | Pos | Neg |');
+  lines.push('|---|---:|---:|---:|---:|');
+  for (const g of report.groups) {
+    lines.push(
+      `| ${g.group} | ${(g.recall * 100).toFixed(0)}% | ${(g.falsePositiveRate * 100).toFixed(0)}% | ${g.positivesFlagged}/${g.positivesTotal} | ${g.negativesFlagged}/${g.negativesTotal} |`
+    );
+  }
+  lines.push('');
+  lines.push('## Parity');
+  lines.push('');
+  lines.push(`- Recall parity gap (max-min): ${(report.recallParityGap * 100).toFixed(0)} pp`);
+  lines.push(`- FPR parity gap (max-min):    ${(report.fprParityGap * 100).toFixed(0)} pp`);
+  lines.push(`- Worst-group recall:          ${(report.worstRecall * 100).toFixed(0)}%`);
+  lines.push(`- Worst-group FPR:             ${(report.worstFalsePositiveRate * 100).toFixed(0)}%`);
+  lines.push(`- Passes bounds:               ${report.passesParityBounds ? 'YES' : 'NO'}`);
+  lines.push('');
+
+  const anyMisses = report.groups.some((g) => g.missedPositives.length > 0);
+  if (anyMisses) {
+    lines.push('## Missed positives (false negatives)');
+    lines.push('');
+    for (const g of report.groups) {
+      if (g.missedPositives.length === 0) continue;
+      lines.push(`### ${g.group}`);
+      for (const m of g.missedPositives) {
+        lines.push(`- ${m.label} → ${m.classification} (${m.score.toFixed(3)})`);
+      }
+      lines.push('');
+    }
+  }
+
+  const anySpurious = report.groups.some((g) => g.spuriousNegatives.length > 0);
+  if (anySpurious) {
+    lines.push('## Spurious flags (false positives)');
+    lines.push('');
+    for (const g of report.groups) {
+      if (g.spuriousNegatives.length === 0) continue;
+      lines.push(`### ${g.group}`);
+      for (const s of g.spuriousNegatives) {
+        lines.push(`- ${s.label} → ${s.classification} (${s.score.toFixed(3)})`);
+      }
+      lines.push('');
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/tests/aiGovernanceAgent.test.ts
+++ b/tests/aiGovernanceAgent.test.ts
@@ -80,15 +80,22 @@ describe('AI Governance Agent — self-audit', () => {
     expect(result.audit.overallScore).toBeGreaterThan(0);
   });
 
-  it('self-audit surfaces TODO items as remediation', () => {
+  it('self-audit surfaces remaining TODO items as failed assessments', () => {
     const result = runAiGovernanceAgent({
       mode: 'self',
       target: 'compliance-analyzer',
       auditedBy: 'test-runner',
     });
-    // At least one TODO should surface (model cards, bias assessment,
-    // shadow AI scan, or Arabic support are flagged false in selfAudit.ts).
-    expect(result.audit.remediation.length).toBeGreaterThanOrEqual(1);
+    // The bias-assessment TODO has been resolved (see
+    // src/services/nameMatchingBiasAssessment.ts), so it no longer
+    // appears in remediation. The remaining TODOs (model cards,
+    // shadow AI scan, Arabic support) are lower severity than the
+    // critical/high bar that populates `remediation`, but they MUST
+    // still surface as failed assessments somewhere in the report.
+    const failedAssessments = result.audit.frameworks
+      .flatMap((f) => f.assessments)
+      .filter((a) => a.status === 'fail');
+    expect(failedAssessments.length).toBeGreaterThanOrEqual(1);
   });
 
   it('markdown summary renders headings + table', () => {

--- a/tests/nameMatchingBiasAssessment.test.ts
+++ b/tests/nameMatchingBiasAssessment.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the name-matching bias assessment harness.
+ *
+ * These tests are the regression bounds the AI Governance self-audit
+ * cites when reporting `hasBiasAssessment: true`. They are intentionally
+ * coarse — the point is to catch the day someone "optimises" the
+ * matcher and recall on Arabic / Persian / Slavic names silently
+ * collapses, not to benchmark a state-of-the-art transliteration
+ * model.
+ *
+ * Regulatory basis:
+ *   - EU AI Act Art.10
+ *   - NIST AI RMF Measure 2.11
+ *   - ISO/IEC 42001 A.7.4
+ *   - UAE AI Charter Principle 3
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  assessNameMatchingBias,
+  formatBiasReport,
+  BIAS_FIXTURE,
+  BIAS_PARITY_BOUNDS,
+} from '@/services/nameMatchingBiasAssessment';
+
+describe('name-matching bias assessment — fixture', () => {
+  it('covers every declared origin group', () => {
+    const groups = BIAS_FIXTURE.map((g) => g.group);
+    expect(groups).toContain('anglo');
+    expect(groups).toContain('arabic');
+    expect(groups).toContain('persian');
+    expect(groups).toContain('slavic');
+    expect(groups).toContain('south_asian');
+    expect(groups).toContain('chinese');
+  });
+
+  it('every group has at least 3 positive and 3 negative pairs', () => {
+    for (const g of BIAS_FIXTURE) {
+      expect(g.positives.length).toBeGreaterThanOrEqual(3);
+      expect(g.negatives.length).toBeGreaterThanOrEqual(3);
+    }
+  });
+});
+
+describe('name-matching bias assessment — assessor', () => {
+  const report = assessNameMatchingBias();
+
+  it('produces a metrics row for every group', () => {
+    expect(report.groups.length).toBe(BIAS_FIXTURE.length);
+    for (const g of report.groups) {
+      expect(g.positivesTotal).toBeGreaterThan(0);
+      expect(g.negativesTotal).toBeGreaterThan(0);
+      expect(g.recall).toBeGreaterThanOrEqual(0);
+      expect(g.recall).toBeLessThanOrEqual(1);
+      expect(g.falsePositiveRate).toBeGreaterThanOrEqual(0);
+      expect(g.falsePositiveRate).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('worst-group recall meets the documented floor', () => {
+    expect(report.worstRecall).toBeGreaterThanOrEqual(BIAS_PARITY_BOUNDS.minRecall);
+  });
+
+  it('worst-group FPR stays under the documented ceiling', () => {
+    expect(report.worstFalsePositiveRate).toBeLessThanOrEqual(
+      BIAS_PARITY_BOUNDS.maxFalsePositiveRate
+    );
+  });
+
+  it('recall parity gap stays inside bounds', () => {
+    expect(report.recallParityGap).toBeLessThanOrEqual(BIAS_PARITY_BOUNDS.maxRecallParityGap);
+  });
+
+  it('FPR parity gap stays inside bounds', () => {
+    expect(report.fprParityGap).toBeLessThanOrEqual(BIAS_PARITY_BOUNDS.maxFprParityGap);
+  });
+
+  it('reports a single overall pass flag consistent with the bounds', () => {
+    const expected =
+      report.worstRecall >= BIAS_PARITY_BOUNDS.minRecall &&
+      report.worstFalsePositiveRate <= BIAS_PARITY_BOUNDS.maxFalsePositiveRate &&
+      report.recallParityGap <= BIAS_PARITY_BOUNDS.maxRecallParityGap &&
+      report.fprParityGap <= BIAS_PARITY_BOUNDS.maxFprParityGap;
+    expect(report.passesParityBounds).toBe(expected);
+  });
+});
+
+describe('name-matching bias assessment — markdown report', () => {
+  it('renders the headings, parity block, and a row per group', () => {
+    const report = assessNameMatchingBias();
+    const md = formatBiasReport(report);
+    expect(md).toContain('# Name-Matching Bias Assessment');
+    expect(md).toContain('## Per-group metrics');
+    expect(md).toContain('## Parity');
+    expect(md).toContain('Recall parity gap');
+    expect(md).toContain('FPR parity gap');
+    for (const g of BIAS_FIXTURE) {
+      expect(md).toContain(g.group);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The name matcher used arithmetic-mean token-set similarity, which systematically over-flagged demographics whose name distributions naturally share common tokens. The bias was severe and demographic-specific:

| Group | Pre-fix FPR | Post-fix FPR |
|---|---:|---:|
| anglo | 25% | **0%** |
| arabic | 75% | **0%** |
| persian | 67% | **0%** |
| slavic | 33% | **0%** |
| south_asian | 100% | **0%** |
| chinese | 100% | **0%** |

Recall stays at 100% for every group except Arabic at 83% (one cross-script transliteration miss in `transliterateArabic`, unrelated to the bias).

## Root cause

Pattern: any short multi-token name where ONE token matched exactly (e.g. `Wang Wei` vs `Wang Lei`, `Imran Khan` vs `Imran Ahmed`, `Ahmed Ali` vs `Ahmed Hassan`) scored above the 0.7 "potential" threshold because the arithmetic mean of best-matches couldn't distinguish shared-name patterns from real matches.

## Fix

`src/services/nameMatching.ts`:
- New `tokenSetBreakdown()` helper exposes mean / min / max of per-token best-matches plus structural metadata.
- `matchScore()` applies a discriminative penalty when either:
  1. any token best-match is below 0.6 (heavy distinct token), or
  2. one token matches perfectly (max ≥ 0.999) and the worst pair is below 0.8 (shared-single-token pattern).
  Penalty replaces the token signal with `min²`.
- Cross-script matches preserve their behaviour because they have no exact-token match (`max < 1.0`) and `minBest` stays above 0.6, so neither trigger fires.

## Regression harness

- `src/services/nameMatchingBiasAssessment.ts` — fixture (6 groups × ~4 positives + ~3 negatives), assessor, parity bounds, markdown report formatter.
- `tests/nameMatchingBiasAssessment.test.ts` — 9 tests asserting per-group recall floors and FPR ceilings, plus parity-gap bounds.

## AI Governance self-audit

- `src/agents/aiGovernance/selfAudit.ts`: `hasBiasAssessment` flipped from `false` → `true` with citation.
- `tests/aiGovernanceAgent.test.ts`: TODO-surfacing test rewritten — `hasBiasAssessment` was the only critical/high failure populating `remediation`, so the assertion now checks that remaining lower-severity TODOs (model cards, shadow AI, Arabic UI) still appear as failed assessments.

## Regulatory citations

- EU AI Act Art.10 (data governance, bias mitigation)
- NIST AI RMF Measure 2.11 (fairness, harmful bias)
- ISO/IEC 42001 A.7.4 (data representativeness)
- UAE AI Charter Principle 3 (fairness, non-discrimination)

## Test plan

- [x] `vitest run tests/nameMatching.test.ts` — 40 tests pass (no regressions in existing matcher behaviour)
- [x] `vitest run tests/nameMatchingBiasAssessment.test.ts` — 9 tests pass
- [x] `vitest run tests/aiGovernanceAgent.test.ts` — 15 tests pass (updated assertion)
- [x] `tsc --noEmit` — clean on all touched files
