### PR TITLE
Fix 5 test assertion bugs from PR #112 that broke main CI

### DIFF
--- a/tests/asanaCentralMlroMirror.test.ts
+++ b/tests/asanaCentralMlroMirror.test.ts
@@ -222,7 +222,14 @@ describe('buildCentralMlroTaskPayload', () => {
       entry: { ...baseEntry, caseId: 'CASE/7 [pep]', verdict: 'freeze' },
       projectGid: 'CENTRAL',
     });
-    expect(payload.name).not.toMatch(/[/\[\]]/);
+    // The literal unsafe input must NOT appear in the rendered
+    // name — slashes, embedded brackets, and spaces are sanitized.
+    // (We can't blanket-reject brackets because the [FREEZE] /
+    // [ESCALATE] / [BLOCKED] verdict prefixes legitimately
+    // contain them.)
+    expect(payload.name).not.toContain('CASE/7 [pep]');
+    expect(payload.name).not.toContain('CASE/7');
+    expect(payload.name).toContain('CASE_7__pep_');
   });
 
   it('formats errors and warnings as bullet lists in notes', () => {

--- a/tests/asanaInspectorMirror.test.ts
+++ b/tests/asanaInspectorMirror.test.ts
@@ -120,7 +120,7 @@ describe('buildInspectorTaskPayload', () => {
     expect(payload.notes).not.toContain('app.asana.com/0/0/');
   });
 
-  it('omits dispatcher warnings from inspector notes', () => {
+  it('omits dispatcher warnings from inspector notes (TBD canary stripped)', () => {
     const payload = buildInspectorTaskPayload({
       entry: {
         ...baseEntry,
@@ -129,8 +129,13 @@ describe('buildInspectorTaskPayload', () => {
       },
       projectGid: 'INSPECTOR',
     });
+    // The literal 'TBD' (which only appears in the warning string)
+    // is the canary — its absence proves the warning was stripped.
+    // Note: the inspector access-notes footer DOES use the word
+    // "drafting" in an explanatory sentence ("PII, internal MLRO
+    // drafting notes ... omitted") so we test for the leaked
+    // PAYLOAD content, not the explanatory footer word.
     expect(payload.notes).not.toContain('TBD');
-    expect(payload.notes).not.toContain('drafting');
   });
 
   it('omits the full machine-readable JSON dump (sanitised view)', () => {
@@ -214,7 +219,15 @@ describe('buildInspectorTaskPayload', () => {
       entry: { ...baseEntry, caseId: 'CASE/7 [pep]', verdict: 'freeze' },
       projectGid: 'INSPECTOR',
     });
-    expect(payload.name).not.toMatch(/[/\[\]]/);
+    // The literal unsafe input must NOT appear in the rendered
+    // name — slashes, embedded brackets, and spaces are sanitized.
+    // (We can't blanket-reject brackets because the [INSPECTOR]
+    // prefix legitimately contains them.)
+    expect(payload.name).not.toContain('CASE/7 [pep]');
+    expect(payload.name).not.toContain('CASE/7');
+    // The sanitized value (slashes/brackets/spaces → underscores)
+    // is what should appear instead.
+    expect(payload.name).toContain('CASE_7__pep_');
   });
 
   it('formats errors as a bullet list when present', () => {

--- a/tests/asanaPhase2.test.ts
+++ b/tests/asanaPhase2.test.ts
@@ -39,15 +39,15 @@ import { buildReadinessPayloads, EU_AI_ACT_DEADLINE } from '@/services/euAiActRe
 // ---------------------------------------------------------------------------
 
 describe('asana-cf-bootstrap field definitions', () => {
-  it('defines 7 canonical fields', () => {
-    expect(FIELDS.length).toBe(7);
+  it('defines 12 canonical fields (7 core + 4 CDD push + manual action chip)', () => {
+    expect(FIELDS.length).toBe(12);
   });
 
-  it('every enum field has at least 4 options', () => {
+  it('every enum field has at least 2 options (no degenerate single-option enums)', () => {
     for (const f of FIELDS) {
       if (f.type === 'enum') {
         expect(f.options).toBeDefined();
-        expect(f.options!.length).toBeGreaterThanOrEqual(4);
+        expect(f.options!.length).toBeGreaterThanOrEqual(2);
       }
     }
   });


### PR DESCRIPTION
## Summary

Unblocks `lint-and-test (20)` on `main` after PR #112 merged with 5 failing tests. **All 5 failures are bugs in the test assertions — the underlying production code (sanitisation, custom field provisioning, mirror filters) is correct and unchanged.**

3 files, 28 insertions, 8 deletions, zero production code changes.

## Failures fixed

| # | File:line | Bug | Fix |
|---|---|---|---|
| 1 | `asanaPhase2.test.ts:43` | `FIELDS.length === 7` but PR #112 added 5 new fields (customer_name, jurisdiction, ubo_count, pep_flag, manual_action) | `=== 12` |
| 2 | `asanaPhase2.test.ts:50` | `enum options >= 4` floor too strict — new PEP flag has 3 options, new manual_action has 2 | Relaxed to `>= 2` (only floor that prevents degenerate single-option enums) |
| 3 | `asanaInspectorMirror.test.ts:133` | `not.toContain('drafting')` matched the legitimate access-notes footer ("PII, internal MLRO drafting notes ... omitted") | Removed; TBD canary check (TBD only appears in the warning string) already proves the actual leaked content is stripped |
| 4 | `asanaInspectorMirror.test.ts:217` | `not.toMatch(/[/\[\]]/)` matched the `[INSPECTOR]` verdict prefix brackets | Replaced with explicit `not.toContain('CASE/7 [pep]')` + `not.toContain('CASE/7')` + `toContain('CASE_7__pep_')` |
| 5 | `asanaCentralMlroMirror.test.ts:225` | Same regex bug — matched `[FREEZE]` / `[ESCALATE]` / `[BLOCKED]` prefix brackets | Same fix |

## Why these slipped through

The cross-mirror integration test in PR #112 (`tests/dispatchMirrorIntegration.test.ts`, commit `4d16647`) caught the exact same bug class during its smoke test — I fixed those assertions there but missed the originals in the per-mirror test files. This commit catches up the per-mirror tests to the same correct pattern.

## Smoke-tested 13/13

```
━━━ Fix 1: FIELDS.length should be 12 ━━━
  ✓ FIELDS.length === 12
━━━ Fix 2: every enum has >= 2 options ━━━
  ✓ Risk level has 4 options (>=2)
  ✓ Brain verdict has 4 options (>=2)
  ✓ Deadline type has 6 options (>=2)
  ✓ PEP flag has 3 options (>=2)
  ✓ Awaiting Manual Action has 2 options (>=2)
━━━ Fix 3: inspector notes do not leak TBD canary ━━━
  ✓ TBD canary stripped from inspector notes
━━━ Fix 4: inspector sanitises CASE/7 [pep] correctly ━━━
    name = "[INSPECTOR] CASE_7__pep_ — freeze"
  ✓ does not contain literal CASE/7 [pep]
  ✓ does not contain CASE/7
  ✓ contains sanitised CASE_7__pep_
━━━ Fix 5: central MLRO sanitises CASE/7 [pep] correctly ━━━
    name = "[FREEZE] CASE_7__pep_ — done"
  ✓ does not contain literal CASE/7 [pep]
  ✓ does not contain CASE/7
  ✓ contains sanitised CASE_7__pep_
```

The rendered names prove the sanitisation is working correctly: the literal unsafe input is gone, the sanitized form is present, and the bracket prefix (`[INSPECTOR]` / `[FREEZE]`) is the verdict label, not a sanitisation failure.

## Test plan

- [ ] `npx vitest run tests/asanaPhase2.test.ts tests/asanaInspectorMirror.test.ts tests/asanaCentralMlroMirror.test.ts` — all green
- [ ] `npx vitest run` — full suite, no regressions to other test files
- [ ] CI `lint-and-test (20)` flips green
- [ ] Spot-check the rendered names against an inspector mirror task in staging once Asana is provisioned: confirm sanitised case ids land correctly

## Regulatory traceability

No production code changed — same regulatory citations as PR #112 apply. This is a pure test-suite repair to unblock main.

https://claude.ai/code/session_01PhSnmzrBxwrhGkjzXqsfU2