### PR TITLE
Add Asana Kanban board, STR lifecycle automation, and health telemetry

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import STRDraftPage from './ui/reports/STRDraftPage';
 import ReportsHub from './ui/reports/ReportsHub';
 import KPIDashboard from './ui/dashboard/KPIDashboard';
 import MetalsTradingPage from './ui/metals/MetalsTradingPage';
+import AsanaKanbanPage from './ui/asana/AsanaKanbanPage';
 import { LocalAppStore } from './services/indexedDbStore';
 import { calculateKPI } from './domain/kpi';
 import { generateAlerts } from './services/alertEngine';
@@ -28,7 +29,8 @@ type Page =
   | 'templates'
   | 'history'
   | 'backup'
-  | 'metals-trading';
+  | 'metals-trading'
+  | 'asana-kanban';
 
 // ─── Sidebar Navigation ──────────────────────────────────────────────────────
 
@@ -36,6 +38,7 @@ const NAV_ITEMS: { id: Page; label: string; icon: string }[] = [
   { id: 'dashboard', label: 'Dashboard', icon: '◉' },
   { id: 'reports', label: 'Reports Hub', icon: '▣' },
   { id: 'cases', label: 'Cases', icon: '◆' },
+  { id: 'asana-kanban', label: 'Asana Kanban', icon: '⊞' },
   { id: 'str', label: 'STR / SAR', icon: '▲' },
   { id: 'customers', label: 'Customers', icon: '●' },
   { id: 'screening', label: 'Screening', icon: '◈' },
@@ -1378,6 +1381,7 @@ export default function App() {
     history: 'Audit History',
     backup: 'Data & Backup',
     'metals-trading': 'Metals Trading Platform',
+    'asana-kanban': 'Asana Kanban Board',
   };
 
   if (loading) {
@@ -1446,6 +1450,7 @@ export default function App() {
         {page === 'dashboard' && kpiData && <KPIDashboard data={kpiData} />}
         {page === 'reports' && <ReportsHub />}
         {page === 'cases' && <CasesPage />}
+        {page === 'asana-kanban' && <AsanaKanbanPage />}
         {page === 'str' && <STRDraftPage />}
         {page === 'customers' && <CustomersPage />}
         {page === 'screening' && <ScreeningPage />}

--- a/src/services/asanaHealthTelemetry.ts
+++ b/src/services/asanaHealthTelemetry.ts
@@ -1,0 +1,215 @@
+/**
+ * Asana Health Telemetry — single-glance sync status for the MLRO.
+ *
+ * The dashboard needs one tile that answers: is Asana up? how many
+ * retries are pending? are we getting rate limited? when did the last
+ * call fail and why? This module produces that snapshot without
+ * touching the Asana API — it reads the local retry queue, task-link
+ * store, and the last-error tombstone we persist on every failed call.
+ *
+ * Pure-ish: reads localStorage (browser) and in-memory cache (tests).
+ * No network traffic. Lives outside asanaClient.ts so we can unit test
+ * the reducer without mocking fetch.
+ *
+ * Regulatory basis:
+ *   - Cabinet Res 134/2025 Art.19 (internal review — operational telemetry)
+ *   - FDL No.10/2025 Art.24 (10yr retention — track sync failures)
+ */
+
+import { getQueueStatus } from './asanaQueue';
+import { getLinkStats } from './asanaTaskLinks';
+import { isAsanaConfigured } from './asanaClient';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type AsanaHealthStatus =
+  | 'unconfigured'
+  | 'healthy'
+  | 'degraded'
+  | 'critical';
+
+export interface AsanaHealthSnapshot {
+  status: AsanaHealthStatus;
+  configured: boolean;
+  /** Pending retry queue depth (retryable). */
+  retryQueuePending: number;
+  /** Permanently failed retry queue depth. */
+  retryQueueFailed: number;
+  /** Total tasks linked from local → Asana. */
+  linksTotal: number;
+  /** Tasks marked complete in Asana (two-way sync observed). */
+  linksCompleted: number;
+  /** Active (not yet completed) task links. */
+  linksActive: number;
+  /** Most recent Asana error observed, if any. */
+  lastError?: string;
+  /** ISO timestamp of the last error. */
+  lastErrorAtIso?: string;
+  /** Most recent 429 (rate limit) hit, if any. */
+  lastRateLimitAtIso?: string;
+  /** Human-readable summary for the dashboard tile. */
+  summary: string;
+}
+
+// ---------------------------------------------------------------------------
+// Tombstone storage
+// ---------------------------------------------------------------------------
+
+const LAST_ERROR_KEY = 'asana_health_last_error';
+const LAST_RATE_LIMIT_KEY = 'asana_health_last_rate_limit';
+
+interface LastErrorRecord {
+  error: string;
+  atIso: string;
+}
+
+function readLastError(): LastErrorRecord | undefined {
+  try {
+    if (typeof localStorage === 'undefined') return undefined;
+    const raw = localStorage.getItem(LAST_ERROR_KEY);
+    return raw ? (JSON.parse(raw) as LastErrorRecord) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readLastRateLimit(): string | undefined {
+  try {
+    if (typeof localStorage === 'undefined') return undefined;
+    return localStorage.getItem(LAST_RATE_LIMIT_KEY) ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Called by asanaClient on any failure so the health tile has something
+ * to surface. Browser-only — node tests can call it directly for
+ * reducer coverage.
+ */
+export function recordAsanaFailure(error: string): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    const record: LastErrorRecord = {
+      error: error.slice(0, 500),
+      atIso: new Date().toISOString(),
+    };
+    localStorage.setItem(LAST_ERROR_KEY, JSON.stringify(record));
+    if (/\b429\b/.test(error)) {
+      localStorage.setItem(LAST_RATE_LIMIT_KEY, record.atIso);
+    }
+  } catch {
+    /* storage quota — ignore, telemetry is degradation-tolerant */
+  }
+}
+
+/** Clear the tombstones — called after a successful health refresh. */
+export function clearAsanaFailureTombstones(): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.removeItem(LAST_ERROR_KEY);
+    localStorage.removeItem(LAST_RATE_LIMIT_KEY);
+  } catch {
+    /* empty */
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure reducer — this is what the tests target.
+// ---------------------------------------------------------------------------
+
+export interface AsanaHealthInputs {
+  configured: boolean;
+  retryQueue: { pending: number; failed: number };
+  linkStats: { total: number; completed: number; active: number };
+  lastError?: LastErrorRecord;
+  lastRateLimitAtIso?: string;
+  /** Optional ISO "now" for deterministic tests. */
+  nowIso?: string;
+}
+
+export function reduceAsanaHealth(inputs: AsanaHealthInputs): AsanaHealthSnapshot {
+  const now = new Date(inputs.nowIso ?? new Date().toISOString()).getTime();
+
+  if (!inputs.configured) {
+    return {
+      status: 'unconfigured',
+      configured: false,
+      retryQueuePending: 0,
+      retryQueueFailed: 0,
+      linksTotal: inputs.linkStats.total,
+      linksCompleted: inputs.linkStats.completed,
+      linksActive: inputs.linkStats.active,
+      summary: 'Asana not configured — set ASANA_TOKEN or proxy URL in Settings.',
+    };
+  }
+
+  const { pending, failed } = inputs.retryQueue;
+  const recentError =
+    inputs.lastError &&
+    now - new Date(inputs.lastError.atIso).getTime() < 15 * 60_000
+      ? inputs.lastError
+      : undefined;
+  const recentRateLimit =
+    inputs.lastRateLimitAtIso &&
+    now - new Date(inputs.lastRateLimitAtIso).getTime() < 5 * 60_000
+      ? inputs.lastRateLimitAtIso
+      : undefined;
+
+  // Status gate:
+  //  - critical: anything permanently failed OR a recent error in the
+  //              last 15 minutes that the operator should see.
+  //  - degraded: retry queue non-empty OR recent rate limit in the
+  //              last 5 minutes.
+  //  - healthy:  everything else.
+  let status: AsanaHealthStatus;
+  if (failed > 0 || recentError) {
+    status = 'critical';
+  } else if (pending > 0 || recentRateLimit) {
+    status = 'degraded';
+  } else {
+    status = 'healthy';
+  }
+
+  const summary =
+    status === 'healthy'
+      ? `Asana healthy — ${inputs.linkStats.total} linked, ${inputs.linkStats.active} active`
+      : status === 'degraded'
+        ? `Asana degraded — ${pending} retry pending${recentRateLimit ? ', recent 429' : ''}`
+        : status === 'critical'
+          ? `Asana critical — ${failed} failed, ${recentError ? 'recent error' : 'check logs'}`
+          : 'Asana unconfigured';
+
+  return {
+    status,
+    configured: true,
+    retryQueuePending: pending,
+    retryQueueFailed: failed,
+    linksTotal: inputs.linkStats.total,
+    linksCompleted: inputs.linkStats.completed,
+    linksActive: inputs.linkStats.active,
+    lastError: recentError?.error,
+    lastErrorAtIso: recentError?.atIso,
+    lastRateLimitAtIso: recentRateLimit,
+    summary,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// I/O wrapper used by the dashboard tile
+// ---------------------------------------------------------------------------
+
+export function getAsanaHealthSnapshot(): AsanaHealthSnapshot {
+  return reduceAsanaHealth({
+    configured: isAsanaConfigured(),
+    retryQueue: getQueueStatus(),
+    linkStats: (() => {
+      const s = getLinkStats();
+      return { total: s.total, completed: s.completed, active: s.active };
+    })(),
+    lastError: readLastError(),
+    lastRateLimitAtIso: readLastRateLimit(),
+  });
+}

--- a/src/services/asanaKanbanView.ts
+++ b/src/services/asanaKanbanView.ts
@@ -1,0 +1,274 @@
+/**
+ * Asana Kanban View — fetch tasks and group them into columns.
+ *
+ * The dashboard SPA needs to render compliance tasks as a Kanban
+ * (To Do / Doing / Review / Done / Blocked) instead of linking out to
+ * Asana. Asana natively exposes "sections" per project, which is the
+ * canonical column source. This module fetches tasks with section
+ * membership and groups them into the five canonical columns.
+ *
+ * If a task is not a member of a section (or the section name doesn't
+ * match any known column), we fall back to:
+ *   1. Name prefix: `[TODO]`, `[DOING]`, `[REVIEW]`, `[BLOCKED]`
+ *   2. `completed` flag → Done
+ *   3. Else → To Do
+ *
+ * Pure grouping logic + a thin fetch wrapper. Tests exercise the
+ * reducer; the fetch wrapper is too thin to warrant mocking.
+ *
+ * Regulatory basis:
+ *   - FDL No.10/2025 Art.24 (10yr retention — Kanban is just a view)
+ *   - Cabinet Res 134/2025 Art.19 (internal review — visible work queue)
+ */
+
+import { asanaRequestWithRetry } from './asanaClient';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export const KANBAN_COLUMNS = [
+  'todo',
+  'doing',
+  'review',
+  'done',
+  'blocked',
+] as const;
+
+export type KanbanColumn = (typeof KANBAN_COLUMNS)[number];
+
+export const KANBAN_COLUMN_LABEL: Record<KanbanColumn, string> = {
+  todo: 'To Do',
+  doing: 'Doing',
+  review: 'Review',
+  done: 'Done',
+  blocked: 'Blocked',
+};
+
+/** Shape we get back from Asana when we request sections. */
+export interface AsanaKanbanTask {
+  gid: string;
+  name: string;
+  completed: boolean;
+  due_on?: string;
+  notes?: string;
+  assignee?: { gid: string; name?: string } | null;
+  memberships?: Array<{
+    project?: { gid: string; name?: string };
+    section?: { gid: string; name?: string };
+  }>;
+  tags?: Array<{ gid: string; name?: string }>;
+}
+
+export interface KanbanCard {
+  gid: string;
+  name: string;
+  column: KanbanColumn;
+  dueOn?: string;
+  assigneeName?: string;
+  tagLabels: string[];
+  breachWarning: boolean;
+  sourceSection?: string;
+}
+
+export interface KanbanBoard {
+  columns: Record<KanbanColumn, KanbanCard[]>;
+  totalCards: number;
+  breachCount: number;
+  projectGid: string;
+  fetchedAtIso: string;
+}
+
+// ---------------------------------------------------------------------------
+// Section → column mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps an Asana section name to a Kanban column. Case-insensitive
+ * substring match — MLROs name sections differently ("To-Do", "In
+ * progress", "QA", "Done ✓") and we want the mapper to be tolerant.
+ */
+export function sectionNameToColumn(name?: string): KanbanColumn | undefined {
+  if (!name) return undefined;
+  const lower = name.toLowerCase();
+  if (lower.includes('block')) return 'blocked';
+  if (lower.includes('done') || lower.includes('complete') || lower.includes('closed')) {
+    return 'done';
+  }
+  if (
+    lower.includes('review') ||
+    lower.includes('qa') ||
+    lower.includes('approv') ||
+    lower.includes('four-eye') ||
+    lower.includes('four eye')
+  ) {
+    return 'review';
+  }
+  if (
+    lower.includes('progress') ||
+    lower.includes('doing') ||
+    lower.includes('in-progress') ||
+    lower.includes('wip') ||
+    lower.includes('working')
+  ) {
+    return 'doing';
+  }
+  if (lower.includes('todo') || lower.includes('to do') || lower.includes('backlog') || lower.includes('queue')) {
+    return 'todo';
+  }
+  return undefined;
+}
+
+/**
+ * Parse a Kanban column out of a task name prefix. Used when the task
+ * is not a member of any section.
+ */
+export function namePrefixToColumn(name: string): KanbanColumn | undefined {
+  const m = /^\[([A-Z0-9_-]+)\]/.exec(name);
+  if (!m) return undefined;
+  const tag = m[1].toLowerCase();
+  if (tag === 'blocked') return 'blocked';
+  if (tag === 'done') return 'done';
+  if (tag === 'review' || tag === 'four-eyes' || tag === 'mlro-review') return 'review';
+  if (tag === 'doing' || tag === 'wip' || tag === 'in-progress') return 'doing';
+  if (tag === 'todo' || tag === 'to-do') return 'todo';
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Pure classifier
+// ---------------------------------------------------------------------------
+
+export interface ClassifierOptions {
+  /** Optional "now" ISO for deterministic breach detection in tests. */
+  nowIso?: string;
+  /** Target project gid we're building the board for. */
+  projectGid: string;
+}
+
+export function classifyTaskToColumn(
+  task: AsanaKanbanTask,
+  projectGid: string
+): { column: KanbanColumn; sourceSection?: string } {
+  // 1. Try the project-scoped section first. Asana tasks can live in
+  //    multiple projects, so we only trust the section from *this*
+  //    project's membership entry.
+  const membership = task.memberships?.find(
+    (m) => m.project?.gid === projectGid && m.section?.name
+  );
+  const fromSection = membership?.section?.name
+    ? sectionNameToColumn(membership.section.name)
+    : undefined;
+  if (fromSection) {
+    return { column: fromSection, sourceSection: membership?.section?.name };
+  }
+
+  // 2. Try the name prefix.
+  const fromPrefix = namePrefixToColumn(task.name);
+  if (fromPrefix) return { column: fromPrefix };
+
+  // 3. Completed → Done.
+  if (task.completed) return { column: 'done' };
+
+  // 4. Default: To Do.
+  return { column: 'todo' };
+}
+
+function isBreach(task: AsanaKanbanTask, nowIso: string): boolean {
+  if (task.completed) return false;
+  if (!task.due_on) return false;
+  // Asana returns `due_on` as YYYY-MM-DD; parse as UTC midnight.
+  const due = Date.parse(task.due_on + 'T23:59:59Z');
+  if (!Number.isFinite(due)) return false;
+  return Date.parse(nowIso) > due;
+}
+
+export function buildKanbanBoard(
+  tasks: readonly AsanaKanbanTask[],
+  options: ClassifierOptions
+): KanbanBoard {
+  const nowIso = options.nowIso ?? new Date().toISOString();
+  const columns: Record<KanbanColumn, KanbanCard[]> = {
+    todo: [],
+    doing: [],
+    review: [],
+    done: [],
+    blocked: [],
+  };
+  let breachCount = 0;
+
+  for (const task of tasks) {
+    const { column, sourceSection } = classifyTaskToColumn(task, options.projectGid);
+    const breach = isBreach(task, nowIso);
+    if (breach) breachCount++;
+    const card: KanbanCard = {
+      gid: task.gid,
+      name: task.name,
+      column,
+      dueOn: task.due_on,
+      assigneeName: task.assignee?.name,
+      tagLabels: (task.tags ?? []).map((t) => t.name ?? '').filter(Boolean),
+      breachWarning: breach,
+      sourceSection,
+    };
+    columns[column].push(card);
+  }
+
+  // Sort every column: breach first, then by due date ascending, then
+  // alphabetical. Breach-first gives the MLRO a single glance at what
+  // needs attention.
+  for (const col of KANBAN_COLUMNS) {
+    columns[col].sort((a, b) => {
+      if (a.breachWarning !== b.breachWarning) {
+        return a.breachWarning ? -1 : 1;
+      }
+      const ad = a.dueOn ? Date.parse(a.dueOn) : Number.POSITIVE_INFINITY;
+      const bd = b.dueOn ? Date.parse(b.dueOn) : Number.POSITIVE_INFINITY;
+      if (ad !== bd) return ad - bd;
+      return a.name.localeCompare(b.name);
+    });
+  }
+
+  return {
+    columns,
+    totalCards: tasks.length,
+    breachCount,
+    projectGid: options.projectGid,
+    fetchedAtIso: nowIso,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fetch wrapper
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch tasks for a project with the fields the Kanban view needs.
+ * Asana rate-limited, retry-enabled via asanaRequestWithRetry.
+ */
+export async function fetchKanbanTasks(
+  projectGid: string
+): Promise<{ ok: boolean; tasks?: AsanaKanbanTask[]; error?: string }> {
+  const fields =
+    'name,gid,completed,due_on,notes,assignee.name,assignee.gid,memberships.section.name,memberships.section.gid,memberships.project.gid,memberships.project.name,tags.name,tags.gid';
+  const result = await asanaRequestWithRetry<AsanaKanbanTask[]>(
+    `/projects/${encodeURIComponent(projectGid)}/tasks?opt_fields=${fields}&limit=100`
+  );
+  if (result.ok) {
+    return { ok: true, tasks: result.data ?? [] };
+  }
+  return { ok: false, error: result.error };
+}
+
+/**
+ * One-shot: fetch + build board.
+ */
+export async function loadKanbanBoard(
+  projectGid: string
+): Promise<{ ok: boolean; board?: KanbanBoard; error?: string }> {
+  const fetched = await fetchKanbanTasks(projectGid);
+  if (!fetched.ok || !fetched.tasks) {
+    return { ok: false, error: fetched.error };
+  }
+  return { ok: true, board: buildKanbanBoard(fetched.tasks, { projectGid }) };
+}

--- a/src/services/asanaSlaAutoEscalation.ts
+++ b/src/services/asanaSlaAutoEscalation.ts
@@ -1,0 +1,259 @@
+/**
+ * Asana SLA Breach Auto-Escalation.
+ *
+ * asanaSlaEnforcer.ts computes a deadline and reports whether a task
+ * is on-time / in the reminder window / breached. It does NOT take
+ * action. This module turns a breach into an escalation: it selects
+ * the next tier (CO → MLRO → Board), builds an escalation task
+ * payload, and optionally dispatches it as a follow-up Asana task
+ * linked to the breached parent.
+ *
+ * Pure tier selector + escalation payload builder + thin dispatcher.
+ *
+ * Regulatory basis:
+ *   - Cabinet Res 74/2020 Art.4-7 (24h EOCN freeze — hard deadline)
+ *   - FDL No.10/2025 Art.20-21 (CO + MLRO duty of care)
+ *   - Cabinet Res 134/2025 Art.19 (internal review)
+ *   - MoE Circular 08/AML/2021 (DPMS deadlines)
+ */
+
+import {
+  asanaRequestWithRetry,
+  isAsanaConfigured,
+  type AsanaTaskPayload,
+} from './asanaClient';
+import {
+  type SlaPlan,
+  type RegulatoryDeadlineKind,
+  evaluateSlaStatus,
+} from './asanaSlaEnforcer';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type EscalationTier = 'CO' | 'MLRO' | 'BOARD' | 'REGULATOR';
+
+export interface EscalationContext {
+  /** Asana task that breached the SLA. */
+  breachedTaskGid: string;
+  /** Short human-readable task title, used in the escalation notes. */
+  breachedTaskTitle: string;
+  /** Asana project to dispatch the escalation task into. */
+  projectGid: string;
+  /** Minutes past the deadline (positive integer). */
+  minutesOverdue: number;
+  /** Which SLA was breached. */
+  slaPlan: SlaPlan;
+  /** Optional linked case or filing id for audit trail. */
+  linkedLocalId?: string;
+  /** The previous escalation tier, if any. Used to promote by one step. */
+  previousTier?: EscalationTier;
+}
+
+export interface EscalationDecision {
+  tier: EscalationTier;
+  /** How many hours the new escalation owner has to respond. */
+  dueHours: number;
+  /** Whether this breach also requires a breakglass notification. */
+  breakglass: boolean;
+  /** Rationale for the tier selection — logged into task notes. */
+  rationale: string;
+}
+
+// ---------------------------------------------------------------------------
+// Pure tier selector
+// ---------------------------------------------------------------------------
+
+/**
+ * Choose the next escalation tier based on the breached SLA kind,
+ * overdue magnitude, and previous tier. The goal: promote by one step
+ * but skip straight to BOARD for critical 24h freezes that are already
+ * more than 60 minutes overdue, and skip to REGULATOR only when the
+ * breach is >24h past due.
+ */
+export function chooseEscalationTier(ctx: EscalationContext): EscalationDecision {
+  const kind: RegulatoryDeadlineKind = ctx.slaPlan.kind;
+  const hoursOverdue = ctx.minutesOverdue / 60;
+
+  // EOCN freeze is the hardest deadline in the regime — any breach is
+  // already a regulatory incident. Always escalate at least to MLRO.
+  if (kind === 'eocn_freeze_24h') {
+    if (hoursOverdue >= 24) {
+      return {
+        tier: 'REGULATOR',
+        dueHours: 2,
+        breakglass: true,
+        rationale:
+          'EOCN freeze is >24h overdue — Cabinet Res 74/2020 Art.4 breach. Notify regulator and Board simultaneously.',
+      };
+    }
+    if (hoursOverdue >= 1 || ctx.previousTier === 'MLRO') {
+      return {
+        tier: 'BOARD',
+        dueHours: 4,
+        breakglass: true,
+        rationale:
+          'EOCN freeze breached — Cabinet Res 74/2020 Art.4. Board notification required.',
+      };
+    }
+    return {
+      tier: 'MLRO',
+      dueHours: 1,
+      breakglass: true,
+      rationale:
+        'EOCN freeze breach window — escalate to MLRO for immediate intervention.',
+    };
+  }
+
+  // STR / CNMR are critical filings but not clock-hours.
+  if (kind === 'str_without_delay' || kind === 'cnmr_5_business_days') {
+    if (ctx.previousTier === 'MLRO' || hoursOverdue >= 48) {
+      return {
+        tier: 'BOARD',
+        dueHours: 8,
+        breakglass: true,
+        rationale: `${kind} is ${Math.round(hoursOverdue)}h overdue — Board escalation (FDL Art.26-27 / Cabinet Res 74/2020 Art.6).`,
+      };
+    }
+    return {
+      tier: 'MLRO',
+      dueHours: 4,
+      breakglass: false,
+      rationale: `${kind} breached — MLRO must file without further delay.`,
+    };
+  }
+
+  // Everything else: promote by one step, default to MLRO.
+  const promotionMap: Record<EscalationTier, EscalationTier> = {
+    CO: 'MLRO',
+    MLRO: 'BOARD',
+    BOARD: 'REGULATOR',
+    REGULATOR: 'REGULATOR',
+  };
+  const tier: EscalationTier = ctx.previousTier
+    ? promotionMap[ctx.previousTier]
+    : 'MLRO';
+
+  return {
+    tier,
+    dueHours: tier === 'CO' ? 24 : tier === 'MLRO' ? 12 : 8,
+    breakglass: tier === 'BOARD' || tier === 'REGULATOR',
+    rationale: `${kind} breach — escalating from ${ctx.previousTier ?? 'CO'} to ${tier}.`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Escalation payload builder
+// ---------------------------------------------------------------------------
+
+export function buildEscalationTaskPayload(
+  ctx: EscalationContext,
+  decision: EscalationDecision
+): AsanaTaskPayload {
+  const dueOn = new Date(Date.now() + decision.dueHours * 3600_000)
+    .toISOString()
+    .slice(0, 10);
+
+  const notes = [
+    `ESCALATION — ${decision.tier} action required.`,
+    '',
+    `Breached task: ${ctx.breachedTaskTitle}`,
+    `Parent GID: ${ctx.breachedTaskGid}`,
+    `Overdue by: ${ctx.minutesOverdue} minutes (${(ctx.minutesOverdue / 60).toFixed(1)}h)`,
+    `Due in: ${decision.dueHours}h`,
+    `SLA: ${ctx.slaPlan.regulatory}`,
+    '',
+    'Rationale:',
+    decision.rationale,
+    '',
+    decision.breakglass
+      ? '*** BREAKGLASS ACTIVATED — notify on-call MLRO immediately ***'
+      : 'Normal escalation — no breakglass trigger.',
+    '',
+    'FDL Art.29 — no tipping off. Do not contact the subject.',
+  ].join('\n');
+
+  const name = `[ESCALATE-${decision.tier}] ${ctx.breachedTaskTitle}`.slice(0, 250);
+
+  return {
+    name,
+    notes,
+    projects: [ctx.projectGid],
+    due_on: dueOn,
+    tags: ['sla-breach', `escalation:${decision.tier.toLowerCase()}`],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Dispatcher
+// ---------------------------------------------------------------------------
+
+export interface EscalationDispatchResult {
+  ok: boolean;
+  decision: EscalationDecision;
+  escalationGid?: string;
+  error?: string;
+  /** True when the SLA is not actually breached and no task was created. */
+  skipped?: boolean;
+}
+
+/**
+ * Evaluate a task's SLA and, if breached, create an escalation task.
+ * Idempotency is the caller's responsibility — pass a unique
+ * `breachedTaskGid` and the downstream Asana queue will de-dupe.
+ */
+export async function dispatchSlaBreachEscalation(
+  ctx: EscalationContext
+): Promise<EscalationDispatchResult> {
+  const status = evaluateSlaStatus(ctx.slaPlan);
+  if (status.status !== 'breached') {
+    return {
+      ok: true,
+      skipped: true,
+      decision: {
+        tier: 'CO',
+        dueHours: 24,
+        breakglass: false,
+        rationale: `SLA not breached (${status.status}); no escalation.`,
+      },
+    };
+  }
+
+  const decision = chooseEscalationTier({
+    ...ctx,
+    minutesOverdue: Math.max(1, -status.minutesUntilDue),
+  });
+
+  if (!isAsanaConfigured()) {
+    return {
+      ok: false,
+      decision,
+      error: 'Asana not configured — cannot dispatch escalation task',
+    };
+  }
+
+  const payload = buildEscalationTaskPayload(
+    { ...ctx, minutesOverdue: Math.max(1, -status.minutesUntilDue) },
+    decision
+  );
+
+  const result = await asanaRequestWithRetry<{ gid: string }>('/tasks', {
+    method: 'POST',
+    body: JSON.stringify({ data: payload }),
+  });
+
+  if (result.ok && result.data?.gid) {
+    return {
+      ok: true,
+      decision,
+      escalationGid: result.data.gid,
+    };
+  }
+
+  return {
+    ok: false,
+    decision,
+    error: result.error ?? 'Escalation dispatch failed with no error message',
+  };
+}

--- a/src/services/cddAsanaCustomFieldPush.ts
+++ b/src/services/cddAsanaCustomFieldPush.ts
@@ -1,0 +1,219 @@
+/**
+ * CDD → Asana Custom Field Push.
+ *
+ * When a CDD record is saved, customer name / risk tier / jurisdiction
+ * / UBO count / PEP flag / sanctions flag must land on the customer's
+ * compliance task in Asana as native custom fields. The field GIDs
+ * already exist in the workspace (wired via env vars — see
+ * asanaCustomFields.ts) but nothing has been pushing CDD snapshots to
+ * them. This module bridges that gap.
+ *
+ * Pure builder (buildCddCustomFieldPayload) plus dispatcher
+ * (pushCddCustomFields). The builder takes a CustomerProfile and
+ * returns a `custom_fields` map ready to hand to updateAsanaTask.
+ *
+ * Regulatory basis:
+ *   - FDL No.10/2025 Art.12-14 (CDD)
+ *   - Cabinet Res 134/2025 Art.7-10 (CDD tiers — SDD/CDD/EDD)
+ *   - Cabinet Res 134/2025 Art.14 (PEP / EDD)
+ *   - Cabinet Decision 109/2023 (UBO ≥25% re-verification)
+ *   - FDL No.10/2025 Art.24 (10yr record retention — rollup visibility)
+ */
+
+import type { CustomerProfile } from '../domain/customers';
+import { isAsanaConfigured, asanaRequestWithRetry } from './asanaClient';
+import {
+  buildComplianceCustomFields,
+  type RiskLevel,
+  type ComplianceCustomFieldInput,
+} from './asanaCustomFields';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CddCustomFieldInput {
+  customer: CustomerProfile;
+  /** Target Asana task GID to update (usually the customer's case task). */
+  taskGid: string;
+  /** Optional explicit CDD level override — defaults to derivation. */
+  cddLevelOverride?: 'SDD' | 'CDD' | 'EDD';
+  /** Optional regulatory citation override. */
+  regulationCitation?: string;
+}
+
+export interface CddCustomFieldPushResult {
+  ok: boolean;
+  error?: string;
+  /** The payload that was (or would have been) sent. */
+  payload: Record<string, string | number>;
+  /** The derived CDD level for logging. */
+  derivedCddLevel: 'SDD' | 'CDD' | 'EDD';
+}
+
+// ---------------------------------------------------------------------------
+// Derivations
+// ---------------------------------------------------------------------------
+
+/**
+ * Map the customer risk rating + PEP/sanctions flags to a CDD tier.
+ * High/PEP/sanctions → EDD; medium → CDD; low → SDD. This mirrors the
+ * decision tree in CLAUDE.md "When a new customer is onboarded" and is
+ * intentionally conservative.
+ */
+export function deriveCddLevel(customer: CustomerProfile): 'SDD' | 'CDD' | 'EDD' {
+  if (
+    customer.riskRating === 'high' ||
+    customer.pepStatus !== 'clear' ||
+    customer.sanctionsStatus !== 'clear'
+  ) {
+    return 'EDD';
+  }
+  if (customer.riskRating === 'medium') {
+    return 'CDD';
+  }
+  return 'SDD';
+}
+
+function deriveRiskLevel(customer: CustomerProfile): RiskLevel {
+  if (customer.pepStatus === 'match' || customer.sanctionsStatus === 'match') {
+    return 'critical';
+  }
+  if (customer.riskRating === 'high') return 'high';
+  if (customer.riskRating === 'medium') return 'medium';
+  return 'low';
+}
+
+function countQualifyingUBOs(customer: CustomerProfile): number {
+  // UBO register threshold: ownership >= 25% (Cabinet Decision 109/2023).
+  return customer.beneficialOwners.filter(
+    (b) => typeof b.ownershipPercent === 'number' && b.ownershipPercent >= 25
+  ).length;
+}
+
+// ---------------------------------------------------------------------------
+// Pure payload builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the custom_fields payload for a CDD → Asana push. Pure — no
+ * I/O, safe to unit test without mocking fetch.
+ *
+ * Every field is degradation-tolerant: if the env GID is not
+ * configured, asanaCustomFields.ts silently drops the entry. The
+ * payload may therefore be empty; the caller MUST tolerate that.
+ */
+export function buildCddCustomFieldPayload(
+  input: CddCustomFieldInput
+): { payload: Record<string, string | number>; derivedCddLevel: 'SDD' | 'CDD' | 'EDD' } {
+  const { customer } = input;
+  const derivedCddLevel = input.cddLevelOverride ?? deriveCddLevel(customer);
+  const riskLevel = deriveRiskLevel(customer);
+
+  // Map the CDD level into the compliance custom-field input shape.
+  // We set:
+  //   - riskLevel (enum)
+  //   - verdict (enum)            — "flag" if EDD/PEP/sanctions
+  //   - caseId (text)             — customer id so Asana rollups match
+  //   - cddLevel (string)         — SDD / CDD / EDD label
+  //   - confidence (number)       — 1.0 if both SoF & SoW verified
+  //   - regulationCitation (text)
+  const verdict: ComplianceCustomFieldInput['verdict'] =
+    derivedCddLevel === 'EDD' ? 'flag' : 'pass';
+
+  const confidence =
+    customer.sourceOfFundsStatus === 'verified' &&
+    customer.sourceOfWealthStatus === 'verified'
+      ? 1.0
+      : 0.6;
+
+  const payload = buildComplianceCustomFields({
+    riskLevel,
+    verdict,
+    caseId: customer.id,
+    confidence,
+    cddLevel: derivedCddLevel,
+    regulationCitation:
+      input.regulationCitation ??
+      `FDL Art.12-14; Cabinet Res 134/2025 Art.${derivedCddLevel === 'EDD' ? '14' : '7-10'}`,
+    sanctionsFlag:
+      customer.pepStatus !== 'clear' || customer.sanctionsStatus !== 'clear',
+  });
+
+  // Side-channel fields that asanaCustomFields doesn't currently map —
+  // we attach them under optional env GIDs so deployments can pick them
+  // up without changing the core builder.
+  const extra: Record<string, string | number> = { ...payload };
+  const nameGid = readEnv('ASANA_CF_CUSTOMER_NAME_GID');
+  if (nameGid) extra[nameGid] = customer.legalName;
+  const jurisdictionGid = readEnv('ASANA_CF_JURISDICTION_GID');
+  if (jurisdictionGid && customer.countryOfRegistration) {
+    extra[jurisdictionGid] = customer.countryOfRegistration;
+  }
+  const uboCountGid = readEnv('ASANA_CF_UBO_COUNT_GID');
+  if (uboCountGid) extra[uboCountGid] = countQualifyingUBOs(customer);
+  const pepFlagGid = readEnv('ASANA_CF_PEP_FLAG_GID');
+  if (pepFlagGid) extra[pepFlagGid] = customer.pepStatus === 'clear' ? 'NO' : 'YES';
+
+  return { payload: extra, derivedCddLevel };
+}
+
+function readEnv(key: string): string | undefined {
+  if (typeof process !== 'undefined' && process.env?.[key]) return process.env[key];
+  if (typeof globalThis !== 'undefined') {
+    const g = globalThis as Record<string, unknown>;
+    const val = g[key];
+    if (typeof val === 'string') return val;
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Dispatcher
+// ---------------------------------------------------------------------------
+
+/**
+ * Push CDD custom fields onto an existing Asana task. Skips the API
+ * call when the derived payload is empty (no env GIDs configured) —
+ * no point spending a rate-limit slot on a no-op update.
+ */
+export async function pushCddCustomFields(
+  input: CddCustomFieldInput
+): Promise<CddCustomFieldPushResult> {
+  const { payload, derivedCddLevel } = buildCddCustomFieldPayload(input);
+
+  if (!isAsanaConfigured()) {
+    return {
+      ok: false,
+      error: 'Asana not configured',
+      payload,
+      derivedCddLevel,
+    };
+  }
+
+  if (Object.keys(payload).length === 0) {
+    return {
+      ok: true,
+      error: 'No custom field GIDs configured — push is a no-op',
+      payload,
+      derivedCddLevel,
+    };
+  }
+
+  const result = await asanaRequestWithRetry<{ gid: string }>(
+    `/tasks/${encodeURIComponent(input.taskGid)}`,
+    {
+      method: 'PUT',
+      body: JSON.stringify({
+        data: { custom_fields: payload },
+      }),
+    }
+  );
+
+  return {
+    ok: result.ok,
+    error: result.error,
+    payload,
+    derivedCddLevel,
+  };
+}

--- a/src/services/strSubtaskLifecycle.ts
+++ b/src/services/strSubtaskLifecycle.ts
@@ -1,0 +1,317 @@
+/**
+ * STR Parent-Child Subtask Lifecycle — Asana weaponization pass.
+ *
+ * When the STR drafter saves a draft, we can't leave the lifecycle in
+ * limbo. Every STR must move deterministically through seven stages:
+ *
+ *   1. MLRO review        — MLRO reads the draft (Cabinet Res 134/2025 Art.19)
+ *   2. Four-eyes approval — two independent approvers (Art.19)
+ *   3. goAML XML generate — build schema-valid FIU XML
+ *   4. Submit to FIU      — upload to goAML portal (FDL Art.26-27)
+ *   5. Retain 10 years    — file in cold storage (FDL Art.24)
+ *   6. Monitor ack        — track FIU acknowledgement
+ *   7. Close              — parent closes when every subtask done
+ *
+ * This module emits one parent Asana task plus those seven subtasks in
+ * a single dispatch call. The parent carries the STR custom fields
+ * (risk, verdict, deadline) from asanaCustomFields.ts so Asana's native
+ * dashboards pick up the filing at rollup time.
+ *
+ * Mirrors the shape of fourEyesSubtasks.ts — a pure payload builder
+ * plus a dispatcher so unit tests can exercise every stage without
+ * touching the Asana API.
+ *
+ * Regulatory basis:
+ *   - FDL No.10/2025 Art.24 (10yr retention)
+ *   - FDL No.10/2025 Art.26-27 (STR filing obligations)
+ *   - FDL No.10/2025 Art.29 (no tipping off — reviewer names only,
+ *     never the subject entity name in subtask titles)
+ *   - Cabinet Res 134/2025 Art.19 (four-eyes internal review)
+ *   - MoE Circular 08/AML/2021 (goAML XML + FIU submission chain)
+ */
+
+import {
+  asanaRequestWithRetry,
+  createAsanaTask,
+  isAsanaConfigured,
+  type AsanaTaskPayload,
+} from './asanaClient';
+import { buildComplianceCustomFields } from './asanaCustomFields';
+import { addTaskLink } from './asanaTaskLinks';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * The seven lifecycle stages. Order is significant — downstream
+ * dashboards rely on this sequence for the funnel rollup.
+ */
+export const STR_SUBTASK_STAGES = [
+  'mlro-review',
+  'four-eyes',
+  'goaml-xml',
+  'submit-fiu',
+  'retain-10y',
+  'monitor-ack',
+  'close',
+] as const;
+
+export type StrSubtaskStage = (typeof STR_SUBTASK_STAGES)[number];
+
+export interface StrLifecycleContext {
+  /** Local STR draft id (used as the task link key). */
+  strId: string;
+  /** Local case id. */
+  caseId: string;
+  /**
+   * Entity reference to use in the parent notes and subtask notes.
+   * The STR page already strips the legal name to avoid tipping-off
+   * (FDL Art.29). Pass the case id as the entity ref by default and
+   * the drafter can override with a safe synonym when appropriate.
+   */
+  entityRef: string;
+  /** Risk level from the case. */
+  riskLevel: 'critical' | 'high' | 'medium' | 'low';
+  /** Free-form reason the STR was triggered. */
+  reasonForSuspicion: string;
+  /** Optional regulatory basis override. */
+  regulatoryBasis?: string;
+  /** Asana project to dispatch the parent + subtasks into. */
+  projectGid: string;
+  /** ISO timestamp the STR was drafted (clock start). */
+  draftedAtIso: string;
+}
+
+export interface StrSubtaskPayload {
+  stage: StrSubtaskStage;
+  name: string;
+  notes: string;
+  due_on: string;
+}
+
+export interface StrLifecycleDispatchResult {
+  ok: boolean;
+  parentGid?: string;
+  subtaskGids: string[];
+  errors: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Deadline table
+// ---------------------------------------------------------------------------
+
+/**
+ * Business-day deadlines per stage, measured from the draft timestamp.
+ * These are *internal* SLAs — the regulatory deadline is the overall
+ * STR filing window (FDL Art.26-27 "without delay"), these just
+ * decompose the window across the seven stages so each stage has its
+ * own due date.
+ */
+const STAGE_DUE_DAYS: Record<StrSubtaskStage, number> = {
+  'mlro-review': 1,
+  'four-eyes': 2,
+  'goaml-xml': 3,
+  'submit-fiu': 5,
+  'retain-10y': 6,
+  'monitor-ack': 10,
+  close: 12,
+};
+
+const STAGE_LABEL: Record<StrSubtaskStage, string> = {
+  'mlro-review': 'MLRO review',
+  'four-eyes': 'Four-eyes approval',
+  'goaml-xml': 'Generate goAML XML',
+  'submit-fiu': 'Submit to FIU',
+  'retain-10y': 'File for 10-year retention',
+  'monitor-ack': 'Monitor FIU acknowledgement',
+  close: 'Close STR lifecycle',
+};
+
+const STAGE_NOTE_BODY: Record<StrSubtaskStage, string> = {
+  'mlro-review':
+    'MLRO must read the parent STR draft, verify the narrative, and mark this subtask complete to release the case for four-eyes review.',
+  'four-eyes':
+    'Two INDEPENDENT approvers must sign off per Cabinet Res 134/2025 Art.19. Do not coordinate decisions. Each reviewer must mark their own sub-subtask complete.',
+  'goaml-xml':
+    'Build goAML schema-valid XML via src/utils/goamlValidator.ts. Never hand-write XML. Attach the validated XML to this subtask.',
+  'submit-fiu':
+    'Upload the validated XML to the UAE FIU goAML portal. Paste the reference number into this subtask description before marking complete.',
+  'retain-10y':
+    'Move the filing + evidence bundle into 10-year cold storage per FDL No.10/2025 Art.24. Record the storage URI in this subtask.',
+  'monitor-ack':
+    'Watch for FIU acknowledgement. If ack is not received within 10 business days, escalate to the MLRO breakglass channel.',
+  close:
+    'All previous subtasks must be complete before this one. Record the final disposition and close the parent task.',
+};
+
+function addBusinessDays(fromIso: string, days: number): string {
+  const start = new Date(fromIso);
+  if (!Number.isFinite(start.getTime())) {
+    throw new Error(`strSubtaskLifecycle: invalid draftedAtIso ${fromIso}`);
+  }
+  let added = 0;
+  const cursor = new Date(start);
+  while (added < days) {
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+    const dow = cursor.getUTCDay();
+    if (dow !== 0 && dow !== 6) {
+      added++;
+    }
+  }
+  return cursor.toISOString().slice(0, 10);
+}
+
+// ---------------------------------------------------------------------------
+// Pure builders — unit-test friendly
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the parent STR task payload. Carries compliance custom fields
+ * so Asana rollups can pick up risk/verdict/deadline without the
+ * compliance-analyzer needing to mirror a dashboard surface.
+ */
+export function buildStrParentTaskPayload(ctx: StrLifecycleContext): AsanaTaskPayload {
+  const notes = [
+    'STR parent lifecycle task — do NOT close this task manually.',
+    'It closes automatically when all seven subtasks are complete.',
+    '',
+    `STR draft: ${ctx.strId}`,
+    `Case: ${ctx.caseId}`,
+    `Entity ref: ${ctx.entityRef}`,
+    `Risk: ${ctx.riskLevel}`,
+    '',
+    'Reason for suspicion:',
+    ctx.reasonForSuspicion,
+    '',
+    `Regulatory basis: ${ctx.regulatoryBasis ?? 'FDL No.10/2025 Art.26-27'}`,
+    '',
+    '--- FDL Art.29 — NO TIPPING OFF ---',
+    'This task is visible only to the compliance team. Never share',
+    'subject identifiers, task name, or URL outside the team.',
+  ].join('\n');
+
+  return {
+    name: `[STR] ${ctx.caseId} — lifecycle`,
+    notes,
+    projects: [ctx.projectGid],
+    due_on: addBusinessDays(ctx.draftedAtIso, STAGE_DUE_DAYS.close),
+    custom_fields: buildComplianceCustomFields({
+      riskLevel: ctx.riskLevel,
+      verdict: 'escalate',
+      caseId: ctx.caseId,
+      deadlineType: 'STR',
+      daysRemaining: STAGE_DUE_DAYS.close,
+      regulationCitation: ctx.regulatoryBasis ?? 'FDL No.10/2025 Art.26-27',
+    }),
+  };
+}
+
+/**
+ * Build every subtask payload for the STR lifecycle. Pure — no I/O.
+ *
+ * Returns an array of exactly seven entries in STR_SUBTASK_STAGES
+ * order. Tests should assert the order because dashboards depend on it.
+ */
+export function buildStrSubtaskPayloads(
+  ctx: StrLifecycleContext
+): StrSubtaskPayload[] {
+  return STR_SUBTASK_STAGES.map((stage) => {
+    const label = STAGE_LABEL[stage];
+    const noteBody = STAGE_NOTE_BODY[stage];
+    const due = addBusinessDays(ctx.draftedAtIso, STAGE_DUE_DAYS[stage]);
+    return {
+      stage,
+      name: `[${stage.toUpperCase()}] ${label} — ${ctx.caseId}`,
+      notes: [
+        noteBody,
+        '',
+        `Parent STR draft: ${ctx.strId}`,
+        `Case: ${ctx.caseId}`,
+        `Risk: ${ctx.riskLevel}`,
+        `Stage: ${stage} (${STR_SUBTASK_STAGES.indexOf(stage) + 1}/${STR_SUBTASK_STAGES.length})`,
+        `Due: ${due}`,
+        '',
+        'Regulatory basis: FDL No.10/2025 Art.26-27; Cabinet Res 134/2025 Art.19.',
+        '',
+        'FDL Art.29 — no tipping off. Do not contact the subject.',
+      ].join('\n'),
+      due_on: due,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Dispatcher
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the parent STR task plus its seven subtasks. Links every
+ * created task into the local task-link store keyed by the STR id so
+ * downstream monitors (Kanban view, health tile, breach escalation)
+ * can find them.
+ *
+ * The subtasks are created sequentially to respect the adaptive rate
+ * limiter in asanaClient. On the first failure we stop and return the
+ * partial result — the caller should inspect `errors` and decide
+ * whether to retry, escalate, or enqueue to asanaQueue.
+ */
+export async function createStrLifecycleTasks(
+  ctx: StrLifecycleContext
+): Promise<StrLifecycleDispatchResult> {
+  if (!isAsanaConfigured()) {
+    return {
+      ok: false,
+      subtaskGids: [],
+      errors: ['Asana not configured'],
+    };
+  }
+
+  const parentPayload = buildStrParentTaskPayload(ctx);
+  const parent = await createAsanaTask(parentPayload);
+  if (!parent.ok || !parent.gid) {
+    return {
+      ok: false,
+      subtaskGids: [],
+      errors: [parent.error ?? 'createAsanaTask returned no gid'],
+    };
+  }
+
+  addTaskLink(ctx.strId, 'filing', parent.gid, ctx.projectGid);
+
+  const subtaskPayloads = buildStrSubtaskPayloads(ctx);
+  const subtaskGids: string[] = [];
+  const errors: string[] = [];
+
+  for (const payload of subtaskPayloads) {
+    const res = await asanaRequestWithRetry<{ gid: string }>(
+      `/tasks/${encodeURIComponent(parent.gid)}/subtasks`,
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          data: {
+            name: payload.name,
+            notes: payload.notes,
+            due_on: payload.due_on,
+          },
+        }),
+      }
+    );
+    if (res.ok && res.data?.gid) {
+      subtaskGids.push(res.data.gid);
+    } else {
+      errors.push(`${payload.stage}: ${res.error ?? 'unknown error'}`);
+      // Stop on first failure to avoid partial fan-out. The parent task
+      // is already created — the caller can retry the subtask creation
+      // loop against the known parent gid.
+      break;
+    }
+  }
+
+  return {
+    ok: errors.length === 0 && subtaskGids.length === STR_SUBTASK_STAGES.length,
+    parentGid: parent.gid,
+    subtaskGids,
+    errors,
+  };
+}

--- a/src/ui/asana/AsanaKanbanPage.tsx
+++ b/src/ui/asana/AsanaKanbanPage.tsx
@@ -1,0 +1,402 @@
+/**
+ * Asana Kanban Page — render compliance tasks as columns inside the SPA.
+ *
+ * Replaces the old "open Asana in a new tab" flow. The MLRO picks a
+ * project from the selector (populated by the customer registry's
+ * asanaComplianceProjectGid) and sees tasks grouped into To Do /
+ * Doing / Review / Done / Blocked columns. Breach cards bubble to the
+ * top of every column with a visible warning badge.
+ *
+ * Regulatory basis:
+ *   - FDL No.10/2025 Art.19-21 (CO visibility into work queue)
+ *   - Cabinet Res 134/2025 Art.19 (internal review)
+ */
+
+import { useEffect, useMemo, useState, useCallback } from 'react';
+import {
+  loadKanbanBoard,
+  KANBAN_COLUMNS,
+  KANBAN_COLUMN_LABEL,
+  type KanbanBoard,
+  type KanbanColumn,
+  type KanbanCard,
+} from '../../services/asanaKanbanView';
+import { COMPANY_REGISTRY } from '../../domain/customers';
+import { isAsanaConfigured } from '../../services/asanaClient';
+
+const DEFAULT_PROJECT_FALLBACK = '1213759768596515';
+
+const COLUMN_ACCENTS: Record<KanbanColumn, string> = {
+  todo: '#3B82F6',
+  doing: '#E8A030',
+  review: '#8B5CF6',
+  done: '#3DA876',
+  blocked: '#D94F4F',
+};
+
+interface ProjectOption {
+  gid: string;
+  label: string;
+}
+
+function buildProjectOptions(): ProjectOption[] {
+  const opts: ProjectOption[] = [];
+  const seen = new Set<string>();
+  for (const c of COMPANY_REGISTRY) {
+    if (c.asanaComplianceProjectGid && !seen.has(c.asanaComplianceProjectGid)) {
+      seen.add(c.asanaComplianceProjectGid);
+      opts.push({
+        gid: c.asanaComplianceProjectGid,
+        label: `${c.legalName} (compliance)`,
+      });
+    }
+    if (c.asanaWorkflowProjectGid && !seen.has(c.asanaWorkflowProjectGid)) {
+      seen.add(c.asanaWorkflowProjectGid);
+      opts.push({
+        gid: c.asanaWorkflowProjectGid,
+        label: `${c.legalName} (workflow)`,
+      });
+    }
+  }
+  if (!seen.has(DEFAULT_PROJECT_FALLBACK)) {
+    opts.unshift({ gid: DEFAULT_PROJECT_FALLBACK, label: 'Default Asana project' });
+  }
+  return opts;
+}
+
+function CardRow({ card }: { card: KanbanCard }) {
+  return (
+    <div
+      style={{
+        padding: '10px 12px',
+        background: '#161b22',
+        border: `1px solid ${card.breachWarning ? '#D94F4F' : '#21262d'}`,
+        borderLeft: card.breachWarning
+          ? '3px solid #D94F4F'
+          : `3px solid ${COLUMN_ACCENTS[card.column]}`,
+        borderRadius: 6,
+        marginBottom: 8,
+        cursor: 'grab',
+      }}
+      draggable
+      onDragStart={(e) => {
+        e.dataTransfer.setData('text/plain', card.gid);
+      }}
+    >
+      <div style={{ fontSize: 12, fontWeight: 600, color: '#e6edf3', marginBottom: 4 }}>
+        {card.name}
+      </div>
+      <div style={{ fontSize: 10, color: '#8b949e', display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+        {card.assigneeName && <span>@ {card.assigneeName}</span>}
+        {card.dueOn && (
+          <span style={{ color: card.breachWarning ? '#D94F4F' : '#8b949e' }}>
+            Due {card.dueOn}
+          </span>
+        )}
+        {card.sourceSection && <span style={{ color: '#484f58' }}>§ {card.sourceSection}</span>}
+      </div>
+      {card.breachWarning && (
+        <div
+          style={{
+            fontSize: 10,
+            color: '#D94F4F',
+            fontWeight: 700,
+            marginTop: 4,
+            letterSpacing: 0.5,
+          }}
+        >
+          SLA BREACH
+        </div>
+      )}
+      {card.tagLabels.length > 0 && (
+        <div style={{ marginTop: 6, display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+          {card.tagLabels.map((t) => (
+            <span
+              key={t}
+              style={{
+                padding: '1px 6px',
+                background: '#0d1117',
+                border: '1px solid #21262d',
+                borderRadius: 10,
+                fontSize: 9,
+                color: '#8b949e',
+              }}
+            >
+              {t}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ColumnView({
+  column,
+  cards,
+  onDropCard,
+}: {
+  column: KanbanColumn;
+  cards: KanbanCard[];
+  onDropCard: (gid: string, column: KanbanColumn) => void;
+}) {
+  const accent = COLUMN_ACCENTS[column];
+  return (
+    <div
+      style={{
+        flex: '1 1 220px',
+        minWidth: 220,
+        background: '#0d1117',
+        border: '1px solid #21262d',
+        borderTop: `3px solid ${accent}`,
+        borderRadius: 8,
+        padding: 12,
+      }}
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={(e) => {
+        const gid = e.dataTransfer.getData('text/plain');
+        if (gid) onDropCard(gid, column);
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: 10,
+        }}
+      >
+        <strong style={{ fontSize: 13, color: '#e6edf3' }}>
+          {KANBAN_COLUMN_LABEL[column]}
+        </strong>
+        <span
+          style={{
+            fontSize: 10,
+            color: '#8b949e',
+            padding: '1px 8px',
+            background: '#161b22',
+            border: '1px solid #21262d',
+            borderRadius: 10,
+          }}
+        >
+          {cards.length}
+        </span>
+      </div>
+      {cards.length === 0 ? (
+        <div
+          style={{
+            textAlign: 'center',
+            color: '#484f58',
+            fontSize: 11,
+            padding: '16px 0',
+            fontStyle: 'italic',
+          }}
+        >
+          Empty
+        </div>
+      ) : (
+        cards.map((c) => <CardRow key={c.gid} card={c} />)
+      )}
+    </div>
+  );
+}
+
+export default function AsanaKanbanPage() {
+  const projectOptions = useMemo(buildProjectOptions, []);
+  const [projectGid, setProjectGid] = useState<string>(
+    projectOptions[0]?.gid ?? DEFAULT_PROJECT_FALLBACK
+  );
+  const [board, setBoard] = useState<KanbanBoard | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [localOverride, setLocalOverride] = useState<Record<string, KanbanColumn>>({});
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const result = await loadKanbanBoard(projectGid);
+    if (!result.ok || !result.board) {
+      setError(result.error ?? 'Failed to load Kanban board');
+      setBoard(null);
+    } else {
+      setBoard(result.board);
+      setLocalOverride({});
+    }
+    setLoading(false);
+  }, [projectGid]);
+
+  useEffect(() => {
+    if (!isAsanaConfigured()) {
+      setError('Asana not configured — set ASANA_TOKEN or proxy URL in Settings.');
+      return;
+    }
+    void refresh();
+  }, [refresh]);
+
+  const handleDrop = useCallback(
+    (gid: string, column: KanbanColumn) => {
+      // Optimistic local move. We do NOT write back to Asana here
+      // because that requires section GIDs per project (different per
+      // project) — wiring that safely needs a per-project section map
+      // which is a separate task. The override lets the MLRO triage
+      // the board visually and see what reordering the columns would
+      // look like; on refresh we re-fetch from Asana and the override
+      // clears.
+      setLocalOverride((prev) => ({ ...prev, [gid]: column }));
+    },
+    []
+  );
+
+  const displayBoard = useMemo(() => {
+    if (!board) return null;
+    if (Object.keys(localOverride).length === 0) return board;
+    // Apply local overrides by rebuilding the column map.
+    const next: Record<KanbanColumn, KanbanCard[]> = {
+      todo: [],
+      doing: [],
+      review: [],
+      done: [],
+      blocked: [],
+    };
+    for (const col of KANBAN_COLUMNS) {
+      for (const card of board.columns[col]) {
+        const target = localOverride[card.gid] ?? col;
+        next[target].push({ ...card, column: target });
+      }
+    }
+    return { ...board, columns: next };
+  }, [board, localOverride]);
+
+  return (
+    <div>
+      <div
+        style={{
+          display: 'flex',
+          gap: 12,
+          alignItems: 'center',
+          marginBottom: 16,
+          flexWrap: 'wrap',
+        }}
+      >
+        <label
+          style={{ fontSize: 12, color: '#8b949e', display: 'flex', alignItems: 'center', gap: 8 }}
+        >
+          Project:
+          <select
+            value={projectGid}
+            onChange={(e) => setProjectGid(e.target.value)}
+            style={{
+              padding: '6px 10px',
+              background: '#0d1117',
+              border: '1px solid #30363d',
+              borderRadius: 6,
+              color: '#e6edf3',
+              fontSize: 12,
+              minWidth: 260,
+            }}
+          >
+            {projectOptions.map((opt) => (
+              <option key={opt.gid} value={opt.gid}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button
+          onClick={() => void refresh()}
+          disabled={loading}
+          style={{
+            padding: '6px 16px',
+            background: '#d4a843',
+            color: '#000',
+            border: 'none',
+            borderRadius: 6,
+            fontSize: 12,
+            fontWeight: 600,
+            cursor: loading ? 'wait' : 'pointer',
+            opacity: loading ? 0.6 : 1,
+          }}
+        >
+          {loading ? 'Loading…' : 'Refresh'}
+        </button>
+        {displayBoard && (
+          <span style={{ fontSize: 11, color: '#8b949e' }}>
+            {displayBoard.totalCards} cards · {displayBoard.breachCount} breach
+            {displayBoard.breachCount === 1 ? '' : 'es'}
+          </span>
+        )}
+      </div>
+
+      {error && (
+        <div
+          style={{
+            padding: 12,
+            background: '#161b22',
+            border: '1px solid #D94F4F44',
+            borderLeft: '3px solid #D94F4F',
+            borderRadius: 6,
+            color: '#D94F4F',
+            fontSize: 12,
+            marginBottom: 16,
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {displayBoard && (
+        <div
+          style={{
+            display: 'flex',
+            gap: 12,
+            overflowX: 'auto',
+            paddingBottom: 8,
+            alignItems: 'flex-start',
+          }}
+        >
+          {KANBAN_COLUMNS.map((col) => (
+            <ColumnView
+              key={col}
+              column={col}
+              cards={displayBoard.columns[col]}
+              onDropCard={handleDrop}
+            />
+          ))}
+        </div>
+      )}
+
+      {!error && !displayBoard && !loading && (
+        <div style={{ textAlign: 'center', color: '#8b949e', padding: 60 }}>
+          Select a project and click Refresh to load the Kanban board.
+        </div>
+      )}
+
+      <div
+        style={{
+          marginTop: 24,
+          padding: 12,
+          background: '#161b22',
+          border: '1px solid #21262d',
+          borderRadius: 6,
+          fontSize: 11,
+          color: '#8b949e',
+          lineHeight: 1.7,
+        }}
+      >
+        <strong style={{ color: '#e6edf3' }}>Kanban column source of truth:</strong> Asana project
+        sections. Supported section names (case-insensitive substring):
+        <br />
+        <span>
+          <code>To Do / Backlog / Queue</code> → <strong>To Do</strong>;{' '}
+          <code>In Progress / Doing / WIP</code> → <strong>Doing</strong>;{' '}
+          <code>Review / QA / Four-Eyes / Approval</code> → <strong>Review</strong>;{' '}
+          <code>Done / Completed / Closed</code> → <strong>Done</strong>;{' '}
+          <code>Blocked</code> → <strong>Blocked</strong>.
+        </span>
+        <br />
+        Drag cards between columns to preview a re-ordering locally — write-back to Asana sections
+        requires per-project section GIDs and is not wired here.
+      </div>
+    </div>
+  );
+}

--- a/src/ui/dashboard/AsanaHealthTile.tsx
+++ b/src/ui/dashboard/AsanaHealthTile.tsx
@@ -1,0 +1,176 @@
+/**
+ * Asana Health Tile — single-glance sync status on the dashboard.
+ *
+ * Surfaces the snapshot from src/services/asanaHealthTelemetry.ts:
+ * sync status, retry queue depth, rate-limit usage, last error.
+ *
+ * Regulatory basis:
+ *   - Cabinet Res 134/2025 Art.19 (internal review)
+ *   - FDL No.10/2025 Art.24 (retention — sync failures tracked)
+ */
+
+import { useEffect, useState } from 'react';
+import {
+  getAsanaHealthSnapshot,
+  type AsanaHealthSnapshot,
+} from '../../services/asanaHealthTelemetry';
+
+const STATUS_COLORS: Record<AsanaHealthSnapshot['status'], string> = {
+  unconfigured: '#8b949e',
+  healthy: '#3DA876',
+  degraded: '#E8A030',
+  critical: '#D94F4F',
+};
+
+const STATUS_LABELS: Record<AsanaHealthSnapshot['status'], string> = {
+  unconfigured: 'NOT CONFIGURED',
+  healthy: 'HEALTHY',
+  degraded: 'DEGRADED',
+  critical: 'CRITICAL',
+};
+
+export default function AsanaHealthTile() {
+  const [snapshot, setSnapshot] = useState<AsanaHealthSnapshot | null>(null);
+
+  useEffect(() => {
+    const load = () => {
+      try {
+        setSnapshot(getAsanaHealthSnapshot());
+      } catch (err) {
+        console.warn('[AsanaHealthTile] snapshot failed:', err);
+      }
+    };
+    load();
+    const interval = setInterval(load, 30_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  if (!snapshot) {
+    return (
+      <div
+        style={{
+          padding: '12px 16px',
+          background: '#0f0f23',
+          borderRadius: 6,
+          border: '1px solid #2a2a4a',
+          color: '#8b949e',
+          fontSize: 11,
+        }}
+      >
+        Loading Asana health…
+      </div>
+    );
+  }
+
+  const color = STATUS_COLORS[snapshot.status];
+  const label = STATUS_LABELS[snapshot.status];
+
+  return (
+    <div
+      style={{
+        padding: '14px 16px',
+        background: '#0f0f23',
+        borderRadius: 8,
+        border: `1px solid ${color}44`,
+        borderLeft: `4px solid ${color}`,
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: 8,
+        }}
+      >
+        <div style={{ fontSize: 12, color: '#8b949e', fontWeight: 600 }}>
+          ASANA SYNC
+        </div>
+        <span
+          style={{
+            padding: '2px 10px',
+            borderRadius: 3,
+            fontSize: 10,
+            fontWeight: 700,
+            background: `${color}22`,
+            color,
+            border: `1px solid ${color}44`,
+            letterSpacing: 0.5,
+          }}
+        >
+          {label}
+        </span>
+      </div>
+      <div style={{ fontSize: 12, color: '#e6edf3', marginBottom: 8 }}>
+        {snapshot.summary}
+      </div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(4, 1fr)',
+          gap: 8,
+          fontSize: 11,
+          color: '#8b949e',
+        }}
+      >
+        <div>
+          <div style={{ color: '#484f58', fontSize: 9, letterSpacing: 0.5 }}>RETRY</div>
+          <div style={{ color: '#e6edf3', fontWeight: 600 }}>
+            {snapshot.retryQueuePending}
+          </div>
+        </div>
+        <div>
+          <div style={{ color: '#484f58', fontSize: 9, letterSpacing: 0.5 }}>FAILED</div>
+          <div
+            style={{
+              color: snapshot.retryQueueFailed > 0 ? '#D94F4F' : '#e6edf3',
+              fontWeight: 600,
+            }}
+          >
+            {snapshot.retryQueueFailed}
+          </div>
+        </div>
+        <div>
+          <div style={{ color: '#484f58', fontSize: 9, letterSpacing: 0.5 }}>ACTIVE</div>
+          <div style={{ color: '#e6edf3', fontWeight: 600 }}>{snapshot.linksActive}</div>
+        </div>
+        <div>
+          <div style={{ color: '#484f58', fontSize: 9, letterSpacing: 0.5 }}>DONE</div>
+          <div style={{ color: '#3DA876', fontWeight: 600 }}>{snapshot.linksCompleted}</div>
+        </div>
+      </div>
+      {snapshot.lastError && (
+        <div
+          style={{
+            marginTop: 10,
+            padding: 8,
+            background: '#161b22',
+            border: '1px solid #D94F4F44',
+            borderRadius: 4,
+            fontSize: 10,
+            color: '#D94F4F',
+            lineHeight: 1.4,
+          }}
+          title={snapshot.lastErrorAtIso}
+        >
+          <strong>Last error:</strong> {snapshot.lastError}
+        </div>
+      )}
+      {snapshot.lastRateLimitAtIso && !snapshot.lastError && (
+        <div
+          style={{
+            marginTop: 10,
+            padding: 6,
+            background: '#161b22',
+            border: '1px solid #E8A03044',
+            borderRadius: 4,
+            fontSize: 10,
+            color: '#E8A030',
+          }}
+        >
+          Recent 429 rate-limit hit ({snapshot.lastRateLimitAtIso.slice(11, 19)})
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/dashboard/KPIDashboard.tsx
+++ b/src/ui/dashboard/KPIDashboard.tsx
@@ -7,6 +7,7 @@
 
 import { useMemo } from 'react';
 import type { KPIDashboard as KPIData } from '../../domain/kpi';
+import AsanaHealthTile from './AsanaHealthTile';
 
 interface KPIDashboardProps {
   data: KPIData;
@@ -190,6 +191,11 @@ export default function KPIDashboardView({ data }: KPIDashboardProps) {
         <MetricCard label="STR Pending" value={data.strPending} target={0} inverse />
         <MetricCard label="Screening Runs" value={data.screeningRuns} target={1} />
         <MetricCard label="PF Alerts" value={data.pfAlertsGenerated} target={0} inverse />
+      </div>
+
+      {/* Asana Health Tile */}
+      <div style={{ marginBottom: '12px' }}>
+        <AsanaHealthTile />
       </div>
 
       {/* Filing Summary */}

--- a/src/ui/reports/STRDraftPage.tsx
+++ b/src/ui/reports/STRDraftPage.tsx
@@ -4,6 +4,9 @@ import type { SuspicionReport } from '../../domain/reports';
 import { LocalAppStore } from '../../services/indexedDbStore';
 import { createId } from '../../utils/id';
 import { nowIso } from '../../utils/dates';
+import { createStrLifecycleTasks } from '../../services/strSubtaskLifecycle';
+import { isAsanaConfigured } from '../../services/asanaClient';
+import { COMPANY_REGISTRY } from '../../domain/customers';
 
 // CRITICAL: FDL Art.29 — No Tipping Off
 // This page must ONLY be accessible to Compliance Officers and MLRO.
@@ -57,6 +60,7 @@ function buildTransactionSummaries(caseObj: ComplianceCase): SuspicionReport['tr
 export default function STRDraftPage() {
   const [cases, setCases] = useState<ComplianceCase[]>([]);
   const [selectedId, setSelectedId] = useState<string>('');
+  const [lifecycleStatus, setLifecycleStatus] = useState<string>('');
 
   useEffect(() => {
     void store.getCases().then((items) => {
@@ -92,7 +96,52 @@ export default function STRDraftPage() {
     };
 
     await store.saveReport(report);
-    alert('STR draft generated.');
+
+    // Fan out to the 7-subtask Asana lifecycle so the draft doesn't
+    // rot in local storage. FDL Art.26-27 + Cabinet Res 134/2025
+    // Art.19 — MLRO review → four-eyes → goAML XML → submit → retain
+    // → monitor → close. If Asana is not configured we keep the draft
+    // saved and surface a status hint so the MLRO knows to wire up the
+    // token in Settings.
+    if (!isAsanaConfigured()) {
+      setLifecycleStatus(
+        'STR draft saved. Asana not configured — lifecycle fan-out skipped. Wire ASANA_TOKEN in Settings to enable.'
+      );
+      return;
+    }
+
+    setLifecycleStatus('Dispatching 7-subtask lifecycle to Asana…');
+    const customer = selected.linkedCustomerId
+      ? COMPANY_REGISTRY.find((c) => c.id === selected.linkedCustomerId)
+      : undefined;
+    const projectGid =
+      customer?.asanaComplianceProjectGid ??
+      customer?.asanaWorkflowProjectGid ??
+      '1213759768596515';
+
+    try {
+      const dispatch = await createStrLifecycleTasks({
+        strId: report.id,
+        caseId: selected.id,
+        entityRef: selected.id, // use case id, not entity name (FDL Art.29)
+        riskLevel: selected.riskLevel,
+        reasonForSuspicion: buildSuspicionNarrative(selected),
+        regulatoryBasis: 'FDL No.10/2025 Art.26-27',
+        projectGid,
+        draftedAtIso: report.generatedAt,
+      });
+      if (dispatch.ok) {
+        setLifecycleStatus(
+          `STR lifecycle dispatched — parent ${dispatch.parentGid} + ${dispatch.subtaskGids.length} subtasks.`
+        );
+      } else {
+        setLifecycleStatus(
+          `STR draft saved. Lifecycle fan-out failed: ${dispatch.errors.join('; ')}`
+        );
+      }
+    } catch (err) {
+      setLifecycleStatus(`STR draft saved. Lifecycle dispatch error: ${(err as Error).message}`);
+    }
   };
 
   return (
@@ -127,6 +176,21 @@ export default function STRDraftPage() {
           </p>
           <p>{buildSuspicionNarrative(selected)}</p>
           <button onClick={handleGenerate}>Generate STR Draft</button>
+          {lifecycleStatus && (
+            <div
+              style={{
+                marginTop: 12,
+                padding: 10,
+                background: '#f5f5f5',
+                border: '1px solid #ccc',
+                borderRadius: 4,
+                fontSize: 12,
+                color: '#333',
+              }}
+            >
+              {lifecycleStatus}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/tests/asanaHealthTelemetry.test.ts
+++ b/tests/asanaHealthTelemetry.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for the Asana health telemetry reducer. Pure inputs → pure
+ * outputs so we can lock the decision table down.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  reduceAsanaHealth,
+  type AsanaHealthInputs,
+} from '@/services/asanaHealthTelemetry';
+
+function baseInputs(
+  overrides: Partial<AsanaHealthInputs> = {}
+): AsanaHealthInputs {
+  return {
+    configured: true,
+    retryQueue: { pending: 0, failed: 0 },
+    linkStats: { total: 12, completed: 8, active: 4 },
+    nowIso: '2026-04-13T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('reduceAsanaHealth', () => {
+  it('reports unconfigured when Asana is not configured', () => {
+    const snap = reduceAsanaHealth(baseInputs({ configured: false }));
+    expect(snap.status).toBe('unconfigured');
+    expect(snap.summary).toMatch(/not configured/i);
+  });
+
+  it('reports healthy when queue is empty and no recent errors', () => {
+    const snap = reduceAsanaHealth(baseInputs());
+    expect(snap.status).toBe('healthy');
+    expect(snap.lastError).toBeUndefined();
+    expect(snap.summary).toMatch(/healthy/i);
+  });
+
+  it('reports degraded when retry queue has pending entries', () => {
+    const snap = reduceAsanaHealth(
+      baseInputs({ retryQueue: { pending: 3, failed: 0 } })
+    );
+    expect(snap.status).toBe('degraded');
+    expect(snap.retryQueuePending).toBe(3);
+  });
+
+  it('reports degraded when a rate limit hit occurred within 5 minutes', () => {
+    const snap = reduceAsanaHealth(
+      baseInputs({ lastRateLimitAtIso: '2026-04-13T11:58:00.000Z' })
+    );
+    expect(snap.status).toBe('degraded');
+    expect(snap.lastRateLimitAtIso).toBeDefined();
+  });
+
+  it('reports critical when the retry queue has permanently failed entries', () => {
+    const snap = reduceAsanaHealth(
+      baseInputs({ retryQueue: { pending: 1, failed: 2 } })
+    );
+    expect(snap.status).toBe('critical');
+    expect(snap.retryQueueFailed).toBe(2);
+  });
+
+  it('reports critical when a recent error is present', () => {
+    const snap = reduceAsanaHealth(
+      baseInputs({
+        lastError: {
+          error: 'Asana API 500: server error',
+          atIso: '2026-04-13T11:55:00.000Z',
+        },
+      })
+    );
+    expect(snap.status).toBe('critical');
+    expect(snap.lastError).toContain('500');
+  });
+
+  it('ignores errors older than 15 minutes', () => {
+    const snap = reduceAsanaHealth(
+      baseInputs({
+        lastError: {
+          error: 'Asana API 500: server error',
+          atIso: '2026-04-13T11:00:00.000Z', // 60 minutes ago
+        },
+      })
+    );
+    expect(snap.status).toBe('healthy');
+    expect(snap.lastError).toBeUndefined();
+  });
+
+  it('critical outranks degraded', () => {
+    const snap = reduceAsanaHealth(
+      baseInputs({
+        retryQueue: { pending: 5, failed: 1 },
+        lastError: {
+          error: '429 rate limit',
+          atIso: '2026-04-13T11:59:00.000Z',
+        },
+      })
+    );
+    expect(snap.status).toBe('critical');
+  });
+});

--- a/tests/asanaKanbanView.test.ts
+++ b/tests/asanaKanbanView.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for the Asana Kanban grouping logic. Pure classifier over
+ * in-memory task fixtures — no fetch mocking.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  sectionNameToColumn,
+  namePrefixToColumn,
+  classifyTaskToColumn,
+  buildKanbanBoard,
+  KANBAN_COLUMNS,
+  type AsanaKanbanTask,
+} from '@/services/asanaKanbanView';
+
+describe('sectionNameToColumn', () => {
+  it('maps common "To Do" synonyms', () => {
+    expect(sectionNameToColumn('To Do')).toBe('todo');
+    expect(sectionNameToColumn('Backlog')).toBe('todo');
+    expect(sectionNameToColumn('Queue')).toBe('todo');
+  });
+
+  it('maps in-progress synonyms', () => {
+    expect(sectionNameToColumn('In Progress')).toBe('doing');
+    expect(sectionNameToColumn('Doing')).toBe('doing');
+    expect(sectionNameToColumn('WIP')).toBe('doing');
+  });
+
+  it('maps review synonyms', () => {
+    expect(sectionNameToColumn('Review')).toBe('review');
+    expect(sectionNameToColumn('QA')).toBe('review');
+    expect(sectionNameToColumn('Four-Eyes Approval')).toBe('review');
+  });
+
+  it('maps done synonyms', () => {
+    expect(sectionNameToColumn('Done ✓')).toBe('done');
+    expect(sectionNameToColumn('Completed')).toBe('done');
+    expect(sectionNameToColumn('Closed')).toBe('done');
+  });
+
+  it('maps blocked', () => {
+    expect(sectionNameToColumn('Blocked')).toBe('blocked');
+  });
+
+  it('returns undefined for unknown', () => {
+    expect(sectionNameToColumn('Random')).toBeUndefined();
+    expect(sectionNameToColumn(undefined)).toBeUndefined();
+  });
+});
+
+describe('namePrefixToColumn', () => {
+  it('extracts the column from a [TAG] prefix', () => {
+    expect(namePrefixToColumn('[TODO] something')).toBe('todo');
+    expect(namePrefixToColumn('[DOING] something')).toBe('doing');
+    expect(namePrefixToColumn('[REVIEW] something')).toBe('review');
+    expect(namePrefixToColumn('[DONE] something')).toBe('done');
+    expect(namePrefixToColumn('[BLOCKED] something')).toBe('blocked');
+    expect(namePrefixToColumn('[FOUR-EYES] something')).toBe('review');
+  });
+
+  it('returns undefined when there is no prefix', () => {
+    expect(namePrefixToColumn('no prefix here')).toBeUndefined();
+  });
+});
+
+describe('classifyTaskToColumn', () => {
+  const projectGid = 'proj-1';
+
+  function task(overrides: Partial<AsanaKanbanTask> = {}): AsanaKanbanTask {
+    return {
+      gid: 'g1',
+      name: 'task',
+      completed: false,
+      ...overrides,
+    };
+  }
+
+  it('prefers this-project section over name prefix', () => {
+    const t = task({
+      name: '[DONE] something',
+      memberships: [
+        { project: { gid: projectGid }, section: { gid: 's1', name: 'Doing' } },
+      ],
+    });
+    expect(classifyTaskToColumn(t, projectGid).column).toBe('doing');
+  });
+
+  it('ignores sections from other projects', () => {
+    const t = task({
+      name: '[BLOCKED] something',
+      memberships: [
+        { project: { gid: 'other' }, section: { gid: 's1', name: 'Doing' } },
+      ],
+    });
+    // Should fall through to name prefix since the section belongs to
+    // a different project.
+    expect(classifyTaskToColumn(t, projectGid).column).toBe('blocked');
+  });
+
+  it('falls back to name prefix when no sections', () => {
+    const t = task({ name: '[REVIEW] approve' });
+    expect(classifyTaskToColumn(t, projectGid).column).toBe('review');
+  });
+
+  it('falls back to done when completed and no section/prefix', () => {
+    const t = task({ name: 'unassigned', completed: true });
+    expect(classifyTaskToColumn(t, projectGid).column).toBe('done');
+  });
+
+  it('defaults to todo otherwise', () => {
+    const t = task({ name: 'unassigned' });
+    expect(classifyTaskToColumn(t, projectGid).column).toBe('todo');
+  });
+});
+
+describe('buildKanbanBoard', () => {
+  const projectGid = 'proj-1';
+
+  it('groups tasks into the 5 canonical columns', () => {
+    const tasks: AsanaKanbanTask[] = [
+      { gid: '1', name: '[TODO] a', completed: false },
+      { gid: '2', name: '[DOING] b', completed: false },
+      { gid: '3', name: '[REVIEW] c', completed: false },
+      { gid: '4', name: 'd', completed: true },
+      { gid: '5', name: '[BLOCKED] e', completed: false },
+    ];
+    const board = buildKanbanBoard(tasks, { projectGid });
+    expect(board.columns.todo).toHaveLength(1);
+    expect(board.columns.doing).toHaveLength(1);
+    expect(board.columns.review).toHaveLength(1);
+    expect(board.columns.done).toHaveLength(1);
+    expect(board.columns.blocked).toHaveLength(1);
+    expect(board.totalCards).toBe(5);
+  });
+
+  it('flags overdue tasks as breaches', () => {
+    const tasks: AsanaKanbanTask[] = [
+      {
+        gid: '1',
+        name: '[DOING] overdue',
+        completed: false,
+        due_on: '2025-01-01',
+      },
+      {
+        gid: '2',
+        name: '[DOING] ontime',
+        completed: false,
+        due_on: '2099-01-01',
+      },
+    ];
+    const board = buildKanbanBoard(tasks, {
+      projectGid,
+      nowIso: '2026-04-13T00:00:00.000Z',
+    });
+    expect(board.breachCount).toBe(1);
+    const doing = board.columns.doing;
+    expect(doing[0].breachWarning).toBe(true);
+    expect(doing[0].gid).toBe('1');
+  });
+
+  it('completed tasks do not count as breaches even when past due', () => {
+    const tasks: AsanaKanbanTask[] = [
+      {
+        gid: '1',
+        name: 'completed overdue',
+        completed: true,
+        due_on: '2025-01-01',
+      },
+    ];
+    const board = buildKanbanBoard(tasks, {
+      projectGid,
+      nowIso: '2026-04-13T00:00:00.000Z',
+    });
+    expect(board.breachCount).toBe(0);
+  });
+
+  it('sorts breach-first, then by due date', () => {
+    const tasks: AsanaKanbanTask[] = [
+      { gid: '1', name: '[TODO] b', completed: false, due_on: '2099-06-01' },
+      { gid: '2', name: '[TODO] a', completed: false, due_on: '2025-01-01' }, // breach
+    ];
+    const board = buildKanbanBoard(tasks, {
+      projectGid,
+      nowIso: '2026-04-13T00:00:00.000Z',
+    });
+    expect(board.columns.todo[0].gid).toBe('2'); // breach first
+  });
+
+  it('always returns all 5 column keys even when empty', () => {
+    const board = buildKanbanBoard([], { projectGid });
+    for (const col of KANBAN_COLUMNS) {
+      expect(Array.isArray(board.columns[col])).toBe(true);
+    }
+  });
+});

--- a/tests/asanaSlaAutoEscalation.test.ts
+++ b/tests/asanaSlaAutoEscalation.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for the SLA breach auto-escalation tier selector + payload
+ * builder. Pure functions — no fetch mocking required.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  chooseEscalationTier,
+  buildEscalationTaskPayload,
+  type EscalationContext,
+} from '@/services/asanaSlaAutoEscalation';
+import { computeSla } from '@/services/asanaSlaEnforcer';
+
+function mkCtx(overrides: Partial<EscalationContext>): EscalationContext {
+  const slaPlan = computeSla({
+    startedAtIso: '2026-04-13T00:00:00.000Z',
+    kind: 'eocn_freeze_24h',
+  });
+  return {
+    breachedTaskGid: 'task-1',
+    breachedTaskTitle: 'Freeze confirmed — case-42',
+    projectGid: 'proj-1',
+    minutesOverdue: 30,
+    slaPlan,
+    ...overrides,
+  };
+}
+
+describe('chooseEscalationTier — EOCN freeze', () => {
+  it('escalates to MLRO inside the first hour past due', () => {
+    const decision = chooseEscalationTier(mkCtx({ minutesOverdue: 30 }));
+    expect(decision.tier).toBe('MLRO');
+    expect(decision.breakglass).toBe(true);
+  });
+
+  it('escalates to BOARD past 60 minutes overdue', () => {
+    const decision = chooseEscalationTier(mkCtx({ minutesOverdue: 120 }));
+    expect(decision.tier).toBe('BOARD');
+    expect(decision.breakglass).toBe(true);
+  });
+
+  it('escalates to REGULATOR past 24 hours overdue', () => {
+    const decision = chooseEscalationTier(
+      mkCtx({ minutesOverdue: 25 * 60 })
+    );
+    expect(decision.tier).toBe('REGULATOR');
+    expect(decision.breakglass).toBe(true);
+  });
+});
+
+describe('chooseEscalationTier — STR/CNMR filings', () => {
+  it('goes to MLRO on first breach', () => {
+    const slaPlan = computeSla({
+      startedAtIso: '2026-04-13T00:00:00.000Z',
+      kind: 'str_without_delay',
+    });
+    const decision = chooseEscalationTier(
+      mkCtx({ slaPlan, minutesOverdue: 60 })
+    );
+    expect(decision.tier).toBe('MLRO');
+  });
+
+  it('promotes to BOARD once previous tier was MLRO', () => {
+    const slaPlan = computeSla({
+      startedAtIso: '2026-04-13T00:00:00.000Z',
+      kind: 'cnmr_5_business_days',
+    });
+    const decision = chooseEscalationTier(
+      mkCtx({ slaPlan, minutesOverdue: 60, previousTier: 'MLRO' })
+    );
+    expect(decision.tier).toBe('BOARD');
+    expect(decision.breakglass).toBe(true);
+  });
+});
+
+describe('chooseEscalationTier — generic promotion', () => {
+  it('promotes CO → MLRO', () => {
+    const slaPlan = computeSla({
+      startedAtIso: '2026-04-13T00:00:00.000Z',
+      kind: 'cdd_periodic_review',
+    });
+    const decision = chooseEscalationTier(
+      mkCtx({ slaPlan, previousTier: 'CO' })
+    );
+    expect(decision.tier).toBe('MLRO');
+  });
+
+  it('promotes MLRO → BOARD', () => {
+    const slaPlan = computeSla({
+      startedAtIso: '2026-04-13T00:00:00.000Z',
+      kind: 'policy_update_30_days',
+    });
+    const decision = chooseEscalationTier(
+      mkCtx({ slaPlan, previousTier: 'MLRO' })
+    );
+    expect(decision.tier).toBe('BOARD');
+  });
+});
+
+describe('buildEscalationTaskPayload', () => {
+  const ctx = mkCtx({ minutesOverdue: 30 });
+  const decision = chooseEscalationTier(ctx);
+  const payload = buildEscalationTaskPayload(ctx, decision);
+
+  it('prefixes the task name with the tier tag', () => {
+    expect(payload.name).toContain(`[ESCALATE-${decision.tier}]`);
+    expect(payload.name).toContain('Freeze confirmed');
+  });
+
+  it('includes the SLA regulatory citation in notes', () => {
+    expect(payload.notes).toContain('Cabinet Res 74/2020');
+  });
+
+  it('flags FDL Art.29 no-tipping-off in notes', () => {
+    expect(payload.notes).toContain('Art.29');
+  });
+
+  it('targets the correct project', () => {
+    expect(payload.projects).toEqual(['proj-1']);
+  });
+
+  it('tags with sla-breach and escalation tier', () => {
+    expect(payload.tags).toContain('sla-breach');
+    expect(payload.tags?.some((t) => t.startsWith('escalation:'))).toBe(true);
+  });
+});

--- a/tests/cddAsanaCustomFieldPush.test.ts
+++ b/tests/cddAsanaCustomFieldPush.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for CDD → Asana custom field push. Exercises the pure
+ * builder and the derivation helpers.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  buildCddCustomFieldPayload,
+  deriveCddLevel,
+} from '@/services/cddAsanaCustomFieldPush';
+import type { CustomerProfile } from '@/domain/customers';
+
+function mkCustomer(overrides: Partial<CustomerProfile> = {}): CustomerProfile {
+  return {
+    id: 'company-x',
+    legalName: 'Test Co LLC',
+    type: 'customer',
+    entityType: 'standalone',
+    activity: 'Jewellery Trading',
+    location: 'Dubai, UAE',
+    countryOfRegistration: 'UAE',
+    sector: 'precious-metals',
+    riskRating: 'medium',
+    pepStatus: 'clear',
+    sanctionsStatus: 'clear',
+    sourceOfFundsStatus: 'verified',
+    sourceOfWealthStatus: 'verified',
+    beneficialOwners: [],
+    reviewHistory: [],
+    ...overrides,
+  };
+}
+
+// Stash + restore env vars so one test doesn't pollute another.
+const savedEnv: Record<string, string | undefined> = {};
+const envKeys = [
+  'ASANA_CF_CUSTOMER_NAME_GID',
+  'ASANA_CF_JURISDICTION_GID',
+  'ASANA_CF_UBO_COUNT_GID',
+  'ASANA_CF_PEP_FLAG_GID',
+  'ASANA_CF_RISK_LEVEL_GID',
+  'ASANA_CF_RISK_LEVEL_HIGH',
+  'ASANA_CF_RISK_LEVEL_MEDIUM',
+  'ASANA_CF_RISK_LEVEL_LOW',
+  'ASANA_CF_RISK_LEVEL_CRITICAL',
+];
+
+beforeEach(() => {
+  for (const k of envKeys) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of envKeys) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+});
+
+describe('deriveCddLevel', () => {
+  it('returns SDD for a clean low-risk customer', () => {
+    expect(deriveCddLevel(mkCustomer({ riskRating: 'low' }))).toBe('SDD');
+  });
+
+  it('returns CDD for medium risk', () => {
+    expect(deriveCddLevel(mkCustomer({ riskRating: 'medium' }))).toBe('CDD');
+  });
+
+  it('returns EDD for high risk', () => {
+    expect(deriveCddLevel(mkCustomer({ riskRating: 'high' }))).toBe('EDD');
+  });
+
+  it('returns EDD for any PEP match regardless of risk', () => {
+    expect(
+      deriveCddLevel(
+        mkCustomer({ riskRating: 'low', pepStatus: 'potential-match' })
+      )
+    ).toBe('EDD');
+  });
+
+  it('returns EDD for sanctions match', () => {
+    expect(
+      deriveCddLevel(mkCustomer({ riskRating: 'low', sanctionsStatus: 'match' }))
+    ).toBe('EDD');
+  });
+});
+
+describe('buildCddCustomFieldPayload', () => {
+  it('returns empty payload when no GIDs are configured (degradation path)', () => {
+    const result = buildCddCustomFieldPayload({
+      customer: mkCustomer(),
+      taskGid: '123',
+    });
+    expect(result.payload).toEqual({});
+    expect(result.derivedCddLevel).toBe('CDD');
+  });
+
+  it('emits risk level enum when GIDs are configured', () => {
+    process.env.ASANA_CF_RISK_LEVEL_GID = 'risk-gid';
+    process.env.ASANA_CF_RISK_LEVEL_MEDIUM = 'medium-opt';
+    const result = buildCddCustomFieldPayload({
+      customer: mkCustomer(),
+      taskGid: '123',
+    });
+    expect(result.payload['risk-gid']).toBe('medium-opt');
+  });
+
+  it('emits customer name, jurisdiction, UBO count, and PEP flag when those env GIDs are set', () => {
+    process.env.ASANA_CF_CUSTOMER_NAME_GID = 'name-gid';
+    process.env.ASANA_CF_JURISDICTION_GID = 'juris-gid';
+    process.env.ASANA_CF_UBO_COUNT_GID = 'ubo-gid';
+    process.env.ASANA_CF_PEP_FLAG_GID = 'pep-gid';
+
+    const customer = mkCustomer({
+      legalName: 'Test Co LLC',
+      countryOfRegistration: 'AE',
+      beneficialOwners: [
+        {
+          id: 'u1',
+          fullName: 'A',
+          ownershipPercent: 30,
+          pepStatus: 'clear',
+          sanctionsStatus: 'clear',
+        },
+        {
+          id: 'u2',
+          fullName: 'B',
+          ownershipPercent: 10, // under 25% — does not count
+          pepStatus: 'clear',
+          sanctionsStatus: 'clear',
+        },
+      ],
+    });
+
+    const result = buildCddCustomFieldPayload({ customer, taskGid: '123' });
+    expect(result.payload['name-gid']).toBe('Test Co LLC');
+    expect(result.payload['juris-gid']).toBe('AE');
+    expect(result.payload['ubo-gid']).toBe(1); // only the ≥25% owner
+    expect(result.payload['pep-gid']).toBe('NO');
+  });
+
+  it('flags PEP=YES when PEP status is not clear', () => {
+    process.env.ASANA_CF_PEP_FLAG_GID = 'pep-gid';
+    const result = buildCddCustomFieldPayload({
+      customer: mkCustomer({ pepStatus: 'match' }),
+      taskGid: '123',
+    });
+    expect(result.payload['pep-gid']).toBe('YES');
+    expect(result.derivedCddLevel).toBe('EDD');
+  });
+
+  it('honours an explicit CDD level override', () => {
+    const result = buildCddCustomFieldPayload({
+      customer: mkCustomer({ riskRating: 'low' }),
+      taskGid: '123',
+      cddLevelOverride: 'EDD',
+    });
+    expect(result.derivedCddLevel).toBe('EDD');
+  });
+});

--- a/tests/strSubtaskLifecycle.test.ts
+++ b/tests/strSubtaskLifecycle.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for strSubtaskLifecycle — pure builder only. Dispatcher is
+ * covered indirectly via type contract; exercising the Asana POST
+ * path would require mocking fetch which asanaClient.test.ts already
+ * does for the transport layer.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildStrParentTaskPayload,
+  buildStrSubtaskPayloads,
+  STR_SUBTASK_STAGES,
+  type StrLifecycleContext,
+} from '@/services/strSubtaskLifecycle';
+
+const baseCtx: StrLifecycleContext = {
+  strId: 'str-abc',
+  caseId: 'case-123',
+  entityRef: 'case-123',
+  riskLevel: 'critical',
+  reasonForSuspicion: 'unexplained third-party payment',
+  regulatoryBasis: 'FDL No.10/2025 Art.26-27',
+  projectGid: '1213759768596515',
+  draftedAtIso: '2026-04-13T12:00:00.000Z', // Monday
+};
+
+describe('buildStrParentTaskPayload', () => {
+  it('uses the case id in the title, not the entity name (FDL Art.29)', () => {
+    const payload = buildStrParentTaskPayload(baseCtx);
+    expect(payload.name).toContain('case-123');
+    expect(payload.name).not.toContain('MADISON');
+    expect(payload.projects).toEqual(['1213759768596515']);
+  });
+
+  it('writes regulatory basis into notes', () => {
+    const payload = buildStrParentTaskPayload(baseCtx);
+    expect(payload.notes).toContain('FDL No.10/2025 Art.26-27');
+    expect(payload.notes).toContain('FDL Art.29 — NO TIPPING OFF');
+  });
+
+  it('defaults the regulatory basis when omitted', () => {
+    const payload = buildStrParentTaskPayload({
+      ...baseCtx,
+      regulatoryBasis: undefined,
+    });
+    expect(payload.notes).toContain('FDL No.10/2025 Art.26-27');
+  });
+
+  it('sets a due date later than the drafted timestamp', () => {
+    const payload = buildStrParentTaskPayload(baseCtx);
+    expect(payload.due_on).toBeDefined();
+    expect(Date.parse(payload.due_on ?? '')).toBeGreaterThan(
+      Date.parse(baseCtx.draftedAtIso)
+    );
+  });
+});
+
+describe('buildStrSubtaskPayloads', () => {
+  it('returns exactly 7 subtasks in canonical order', () => {
+    const subtasks = buildStrSubtaskPayloads(baseCtx);
+    expect(subtasks).toHaveLength(7);
+    expect(subtasks.map((s) => s.stage)).toEqual([...STR_SUBTASK_STAGES]);
+  });
+
+  it('every subtask has a due date that skips weekends', () => {
+    const subtasks = buildStrSubtaskPayloads(baseCtx);
+    for (const s of subtasks) {
+      const d = new Date(s.due_on);
+      const dow = d.getUTCDay();
+      expect(dow).not.toBe(0); // sunday
+      expect(dow).not.toBe(6); // saturday
+    }
+  });
+
+  it('subtask due dates are monotonically non-decreasing', () => {
+    const subtasks = buildStrSubtaskPayloads(baseCtx);
+    const dates = subtasks.map((s) => Date.parse(s.due_on));
+    for (let i = 1; i < dates.length; i++) {
+      expect(dates[i]).toBeGreaterThanOrEqual(dates[i - 1]);
+    }
+  });
+
+  it('subtask names include the stage label', () => {
+    const subtasks = buildStrSubtaskPayloads(baseCtx);
+    expect(subtasks[0].name).toContain('MLRO-REVIEW');
+    expect(subtasks[1].name).toContain('FOUR-EYES');
+    expect(subtasks[2].name).toContain('GOAML-XML');
+    expect(subtasks[3].name).toContain('SUBMIT-FIU');
+    expect(subtasks[4].name).toContain('RETAIN-10Y');
+    expect(subtasks[5].name).toContain('MONITOR-ACK');
+    expect(subtasks[6].name).toContain('CLOSE');
+  });
+
+  it('never includes the entity legal name in subtask titles', () => {
+    const subtasks = buildStrSubtaskPayloads({
+      ...baseCtx,
+      entityRef: 'MADISON JEWELLERY',
+    });
+    // The builder uses caseId in the title — entityRef only lands in
+    // parent notes. This guards against a refactor that accidentally
+    // starts echoing the entity name into subtask titles.
+    for (const s of subtasks) {
+      expect(s.name).not.toContain('MADISON');
+    }
+  });
+
+  it('rejects malformed draftedAtIso', () => {
+    expect(() =>
+      buildStrSubtaskPayloads({ ...baseCtx, draftedAtIso: 'not-a-date' })
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

This PR integrates Asana task management into the compliance dashboard with three major features:

1. **Asana Kanban Board UI** — Replaces the "open Asana in a new tab" flow with an in-app Kanban view (To Do / Doing / Review / Done / Blocked columns)
2. **STR Lifecycle Automation** — When an STR draft is saved, automatically creates a parent task + 7 subtasks in Asana covering the full filing lifecycle (MLRO review → four-eyes → goAML XML → FIU submission → 10-year retention → FIU ack → close)
3. **Asana Health Telemetry** — Dashboard tile showing sync status, retry queue depth, rate-limit usage, and last error without touching the Asana API

## Key Changes

### New Modules

- **`src/services/asanaKanbanView.ts`** — Pure grouping logic to fetch tasks and classify them into Kanban columns. Supports section-based mapping (case-insensitive substring match) with fallback to name prefix (`[TODO]`, `[DOING]`, etc.) and completion status.

- **`src/services/strSubtaskLifecycle.ts`** — Builds a parent STR task + 7 subtasks with business-day deadlines per stage. Emits a single dispatch call with all payloads. Includes regulatory citations (FDL Art.24, Art.26-27, Art.29; Cabinet Res 134/2025 Art.19).

- **`src/services/asanaSlaAutoEscalation.ts`** — Tier selector for SLA breach escalation (CO → MLRO → Board → Regulator). Handles EOCN 24h freeze as a hard deadline with breakglass notifications.

- **`src/services/cddAsanaCustomFieldPush.ts`** — Derives CDD level (SDD/CDD/EDD) from customer risk + PEP/sanctions flags and pushes to Asana custom fields. Degradation-tolerant when field GIDs are not configured.

- **`src/services/asanaHealthTelemetry.ts`** — Reads retry queue, task-link store, and error tombstones to produce a health snapshot. No network traffic; pure reducer over in-memory state.

### UI Components

- **`src/ui/asana/AsanaKanbanPage.tsx`** — Full Kanban board with project selector, drag-and-drop (optimistic local moves), breach warning badges, and card metadata (assignee, due date, tags, regulatory section).

- **`src/ui/dashboard/AsanaHealthTile.tsx`** — Dashboard tile showing status badge, summary, and metrics (retry queue, links, rate limits).

### Integration Points

- **`src/ui/reports/STRDraftPage.tsx`** — On save, calls `createStrLifecycleTasks()` to dispatch the 7-subtask lifecycle to Asana.

- **`src/ui/dashboard/KPIDashboard.tsx`** — Embeds `AsanaHealthTile` for operational visibility.

- **`src/App.tsx`** — Routes `/asana` to `AsanaKanbanPage`.

### Tests

- **`tests/asanaKanbanView.test.ts`** — Section/prefix mapping, task classification, board building.
- **`tests/strSubtaskLifecycle.test.ts`** — Parent + subtask payload builders, deadline calculation.
- **`tests/asanaSlaAutoEscalation.test.ts`** — Tier selection logic for EOCN, STR, and CNMR breaches.
- **`tests/cddAsanaCustomFieldPush.test.ts`** — CDD level derivation and custom field payload building.
- **`tests/asanaHealthTelemetry.test.ts`** — Health reducer decision table.

## Notable Implementation Details

- **No Tipping Off (FDL Art.29)** — STR parent tasks use case ID in title, never entity name. Subtask notes reference only reviewer roles, not

https://claude.ai/code/session_01FdK2XNYPexqNwMhXZd1hxE