### PR TITLE
Fix setup wizard 503 — drop hk- prefix from brain token

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -54,7 +54,7 @@
     }
     var lines = [
       'ANTHROPIC_API_KEY=' + (state.anthropic || 'sk-ant-PASTE-YOURS'),
-      'HAWKEYE_BRAIN_TOKEN=hk-' + state.brainToken,
+      'HAWKEYE_BRAIN_TOKEN=' + state.brainToken,
       'HAWKEYE_ALLOWED_ORIGIN=' + (state.siteUrl || 'https://YOUR-SITE.netlify.app'),
       'HAWKEYE_CROSS_TENANT_SALT=v2026Q2-' + state.crossSalt,
       'ASANA_ACCESS_TOKEN=' + (state.asanaToken || '1/PASTE-YOURS'),
@@ -110,7 +110,7 @@
     }
     setStatus('verify-status', 'pending', 'Checking…');
     writeOutput('verify-output', 'Checking ' + state.siteUrl + ' …');
-    var token = 'hk-' + state.brainToken;
+    var token = state.brainToken;
     Promise.all([
       fetch(state.siteUrl + '/api/brain/diagnostics', {
         method: 'POST',
@@ -140,7 +140,7 @@
       return;
     }
     setStatus('cohort-status', 'pending', 'Uploading…');
-    var token = 'hk-' + state.brainToken;
+    var token = state.brainToken;
     fetch(state.siteUrl + '/api/setup/cohort-upload', {
       method: 'POST',
       headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json' },
@@ -166,7 +166,7 @@
       return;
     }
     setStatus('bootstrap-status', 'pending', 'Provisioning…');
-    var token = 'hk-' + state.brainToken;
+    var token = state.brainToken;
     fetch(state.siteUrl + '/api/setup/asana-bootstrap', {
       method: 'POST',
       headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Root cause

Step 6 Verify was returning `503` for **both** `brain-diagnostics` and `brain-health`. The brain-health endpoint we just merged has no `src/services` imports — it can't crash at module load — so the 503 had to come from somewhere else.

It comes from `netlify/functions/middleware/auth.mts` line 137:

```ts
if (!expected || expected.length < TOKEN_MIN_LENGTH || !/^[a-f0-9]+$/i.test(expected)) {
  return serverMisconfigured("Server authentication is not configured");  // → 503
}
```

The middleware requires `HAWKEYE_BRAIN_TOKEN` to be **pure hex** (≥32 chars). If the env var fails that check, every endpoint using `authenticate()` returns 503.

`setup.js` was writing the env var as `HAWKEYE_BRAIN_TOKEN=hk-<32 hex>` and sending the bearer as `hk-<32 hex>`. The `hk-` prefix broke the hex regex on **both** sides:

1. Server rejects its own env var as malformed → 503
2. Client bearer also fails the hex check → 401 (but the 503 fires first)

## Fix

Drop the `hk-` prefix. Write the env var as plain hex, send the bearer as plain hex. No code path in the codebase actually requires the `hk-` prefix — it was cosmetic and nobody told the auth middleware about it.

## Operator action required AFTER this deploys

1. Netlify → Site configuration → Environment variables → `HAWKEYE_BRAIN_TOKEN` → edit
2. Delete the leading `hk-` from the value (keep the 32 hex chars)
3. Save → Netlify auto-redeploys
4. Hard-refresh the setup wizard and click Verify again

## Regulatory basis
- FDL No.10/2025 Art.20-22 (CO visibility into system health)

## Test plan
- [ ] PR merges cleanly into main
- [ ] Netlify auto-deploys
- [ ] Operator updates `HAWKEYE_BRAIN_TOKEN` in Netlify env vars to strip `hk-` prefix
- [ ] Hard-refresh wizard → click Verify → `brain-health` returns 200 / "Live" ✓

https://claude.ai/code/session_01C6teuuVuxL5waAJJD3fBHs