### PR TITLE
Asana workspace bootstrap: custom fields + sections + webhooks (FDL No.10/2025 Art.20-21, Art.24; Cabinet Res 134/2025 Art.19)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,12 +84,42 @@ ASANA_CF_CONFIDENCE_GID=
 # Text fields
 ASANA_CF_REGULATION_GID=
 
-# CDD push side-channel fields (added in this session — see
-# src/services/cddAsanaCustomFieldPush.ts)
+# CDD push side-channel fields (consumed by
+# src/services/cddAsanaCustomFieldPush.ts). Provisioned by
+# `npm run asana:bootstrap:cf` — paste the export lines back here.
 ASANA_CF_CUSTOMER_NAME_GID=
 ASANA_CF_JURISDICTION_GID=
 ASANA_CF_UBO_COUNT_GID=
+
+# PEP flag (enum field — provisioned by asana-cf-bootstrap.ts)
 ASANA_CF_PEP_FLAG_GID=
+ASANA_CF_PEP_FLAG_CLEAR=
+ASANA_CF_PEP_FLAG_POTENTIAL=
+ASANA_CF_PEP_FLAG_MATCH=
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Cross-project / audit-log Asana destinations
+# ─────────────────────────────────────────────────────────────────────────
+# These two projects live OUTSIDE the per-customer projects and
+# aggregate compliance signals across the entire workspace. Both are
+# [STUB-OK] — when unset, the cross-project mirror and audit-log
+# mirror return 'unconfigured' and become no-ops.
+
+# Central MLRO triage project — receives a mirrored task for every
+# blocked / freeze / escalated case across all customer projects.
+# Create manually in Asana, then paste the GID here.
+ASANA_CENTRAL_MLRO_PROJECT_GID=
+
+# Compliance audit log project — receives a mirrored task for every
+# entry written to the dispatch audit log. Required for the FDL
+# Art.24 10-year retention guarantee outside localStorage.
+ASANA_AUDIT_LOG_PROJECT_GID=
+
+# Public base URL of the deployed analyzer — used by
+# `npm run asana:bootstrap:webhooks` to compute the receiver target.
+# If unset, the webhook bootstrap falls back to HAWKEYE_BRAIN_URL.
+PUBLIC_BASE_URL=https://compliance-analyzer.netlify.app
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/package.json
+++ b/package.json
@@ -59,6 +59,10 @@
     "validate:goaml": "tsx scripts/validate-goaml.ts",
     "regulatory:watch": "tsx scripts/regulatory-watcher.ts",
     "audit:lbma": "tsx scripts/lbma-audit-pack.ts",
-    "redteam": "tsx scripts/redteam.ts"
+    "redteam": "tsx scripts/redteam.ts",
+    "asana:bootstrap": "tsx scripts/asana-project-bootstrap.ts",
+    "asana:bootstrap:cf": "tsx scripts/asana-cf-bootstrap.ts",
+    "asana:bootstrap:sections": "tsx scripts/asana-section-bootstrap.ts",
+    "asana:bootstrap:webhooks": "tsx scripts/asana-webhook-bootstrap.ts"
   }
 }

--- a/scripts/asana-cf-bootstrap.ts
+++ b/scripts/asana-cf-bootstrap.ts
@@ -99,6 +99,40 @@ const FIELDS: readonly FieldDefinition[] = [
     type: 'text',
     description: 'Article / Circular that justifies the task.',
   },
+  // CDD push side-channel fields (consumed by
+  // src/services/cddAsanaCustomFieldPush.ts). Required so a CDD
+  // snapshot lands as native Asana custom fields on the customer
+  // case task — without these the MLRO can't filter customers by
+  // jurisdiction/PEP/UBO count in Asana.
+  {
+    envKey: 'ASANA_CF_CUSTOMER_NAME_GID',
+    name: 'Customer name',
+    type: 'text',
+    description: 'Legal entity name pushed from the CDD record.',
+  },
+  {
+    envKey: 'ASANA_CF_JURISDICTION_GID',
+    name: 'Jurisdiction',
+    type: 'text',
+    description: 'Country / jurisdiction of registration (ISO short name).',
+  },
+  {
+    envKey: 'ASANA_CF_UBO_COUNT_GID',
+    name: 'UBO count',
+    type: 'number',
+    description: 'Beneficial owners ≥25% on file (Cabinet Decision 109/2023).',
+  },
+  {
+    envKey: 'ASANA_CF_PEP_FLAG_GID',
+    name: 'PEP flag',
+    type: 'enum',
+    description: 'Politically Exposed Person screening result (Cabinet Res 134/2025 Art.14).',
+    options: [
+      { envKey: 'ASANA_CF_PEP_FLAG_CLEAR', name: 'Clear', color: 'green' },
+      { envKey: 'ASANA_CF_PEP_FLAG_POTENTIAL', name: 'Potential match', color: 'yellow' },
+      { envKey: 'ASANA_CF_PEP_FLAG_MATCH', name: 'Confirmed match', color: 'red' },
+    ],
+  },
 ];
 
 // ---------------------------------------------------------------------------

