### PR TITLE
Fix Asana tenant bootstrap — invalid color, missing precision, wrong webhook URL

### DIFF
--- a/netlify/functions/setup-asana-bootstrap.mts
+++ b/netlify/functions/setup-asana-bootstrap.mts
@@ -134,23 +134,34 @@ function makeAsanaDispatcher(accessToken: string): AsanaProvisionDispatcher {
       const match = existing.find((f) => f.name === field.name);
       if (match) return { fieldGid: match.gid, created: false };
 
+      // Build the data payload — the shape depends on the field type.
+      // Asana rejects unrecognised colors (e.g. `light-gray`) with 403,
+      // and rejects number fields without `precision` with 400 — so we
+      // omit color entirely (Asana picks a default) and always pass
+      // precision for number fields.
+      const data: Record<string, unknown> = {
+        workspace: workspaceGid,
+        name: field.name,
+        resource_subtype: mapFieldType(field),
+      };
+      if (field.type === 'enum') {
+        data.enum_options = (field.enumValues ?? []).map((v) => ({
+          name: v,
+          // Use 'cool-gray' — the only neutral gray Asana actually
+          // accepts. Omitting color entirely also works but the API
+          // is undocumented on what it picks; cool-gray is explicit.
+          color: 'cool-gray',
+        }));
+      } else if (field.type === 'number') {
+        // Asana requires precision (decimal places) on number fields.
+        // 2 covers Confidence (0.00..1.00) and Power Score (0.00..100.00)
+        // and any other 2-decimal metric we currently use.
+        data.precision = 2;
+      }
+
       const created = await asanaRequest<{ gid: string }>('/custom_fields', {
         method: 'POST',
-        body: JSON.stringify({
-          data: {
-            workspace: workspaceGid,
-            name: field.name,
-            resource_subtype: mapFieldType(field),
-            ...(field.type === 'enum'
-              ? {
-                  enum_options: (field.enumValues ?? []).map((v) => ({
-                    name: v,
-                    color: 'light-gray',
-                  })),
-                }
-              : {}),
-          },
-        }),
+        body: JSON.stringify({ data }),
       });
       return { fieldGid: created.gid, created: true };
     },
@@ -272,8 +283,15 @@ export default async (req: Request, context: Context): Promise<Response> => {
 
   const accessToken = process.env.ASANA_ACCESS_TOKEN;
   const workspaceGid = process.env.ASANA_WORKSPACE_GID;
-  const webhookTarget =
-    (process.env.HAWKEYE_ALLOWED_ORIGIN ?? '') + '/api/asana-webhook';
+  // The receiver function lives at /api/asana/webhook (see
+  // netlify/functions/asana-webhook.mts) and expects ?workspaceGid=<gid>
+  // as a query param so it can look up the right webhook secret per
+  // workspace. The previous /api/asana-webhook URL was a 404 →
+  // Asana's handshake POST got 404 → registration failed.
+  const origin = (process.env.HAWKEYE_ALLOWED_ORIGIN ?? '').replace(/\/+$/, '');
+  const webhookTarget = workspaceGid
+    ? `${origin}/api/asana/webhook?workspaceGid=${encodeURIComponent(workspaceGid)}`
+    : `${origin}/api/asana/webhook`;
 
   if (!accessToken || accessToken.length < 16) {
     return jsonResponse(


### PR DESCRIPTION
## Diagnosed from a real wizard run

The operator's Step 8 Bootstrap on `tenant-a` reported `0 created, 23 reused, 8 failed`. Drilling into the JSON `steps[]` array revealed 3 distinct bugs causing all 8 failures.

**Operator's plan**: Asana **Starter** ($10.99/seat/mo) — confirmed paid plan, custom fields and webhooks both supported. So none of this is an Asana plan limit.

## Bug 1 — Invalid enum option color `light-gray` (3 customField failures)

`Brain Verdict`, `Four-Eyes Role`, `Four-Eyes Decision` all failed with:

```
Asana POST /custom_fields → 403:
{"error":"enum_option_invalid_color","message":"Invalid enum option color: light-gray"}
```

`light-gray` is not in Asana's enum-option color palette. The closest neutral gray Asana actually accepts is **`cool-gray`**.

**Fix**: send `cool-gray` for every enum option.

## Bug 2 — Missing `precision` on number fields (4 customField failures)

`Confidence`, `Power Score`, `Uncertainty Lower`, `Uncertainty Upper` all failed with:

```
Asana POST /custom_fields → 400:
{"message":"precision: Missing input"}
```

Asana requires `precision` (0..6 decimal places) on every number-type custom field.

**Fix**: always include `precision: 2` for number fields. 2 covers `Confidence` (0.00..1.00) and `Power Score` (0.00..100.00) and the uncertainty bands.

**Refactor**: build the data payload as a typed object with explicit type-specific branches instead of the previous spread-conditional, so adding per-type fields like `precision` is straightforward.

## Bug 3 — Wrong webhook target URL (1 webhook failure)

The bootstrap was telling Asana to register a webhook pointing at `<origin>/api/asana-webhook`. That endpoint **does not exist**. The actual receiver function is registered at **`/api/asana/webhook`** (see `netlify/functions/asana-webhook.mts:249`).

The receiver also expects `?workspaceGid=<gid>` as a query param because Asana scopes webhook secrets per workspace.

```
Asana POST /webhooks → 400:
{"message":"The remote server which is intended to receive the webhook responded with an incorrect status code: 404"}
```

**Fix**: build the target as
```
<origin>/api/asana/webhook?workspaceGid=<workspaceGid>
```

## Expected outcome after merge

Re-running the wizard's Bootstrap Asana button on the same tenant should now report `8 created, 23 reused, 0 failed` and `webhookGid: "<some-gid>"` instead of `null`.

## Regulatory basis
- FDL No.10/2025 Art.20-22 (CO visibility into provisioning)
- FDL No.10/2025 Art.24 (provisioning audit trail)
- Cabinet Res 134/2025 Art.12-14 (CDD operational tooling)
- Cabinet Res 134/2025 Art.19 (internal review readiness)
- Cabinet Res 74/2020 Art.4-7 (asset freeze workflow paths)

## Test plan
- [ ] Merge → Netlify auto-deploys
- [ ] Hard-refresh wizard
- [ ] Click Bootstrap Asana tenant on `tenant-a` (idempotent — safe to re-run)
- [ ] Output should show all 31 steps with `ok: true`
- [ ] `webhookGid` should be a non-null string
- [ ] Asana → tenant-a project → check that all 15 custom fields appear in the field library
- [ ] Asana → workspace settings → webhooks → confirm the new webhook is listed and active

https://claude.ai/code/session_01C6teuuVuxL5waAJJD3fBHs