### PR TITLE
Fix CI: drop unused simulate import + prettier format drift

### DIFF
--- a/src/services/hawkeyeReportGenerator.ts
+++ b/src/services/hawkeyeReportGenerator.ts
@@ -342,11 +342,7 @@ function buildMarkdownReport(input: HawkeyeReportInput, reportId: string, now: s
   if (ext.goldOrigin) {
     // OriginTraceReport exposes refuseCount/eddCount/cleanCount + results[].
     const originRisk =
-      ext.goldOrigin.refuseCount > 0
-        ? 'REFUSE'
-        : ext.goldOrigin.eddCount > 0
-          ? 'EDD'
-          : 'CLEAN';
+      ext.goldOrigin.refuseCount > 0 ? 'REFUSE' : ext.goldOrigin.eddCount > 0 ? 'EDD' : 'CLEAN';
     lines.push(
       `| **Gold Origin Risk** | ${originRisk} | ${ext.goldOrigin.results.length} shipment(s) | LBMA RGG v9; OECD DDG 2016 |`
     );
@@ -466,15 +462,11 @@ function buildMarkdownReport(input: HawkeyeReportInput, reportId: string, now: s
       const sScore = ext.esgScore.pillars?.S?.score;
       const gScore = ext.esgScore.pillars?.G?.score;
       if (eScore !== undefined)
-        lines.push(
-          `| Environmental (E) | — | ${eScore.toFixed(0)} / 100 | GRI 2021 Standards |`
-        );
+        lines.push(`| Environmental (E) | — | ${eScore.toFixed(0)} / 100 | GRI 2021 Standards |`);
       if (sScore !== undefined)
         lines.push(`| Social (S) | — | ${sScore.toFixed(0)} / 100 | ILO Conventions 29, 105 |`);
       if (gScore !== undefined)
-        lines.push(
-          `| Governance (G) | — | ${gScore.toFixed(0)} / 100 | OECD CG Principles 2023 |`
-        );
+        lines.push(`| Governance (G) | — | ${gScore.toFixed(0)} / 100 | OECD CG Principles 2023 |`);
     }
     if (ext.carbonFootprint) {
       // netZeroAligned is derived from netZeroGap_tCO2e; per-oz intensity

--- a/src/services/weaponizedBrain.ts
+++ b/src/services/weaponizedBrain.ts
@@ -352,7 +352,6 @@ import {
 } from './multiModelScreening';
 import {
   createCausalGraph,
-  simulate,
   runCounterfactual,
   type CausalNode,
   type Assignment,
@@ -2121,9 +2120,7 @@ export async function runWeaponizedBrain(
     // mega.auditNarrative on MegaBrainResponse.
     Promise.resolve(
       runSafely('promptInjection', () =>
-        detectPromptInjection(
-          `${req.mega.entity?.name ?? ''} ${(mega.notes ?? []).join(' ')}`
-        )
+        detectPromptInjection(`${req.mega.entity?.name ?? ''} ${(mega.notes ?? []).join(' ')}`)
       )
     ),
     // #60 Deepfake document detector — conditional


### PR DESCRIPTION
## Summary

- Remove unused `simulate` import from `src/services/weaponizedBrain.ts` — was blocking `npm run lint:ts` with `@typescript-eslint/no-unused-vars`.
- Apply `prettier --write` to `src/services/hawkeyeReportGenerator.ts` and `weaponizedBrain.ts` to clear drift (whitespace only, no logic changes).

Both errors were pre-existing on `main` (from commit `eb80340` "Fix 186 tsc errors") and were not introduced by #103. They surfaced on `lint-and-test (20)` after #103 merged.

## Test plan

- [x] `npm run lint:ts` — clean
- [x] `npm run format:check` — all files pass
- [x] `npx vitest run` — 108 files / 1703 tests pass
- [ ] CI `lint-and-test (18)` and `lint-and-test (20)` green on this branch

https://claude.ai/code/session_01DExkcQ1NxGt9GxRcQ2tr3i