--- a/scripts/asana-project-bootstrap.ts
+++ b/scripts/asana-project-bootstrap.ts
@@ -1,0 +1,174 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * asana-project-bootstrap.ts — One-shot Asana workspace bootstrap.
+ *
+ * Runs the three idempotent Asana setup steps in the correct order
+ * for a fresh workspace (or a re-sync after env changes):
+ *
+ *   1. Custom fields  → scripts/asana-cf-bootstrap.ts
+ *      Creates the 11 compliance custom fields (risk_level, verdict,
+ *      case_id, deadline_type, days_remaining, confidence,
+ *      regulation_citation, customer_name, jurisdiction, ubo_count,
+ *      pep_flag) on the workspace and prints export-line GIDs.
+ *
+ *   2. Sections       → scripts/asana-section-bootstrap.ts
+ *      Walks COMPANY_REGISTRY and creates the 5 canonical Kanban
+ *      sections (To Do / In Progress / Four-Eyes Review / Done /
+ *      Blocked) on every customer compliance + workflow project.
+ *
+ *   3. Webhooks       → scripts/asana-webhook-bootstrap.ts
+ *      Subscribes one Asana webhook per customer project pointing
+ *      at /api/asana/webhook?workspaceGid=<gid>, with filters that
+ *      pass through task adds, completion changes, custom-field
+ *      changes, and comment_added stories.
+ *
+ * Usage:
+ *   ASANA_TOKEN=xxx \
+ *   ASANA_WORKSPACE_GID=xxx \
+ *   PUBLIC_BASE_URL=https://compliance-analyzer.netlify.app \
+ *   npx tsx scripts/asana-project-bootstrap.ts                 # dry-run
+ *
+ *   ASANA_TOKEN=xxx \
+ *   ASANA_WORKSPACE_GID=xxx \
+ *   PUBLIC_BASE_URL=https://compliance-analyzer.netlify.app \
+ *   npx tsx scripts/asana-project-bootstrap.ts --apply         # write
+ *
+ * Each step is idempotent — re-running after a partial run is safe
+ * and only creates what is missing.
+ *
+ * Regulatory basis:
+ *   - FDL No.10/2025 Art.20-21 (CO duty of care)
+ *   - FDL No.10/2025 Art.24 (10yr retention)
+ *   - Cabinet Res 134/2025 Art.19 (internal review)
+ */
+
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+interface Step {
+  name: string;
+  script: string;
+  requires: string[];
+}
+
+const STEPS: readonly Step[] = [
+  {
+    name: 'Custom fields',
+    script: 'asana-cf-bootstrap.ts',
+    requires: ['ASANA_TOKEN', 'ASANA_WORKSPACE_GID'],
+  },
+  {
+    name: 'Project sections',
+    script: 'asana-section-bootstrap.ts',
+    requires: ['ASANA_TOKEN'],
+  },
+  {
+    name: 'Webhooks',
+    script: 'asana-webhook-bootstrap.ts',
+    requires: ['ASANA_TOKEN', 'ASANA_WORKSPACE_GID', 'PUBLIC_BASE_URL_OR_HAWKEYE_BRAIN_URL'],
+  },
+];
+
+function checkRequirement(req: string): boolean {
+  if (req === 'PUBLIC_BASE_URL_OR_HAWKEYE_BRAIN_URL') {
+    return Boolean(process.env.PUBLIC_BASE_URL || process.env.HAWKEYE_BRAIN_URL);
+  }
+  return Boolean(process.env[req]);
+}
+
+function describeRequirement(req: string): string {
+  if (req === 'PUBLIC_BASE_URL_OR_HAWKEYE_BRAIN_URL') {
+    return 'PUBLIC_BASE_URL or HAWKEYE_BRAIN_URL';
+  }
+  return req;
+}
+
+function runStep(scriptName: string, extraArgs: readonly string[]): Promise<number> {
+  return new Promise((resolve) => {
+    const scriptPath = join(__dirname, scriptName);
+    const child = spawn('npx', ['tsx', scriptPath, ...extraArgs], {
+      stdio: 'inherit',
+      env: process.env,
+    });
+    child.on('close', (code) => resolve(code ?? 1));
+    child.on('error', (err) => {
+      console.error(`Failed to spawn ${scriptName}:`, err);
+      resolve(1);
+    });
+  });
+}
+
+async function main(): Promise<void> {
+  const apply = process.argv.includes('--apply');
+  const extraArgs = apply ? ['--apply'] : [];
+
+  console.log('# ═══════════════════════════════════════════════');
+  console.log('# Asana project bootstrap — one-shot orchestrator');
+  console.log(`# Mode: ${apply ? 'APPLY' : 'DRY-RUN'}`);
+  console.log('# ═══════════════════════════════════════════════');
+  console.log('');
+
+  // Pre-flight: validate every step's required env vars before
+  // starting. Better to fail fast than create custom fields and
+  // then bail at the webhook step because PUBLIC_BASE_URL was unset.
+  let preflightOk = true;
+  for (const step of STEPS) {
+    for (const req of step.requires) {
+      if (!checkRequirement(req)) {
+        console.error(`# ✗ ${step.name}: missing ${describeRequirement(req)}`);
+        preflightOk = false;
+      }
+    }
+  }
+  if (!preflightOk) {
+    console.error('');
+    console.error('# Aborting — set the required env vars and re-run.');
+    process.exit(2);
+  }
+
+  console.log('# ✓ Pre-flight env check passed');
+  console.log('');
+
+  let failedSteps = 0;
+  for (const step of STEPS) {
+    console.log(`# ───── Step: ${step.name} (${step.script}) ─────`);
+    const code = await runStep(step.script, extraArgs);
+    if (code !== 0) {
+      console.error(`# ! ${step.name} exited with code ${code}`);
+      failedSteps++;
+    }
+    console.log('');
+  }
+
+  console.log('# ═══════════════════════════════════════════════');
+  if (failedSteps === 0) {
+    console.log(`# All ${STEPS.length} steps ${apply ? 'applied' : 'dry-ran'} successfully.`);
+    if (!apply) {
+      console.log('# Re-run with --apply to actually mutate the workspace.');
+    } else {
+      console.log('# Next: paste the export lines above into Netlify env vars.');
+    }
+    process.exit(0);
+  } else {
+    console.error(`# ${failedSteps}/${STEPS.length} steps failed. Review output above.`);
+    process.exit(1);
+  }
+}
+
+const isMain =
+  typeof import.meta !== 'undefined' &&
+  typeof process !== 'undefined' &&
+  import.meta.url === `file://${process.argv[1]}`;
+
+if (isMain) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+export { STEPS };

