### PR TITLE
Setup wizard — persist secrets in localStorage so refresh doesn't break the token

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -19,6 +19,49 @@
     siteUrl: '',
   };
 
+  // --- Persistence ---
+  // The wizard regenerates fresh tokens on every Generate click, but the
+  // Netlify env vars only get updated when the operator imports the env
+  // block. If the operator refreshes the wizard tab between Generate and
+  // the next deploy, the in-memory token is wiped and the new browser
+  // token no longer matches HAWKEYE_BRAIN_TOKEN → "Invalid token" 401.
+  //
+  // Persist the generated secrets in localStorage so they survive
+  // refreshes. The stored token only ever changes when the operator
+  // explicitly clicks Generate again, so as long as they sync once,
+  // every subsequent click of Verify / Upload / Bootstrap works.
+  //
+  // localStorage is same-origin, never sent over the network, and the
+  // wizard is operator-only behind /setup.html which has noindex/nofollow.
+  var STORAGE_KEY = 'hawkeye-setup-wizard-v1';
+
+  function saveState() {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({
+        brainToken: state.brainToken,
+        crossSalt: state.crossSalt,
+        jwtSecret: state.jwtSecret,
+        bcryptPepper: state.bcryptPepper,
+      }));
+    } catch (_) { /* localStorage may be disabled — fail silent */ }
+  }
+
+  function loadState() {
+    try {
+      var raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return false;
+      var saved = JSON.parse(raw);
+      if (saved && typeof saved.brainToken === 'string' && saved.brainToken) {
+        state.brainToken = saved.brainToken;
+        state.crossSalt = saved.crossSalt || '';
+        state.jwtSecret = saved.jwtSecret || '';
+        state.bcryptPepper = saved.bcryptPepper || '';
+        return true;
+      }
+    } catch (_) { /* corrupt JSON — ignore */ }
+    return false;
+  }
+
   // --- Helpers ---
   function randHex(bytes) {
     var arr = new Uint8Array(bytes);
@@ -92,6 +135,7 @@
     state.crossSalt = randHex(16);
     state.jwtSecret = randHex(32);
     state.bcryptPepper = randHex(16);
+    saveState();
     setStatus('generate-status', 'ok', 'Generated');
     readInputs();
     renderEnvBlock();
@@ -210,5 +254,17 @@
     byId('link-brain').textContent = '→ Open Brain Console at ' + base;
     byId('link-status').href = base + '/status.html';
     byId('link-status').textContent = '→ Public status page at ' + base + '/status.html';
+  }
+
+  // --- Init ---
+  // Restore previously generated secrets from localStorage so the
+  // operator can refresh the wizard tab without losing the in-memory
+  // token (which would otherwise stop matching Netlify's
+  // HAWKEYE_BRAIN_TOKEN env var until they re-imported the env block).
+  if (loadState()) {
+    setStatus('generate-status', 'ok', 'Restored from previous session');
+    readInputs();
+    renderEnvBlock();
+    updateLinks();
   }
 })();


### PR DESCRIPTION
## Root cause of the recurring "Invalid token" 401

The setup wizard was catastrophically fragile around page reloads.

**The flow that broke:**
1. Operator clicks **🎲 Generate secrets** → fresh random hex stored only in `state.brainToken` (memory)
2. Copies env block, pastes into Netlify, waits ~2 min for redeploy
3. Goes back to the wizard tab and... at any point hits Refresh
4. Page reloads → `state.brainToken` is now empty
5. Clicks **Verify** or **Upload cohort** — but the wizard either generates a *new* random token or sends nothing
6. Server compares against the OLD token from Netlify → mismatch → **`{"error": "Invalid token"}` 401**

The operator had no way to know that refreshing the tab broke the deployment. They'd been hitting this loop repeatedly.

## Fix

Persist the four generated secrets in `localStorage` on every Generate, restore them on page load.

Now:
1. Operator clicks **Generate** **ONCE** → token written to `localStorage`
2. Copies env block, imports to Netlify, waits for redeploy
3. **Free to refresh the wizard tab as many times as they want**
4. Every refresh restores the same token from `localStorage`
5. Verify/Upload/Bootstrap keep working until the operator explicitly clicks Generate again

UX bonus: on restore, the Generate status pill says **"Restored from previous session"** so the operator knows the wizard remembered them.

## Security

- `localStorage` is same-origin, never sent over the network
- `/setup.html` has `<meta name="robots" content="noindex,nofollow">` and is operator-only
- The persisted token is the same token already in the Netlify env var — there is no NEW exposure surface
- Storage key is versioned (`hawkeye-setup-wizard-v1`) so future schema changes can invalidate cleanly

## Regulatory basis
- FDL No.10/2025 Art.20-22 (CO operability of compliance tooling)

## Test plan
- [ ] Merge → Netlify auto-deploys
- [ ] Hard-refresh wizard
- [ ] Notice it doesn't auto-restore (no localStorage data yet)
- [ ] Click Generate once → status says "Generated"
- [ ] Refresh wizard
- [ ] Status pill should now say "Restored from previous session"
- [ ] Click Verify → returns 200 (token matches Netlify)
- [ ] Click Upload cohort → returns `{ok: true, imported: 2, ...}`

https://claude.ai/code/session_01C6teuuVuxL5waAJJD3fBHs