--- a/scripts/asana-section-bootstrap.ts
+++ b/scripts/asana-section-bootstrap.ts
@@ -1,0 +1,277 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * asana-section-bootstrap.ts — Asana per-project section provisioner.
+ *
+ * The Kanban view + section write-back assume each customer compliance
+ * project has 5 sections named:
+ *
+ *   - To Do
+ *   - In Progress
+ *   - Four-Eyes Review
+ *   - Done
+ *   - Blocked
+ *
+ * Without those sections, the brain dispatcher's "move task to
+ * Blocked" calls fall back to the project's default section and the
+ * Kanban view collapses everything into one column. This script walks
+ * COMPANY_REGISTRY, fetches each project's existing sections, and
+ * creates the missing canonical ones via:
+ *
+ *   POST /projects/{project_gid}/sections
+ *
+ * Idempotent: any section whose name (case-insensitive substring)
+ * already maps to a canonical Kanban column via
+ * `sectionNameToColumn()` is treated as already-present. Re-running
+ * after a partial run is safe.
+ *
+ * Usage:
+ *   ASANA_TOKEN=xxx npx tsx scripts/asana-section-bootstrap.ts
+ *   ASANA_TOKEN=xxx npx tsx scripts/asana-section-bootstrap.ts --apply
+ *
+ * By default the script runs in dry-run mode and prints what WOULD
+ * be created. Pass --apply to actually create the sections.
+ *
+ * Scope: by default, walks both `asanaComplianceProjectGid` and
+ * `asanaWorkflowProjectGid` for every entry in COMPANY_REGISTRY.
+ * Pass --compliance-only or --workflow-only to limit the scope.
+ *
+ * Regulatory basis:
+ *   - FDL No.10/2025 Art.20-21 (CO duty of care — visible queue)
+ *   - Cabinet Res 134/2025 Art.19 (internal review — work in progress
+ *     must be inspectable)
+ */
+
+import { COMPANY_REGISTRY } from '../src/domain/customers';
+import {
+  KANBAN_COLUMNS,
+  KANBAN_COLUMN_LABEL,
+  sectionNameToColumn,
+  type KanbanColumn,
+} from '../src/services/asanaKanbanView';
+
+interface AsanaSection {
+  gid: string;
+  name: string;
+}
+
+/**
+ * The five canonical sections we want on every customer project.
+ * Order is preserved when we POST — Asana renders sections in
+ * insertion order, so the operator sees the same column layout in
+ * every project.
+ */
+const CANONICAL_SECTIONS: ReadonlyArray<{ name: string; column: KanbanColumn }> = [
+  { name: 'To Do', column: 'todo' },
+  { name: 'In Progress', column: 'doing' },
+  { name: 'Four-Eyes Review', column: 'review' },
+  { name: 'Done', column: 'done' },
+  { name: 'Blocked', column: 'blocked' },
+];
+
+interface RunOptions {
+  apply: boolean;
+  scope: 'both' | 'compliance' | 'workflow';
+}
+
+function parseArgs(argv: readonly string[]): RunOptions {
+  const apply = argv.includes('--apply');
+  let scope: RunOptions['scope'] = 'both';
+  if (argv.includes('--compliance-only')) scope = 'compliance';
+  if (argv.includes('--workflow-only')) scope = 'workflow';
+  return { apply, scope };
+}
+
+async function fetchProjectSections(
+  token: string,
+  projectGid: string
+): Promise<AsanaSection[]> {
+  const res = await fetch(
+    `https://app.asana.com/api/1.0/projects/${encodeURIComponent(projectGid)}/sections?opt_fields=gid,name&limit=100`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  if (!res.ok) {
+    throw new Error(`GET /projects/${projectGid}/sections failed: HTTP ${res.status}`);
+  }
+  const json = (await res.json()) as { data?: AsanaSection[] };
+  return json.data ?? [];
+}
+
+async function createSection(
+  token: string,
+  projectGid: string,
+  name: string
+): Promise<AsanaSection> {
+  const res = await fetch(
+    `https://app.asana.com/api/1.0/projects/${encodeURIComponent(projectGid)}/sections`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ data: { name } }),
+    }
+  );
+  if (!res.ok) {
+    throw new Error(
+      `POST /projects/${projectGid}/sections failed: HTTP ${res.status} ${(await res.text()).slice(0, 200)}`
+    );
+  }
+  const json = (await res.json()) as { data?: AsanaSection };
+  if (!json.data) throw new Error(`Asana returned empty section payload for "${name}"`);
+  return json.data;
+}
+
+function summarizeProject(
+  legalName: string,
+  kind: 'compliance' | 'workflow',
+  projectGid: string
+): string {
+  return `${legalName} [${kind} ${projectGid}]`;
+}
+
+interface ProjectResult {
+  label: string;
+  projectGid: string;
+  created: string[];
+  alreadyPresent: string[];
+  errors: string[];
+}
+
+async function bootstrapProject(
+  token: string,
+  label: string,
+  projectGid: string,
+  apply: boolean
+): Promise<ProjectResult> {
+  const result: ProjectResult = {
+    label,
+    projectGid,
+    created: [],
+    alreadyPresent: [],
+    errors: [],
+  };
+
+  let existing: AsanaSection[];
+  try {
+    existing = await fetchProjectSections(token, projectGid);
+  } catch (err) {
+    result.errors.push(err instanceof Error ? err.message : String(err));
+    return result;
+  }
+
+  // Build a column → existing section map using the same tolerant
+  // matcher the Kanban view uses. If a project already has e.g.
+  // "Backlog" we treat it as the To Do column and skip creating
+  // a duplicate "To Do" section.
+  const coveredColumns = new Set<KanbanColumn>();
+  for (const section of existing) {
+    const column = sectionNameToColumn(section.name);
+    if (column) coveredColumns.add(column);
+  }
+
+  for (const canonical of CANONICAL_SECTIONS) {
+    if (coveredColumns.has(canonical.column)) {
+      result.alreadyPresent.push(`${canonical.name} (${KANBAN_COLUMN_LABEL[canonical.column]})`);
+      continue;
+    }
+    if (!apply) {
+      result.created.push(`${canonical.name} (DRY RUN)`);
+      coveredColumns.add(canonical.column);
+      continue;
+    }
+    try {
+      const created = await createSection(token, projectGid, canonical.name);
+      result.created.push(`${created.name} → ${created.gid}`);
+      coveredColumns.add(canonical.column);
+    } catch (err) {
+      result.errors.push(
+        `Create "${canonical.name}" failed: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  // Sanity check: every canonical Kanban column must now be covered.
+  const stillMissing = KANBAN_COLUMNS.filter((c) => !coveredColumns.has(c));
+  if (stillMissing.length > 0) {
+    result.errors.push(
+      `After bootstrap, columns still missing: ${stillMissing.map((c) => KANBAN_COLUMN_LABEL[c]).join(', ')}`
+    );
+  }
+
+  return result;
+}
+
+async function main(): Promise<void> {
+  const opts = parseArgs(process.argv.slice(2));
+  const token = process.env.ASANA_TOKEN;
+
+  if (!token) {
+    console.error('ASANA_TOKEN must be set');
+    process.exit(2);
+  }
+
+  console.log(`# Asana section bootstrap`);
+  console.log(`# Mode: ${opts.apply ? 'APPLY' : 'DRY-RUN (use --apply to create)'}`);
+  console.log(`# Scope: ${opts.scope}`);
+  console.log(`# Customers: ${COMPANY_REGISTRY.length}`);
+  console.log('');
+
+  const results: ProjectResult[] = [];
+
+  for (const customer of COMPANY_REGISTRY) {
+    const targets: Array<{ kind: 'compliance' | 'workflow'; gid?: string }> = [];
+    if (opts.scope === 'both' || opts.scope === 'compliance') {
+      targets.push({ kind: 'compliance', gid: customer.asanaComplianceProjectGid });
+    }
+    if (opts.scope === 'both' || opts.scope === 'workflow') {
+      targets.push({ kind: 'workflow', gid: customer.asanaWorkflowProjectGid });
+    }
+
+    for (const t of targets) {
+      if (!t.gid) {
+        console.log(`# SKIP ${customer.legalName} [${t.kind}]: no project GID configured`);
+        continue;
+      }
+      const label = summarizeProject(customer.legalName, t.kind, t.gid);
+      console.log(`# ${label}`);
+      const result = await bootstrapProject(token, label, t.gid, opts.apply);
+      results.push(result);
+      for (const a of result.alreadyPresent) console.log(`#   ✓ ${a}`);
+      for (const c of result.created) console.log(`#   + ${c}`);
+      for (const e of result.errors) console.log(`#   ! ${e}`);
+      console.log('');
+    }
+  }
+
+  // Summary footer.
+  const totalCreated = results.reduce((sum, r) => sum + r.created.length, 0);
+  const totalCovered = results.reduce((sum, r) => sum + r.alreadyPresent.length, 0);
+  const totalErrors = results.reduce((sum, r) => sum + r.errors.length, 0);
+  console.log('# ─────────────────────────────────────────────');
+  console.log(`# Summary:`);
+  console.log(`#   Projects processed: ${results.length}`);
+  console.log(`#   Sections already present: ${totalCovered}`);
+  console.log(`#   Sections ${opts.apply ? 'created' : 'pending creation'}: ${totalCreated}`);
+  console.log(`#   Errors: ${totalErrors}`);
+  if (!opts.apply) {
+    console.log('#');
+    console.log('# Re-run with --apply to actually create the sections.');
+  }
+
+  if (totalErrors > 0) process.exit(1);
+}
+
+const isMain =
+  typeof import.meta !== 'undefined' &&
+  typeof process !== 'undefined' &&
+  import.meta.url === `file://${process.argv[1]}`;
+
+if (isMain) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+export { CANONICAL_SECTIONS, bootstrapProject };

--- a/scripts/asana-webhook-bootstrap.ts
+++ b/scripts/asana-webhook-bootstrap.ts
@@ -1,0 +1,293 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * asana-webhook-bootstrap.ts — Asana webhook subscription provisioner.
+ *
+ * Asana does NOT push events anywhere unless you explicitly subscribe
+ * each (resource, target) pair via the Asana REST API. Our receiver
+ * function at netlify/functions/asana-webhook.mts is fully wired —
+ * including the X-Hook-Secret two-phase handshake and HMAC-SHA256
+ * signature verification — but it never fires because no webhook has
+ * been registered against it.
+ *
+ * This script walks COMPANY_REGISTRY and creates one Asana webhook
+ * per customer compliance project, pointing at:
+ *
+ *   <PUBLIC_BASE_URL>/api/asana/webhook?workspaceGid=<gid>
+ *
+ * The receiver scopes its handshake-secret blob by the workspaceGid
+ * query param so we can re-bootstrap a workspace cleanly without
+ * collisions with other workspaces that may share the same Netlify
+ * site in the future.
+ *
+ * Asana webhooks support filters that limit which events fire. We
+ * subscribe to the four event types the brain dispatcher + skill
+ * router actually consume:
+ *
+ *   - Task added to project   → seeds new compliance cases
+ *   - Task changed (completed/custom-field) → bidirectional resolution
+ *   - Story added (comment_added)            → /audit, /screen, /goaml
+ *                                              slash-command handler
+ *
+ * Usage:
+ *   ASANA_TOKEN=xxx \
+ *   PUBLIC_BASE_URL=https://compliance-analyzer.netlify.app \
+ *   ASANA_WORKSPACE_GID=xxx \
+ *   npx tsx scripts/asana-webhook-bootstrap.ts
+ *
+ *   ASANA_TOKEN=xxx \
+ *   PUBLIC_BASE_URL=... \
+ *   ASANA_WORKSPACE_GID=xxx \
+ *   npx tsx scripts/asana-webhook-bootstrap.ts --apply
+ *
+ * Idempotent: lists existing webhooks first via
+ * GET /webhooks?workspace=<gid> and skips any whose `target` already
+ * matches the URL we would create.
+ *
+ * Regulatory basis:
+ *   - FDL No.10/2025 Art.20-21 (CO duty of care — every Asana action
+ *     must reach the audit chain)
+ *   - FDL No.10/2025 Art.24 (10yr retention — the receiver writes
+ *     every verified delivery to the audit blob store)
+ *   - Cabinet Res 134/2025 Art.19 (internal review must be reflected
+ *     bidirectionally between Asana and the analyzer)
+ */
+
+import { COMPANY_REGISTRY } from '../src/domain/customers';
+
+interface AsanaWebhook {
+  gid: string;
+  resource: { gid: string; name?: string };
+  target: string;
+  active?: boolean;
+}
+
+interface RunOptions {
+  apply: boolean;
+  scope: 'both' | 'compliance' | 'workflow';
+}
+
+function parseArgs(argv: readonly string[]): RunOptions {
+  const apply = argv.includes('--apply');
+  let scope: RunOptions['scope'] = 'both';
+  if (argv.includes('--compliance-only')) scope = 'compliance';
+  if (argv.includes('--workflow-only')) scope = 'workflow';
+  return { apply, scope };
+}
+
+/**
+ * Filters: limit the events Asana actually delivers to our receiver.
+ * Cuts noise + cost. Anything we don't list here is silently dropped
+ * by Asana before it ever touches our function.
+ *
+ * Schema reference: https://developers.asana.com/docs/webhook-filters
+ */
+const WEBHOOK_FILTERS: ReadonlyArray<Record<string, string>> = [
+  // New compliance case landing in the project.
+  { action: 'added', resource_type: 'task' },
+  // Task completed / re-opened — bidirectional resolution sync.
+  { action: 'changed', resource_type: 'task', fields: 'completed' },
+  // Custom field changes — risk_level / verdict / deadline_type.
+  { action: 'changed', resource_type: 'task', fields: 'custom_fields' },
+  // Comments — slash-command handler (/audit, /screen, /goaml).
+  { action: 'added', resource_type: 'story', resource_subtype: 'comment_added' },
+];
+
+async function listExistingWebhooks(
+  token: string,
+  workspaceGid: string
+): Promise<AsanaWebhook[]> {
+  const res = await fetch(
+    `https://app.asana.com/api/1.0/webhooks?workspace=${encodeURIComponent(workspaceGid)}&opt_fields=gid,resource.gid,resource.name,target,active&limit=100`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  if (!res.ok) {
+    throw new Error(
+      `GET /webhooks?workspace=${workspaceGid} failed: HTTP ${res.status} ${(await res.text()).slice(0, 200)}`
+    );
+  }
+  const json = (await res.json()) as { data?: AsanaWebhook[] };
+  return json.data ?? [];
+}
+
+async function createWebhook(
+  token: string,
+  resourceGid: string,
+  target: string
+): Promise<AsanaWebhook> {
+  const res = await fetch(`https://app.asana.com/api/1.0/webhooks`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      data: {
+        resource: resourceGid,
+        target,
+        filters: WEBHOOK_FILTERS,
+      },
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `POST /webhooks failed: HTTP ${res.status} ${(await res.text()).slice(0, 200)}`
+    );
+  }
+  const json = (await res.json()) as { data?: AsanaWebhook };
+  if (!json.data) throw new Error('Asana returned empty webhook payload');
+  return json.data;
+}
+
+interface ProjectResult {
+  label: string;
+  projectGid: string;
+  alreadySubscribed: boolean;
+  created?: string;
+  errors: string[];
+}
+
+async function bootstrapProjectWebhook(
+  token: string,
+  publicBaseUrl: string,
+  workspaceGid: string,
+  legalName: string,
+  kind: 'compliance' | 'workflow',
+  projectGid: string,
+  existing: AsanaWebhook[],
+  apply: boolean
+): Promise<ProjectResult> {
+  const target = `${publicBaseUrl.replace(/\/$/, '')}/api/asana/webhook?workspaceGid=${encodeURIComponent(workspaceGid)}`;
+  const result: ProjectResult = {
+    label: `${legalName} [${kind} ${projectGid}]`,
+    projectGid,
+    alreadySubscribed: false,
+    errors: [],
+  };
+
+  const match = existing.find(
+    (wh) => wh.resource?.gid === projectGid && wh.target === target
+  );
+  if (match) {
+    result.alreadySubscribed = true;
+    result.created = `existing webhook ${match.gid} (active=${match.active ?? 'unknown'})`;
+    return result;
+  }
+
+  if (!apply) {
+    result.created = `WOULD subscribe → ${target}`;
+    return result;
+  }
+
+  try {
+    const created = await createWebhook(token, projectGid, target);
+    result.created = `created webhook ${created.gid} → ${target}`;
+  } catch (err) {
+    result.errors.push(err instanceof Error ? err.message : String(err));
+  }
+  return result;
+}
+
+async function main(): Promise<void> {
+  const opts = parseArgs(process.argv.slice(2));
+  const token = process.env.ASANA_TOKEN;
+  const workspaceGid = process.env.ASANA_WORKSPACE_GID;
+  const publicBaseUrl = process.env.PUBLIC_BASE_URL || process.env.HAWKEYE_BRAIN_URL;
+
+  if (!token || !workspaceGid || !publicBaseUrl) {
+    console.error(
+      'ASANA_TOKEN, ASANA_WORKSPACE_GID, and PUBLIC_BASE_URL (or HAWKEYE_BRAIN_URL) must be set'
+    );
+    process.exit(2);
+  }
+
+  // Validate that the URL is HTTPS — Asana refuses HTTP webhook
+  // targets, and it's also a CLAUDE.md security guarantee.
+  if (!publicBaseUrl.startsWith('https://')) {
+    console.error(`PUBLIC_BASE_URL must be HTTPS, got: ${publicBaseUrl}`);
+    process.exit(2);
+  }
+
+  console.log(`# Asana webhook bootstrap`);
+  console.log(`# Workspace: ${workspaceGid}`);
+  console.log(`# Receiver:  ${publicBaseUrl.replace(/\/$/, '')}/api/asana/webhook`);
+  console.log(`# Mode:      ${opts.apply ? 'APPLY' : 'DRY-RUN (use --apply to subscribe)'}`);
+  console.log(`# Scope:     ${opts.scope}`);
+  console.log('');
+
+  let existing: AsanaWebhook[];
+  try {
+    existing = await listExistingWebhooks(token, workspaceGid);
+    console.log(`# Existing webhooks in workspace: ${existing.length}`);
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+  console.log('');
+
+  const results: ProjectResult[] = [];
+  for (const customer of COMPANY_REGISTRY) {
+    const targets: Array<{ kind: 'compliance' | 'workflow'; gid?: string }> = [];
+    if (opts.scope === 'both' || opts.scope === 'compliance') {
+      targets.push({ kind: 'compliance', gid: customer.asanaComplianceProjectGid });
+    }
+    if (opts.scope === 'both' || opts.scope === 'workflow') {
+      targets.push({ kind: 'workflow', gid: customer.asanaWorkflowProjectGid });
+    }
+
+    for (const t of targets) {
+      if (!t.gid) {
+        console.log(`# SKIP ${customer.legalName} [${t.kind}]: no project GID configured`);
+        continue;
+      }
+      const result = await bootstrapProjectWebhook(
+        token,
+        publicBaseUrl,
+        workspaceGid,
+        customer.legalName,
+        t.kind,
+        t.gid,
+        existing,
+        opts.apply
+      );
+      results.push(result);
+      console.log(`# ${result.label}`);
+      if (result.alreadySubscribed) console.log(`#   ✓ ${result.created}`);
+      else if (result.created) console.log(`#   + ${result.created}`);
+      for (const e of result.errors) console.log(`#   ! ${e}`);
+      console.log('');
+    }
+  }
+
+  // Summary footer.
+  const totalCreated = results.filter((r) => !r.alreadySubscribed && r.errors.length === 0).length;
+  const totalExisting = results.filter((r) => r.alreadySubscribed).length;
+  const totalErrors = results.reduce((sum, r) => sum + r.errors.length, 0);
+  console.log('# ─────────────────────────────────────────────');
+  console.log(`# Summary:`);
+  console.log(`#   Projects processed: ${results.length}`);
+  console.log(`#   Already subscribed: ${totalExisting}`);
+  console.log(`#   ${opts.apply ? 'Subscribed' : 'Pending subscribe'}: ${totalCreated}`);
+  console.log(`#   Errors: ${totalErrors}`);
+  if (!opts.apply) {
+    console.log('#');
+    console.log('# Re-run with --apply to actually subscribe the webhooks.');
+    console.log('# After --apply, the receiver completes the X-Hook-Secret');
+    console.log('# handshake and stores the secret in the Netlify blob store.');
+  }
+
+  if (totalErrors > 0) process.exit(1);
+}
+
+const isMain =
+  typeof import.meta !== 'undefined' &&
+  typeof process !== 'undefined' &&
+  import.meta.url === `file://${process.argv[1]}`;
+
+if (isMain) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+export { WEBHOOK_FILTERS, bootstrapProjectWebhook };


### PR DESCRIPTION
Closes the Tier-1 Asana setup gaps blocking the autopilot dispatcher
from operating against the live workspace.

Custom fields (scripts/asana-cf-bootstrap.ts):
  Extends the existing 7-field bootstrap with the 4 CDD push
  side-channel fields that cddAsanaCustomFieldPush.ts already reads
  from env vars but had no provisioner: customer_name (text),
  jurisdiction (text), ubo_count (number), pep_flag (enum:
  Clear/Potential/Confirmed). Total: 11 compliance custom fields
  provisioned in one idempotent run.

Per-project sections (scripts/asana-section-bootstrap.ts):
  Walks COMPANY_REGISTRY and creates the 5 canonical Kanban
  sections (To Do / In Progress / Four-Eyes Review / Done /
  Blocked) on every customer compliance + workflow project via
  POST /projects/{gid}/sections. Uses the same tolerant
  sectionNameToColumn() matcher as the Kanban view to detect
  pre-existing equivalents (e.g. "Backlog" already covers To Do)
  so re-runs are safe.

Webhook subscriptions (scripts/asana-webhook-bootstrap.ts):
  Subscribes one Asana webhook per customer project pointing at
  /api/asana/webhook?workspaceGid=<gid> with filters limited to
  the four event types the brain dispatcher + comment skill
  router actually consume (task added, completed change,
  custom_fields change, comment_added story). Idempotent via
  GET /webhooks?workspace=<gid>. Validates HTTPS-only targets
  before POST. The receiver function already handles the
  X-Hook-Secret two-phase handshake — this script unblocks it.

One-shot orchestrator (scripts/asana-project-bootstrap.ts):
  Spawns the three steps in order with a pre-flight env-var
  check so we fail fast instead of half-bootstrapping the
  workspace. Wired as `npm run asana:bootstrap` (dry-run) and
  `npm run asana:bootstrap -- --apply` (mutate).

.env.example:
  Documents PEP_FLAG enum option GIDs, the new
  ASANA_CENTRAL_MLRO_PROJECT_GID and ASANA_AUDIT_LOG_PROJECT_GID
  cross-project mirror destinations, and PUBLIC_BASE_URL for the
  webhook bootstrap script.

package.json:
  Adds asana:bootstrap, asana:bootstrap:cf, asana:bootstrap:sections,
  asana:bootstrap:webhooks scripts so the operator (Luisa Fernanda,
  MLRO) can run them with `npm run`.

Regulatory basis: FDL No.10/2025 Art.20-21 (CO duty of care — every
Asana action visible), Art.24 (10yr retention — receiver writes every
verified delivery to audit blob), Cabinet Res 134/2025 Art.19
(internal review must be inspectable + bidirectionally synced).

https://claude.ai/code/session_01PhSnmzrBxwrhGkjzXqsfU2