### PR TITLE
Always refresh watchlist after token validation

### DIFF
--- a/watchlist-admin.html
+++ b/watchlist-admin.html
@@ -296,6 +296,6 @@
     FATF Rec 10 · Cabinet Res 134/2025 Art.19 · FDL Art.24
   </p>
 
-  <script src="watchlist-admin.js?v=3">
+  <script src="watchlist-admin.js?v=4"></script>
 </body>
 </html>

--- a/watchlist-admin.js
+++ b/watchlist-admin.js
@@ -409,11 +409,12 @@
 
   // On initial load: if a token is already saved from a previous session,
   // auto-validate it so the user immediately sees whether it still works.
-  // Otherwise just refresh the list (which will show the "token required"
-  // message if no token is set).
+  // Always refresh the list afterwards — even on validation failure —
+  // so the stat box never sits on its HTML default "—" and the user
+  // gets an actionable error instead of a silent-looking page.
   if (tokenInput.value.trim()) {
-    validateToken().then(function (ok) {
-      if (ok) refreshList();
+    validateToken().finally(function () {
+      refreshList();
     });
   } else {
     refreshList();


### PR DESCRIPTION
## Summary
Modified the token validation flow to always refresh the watchlist, even when validation fails. This ensures users receive actionable feedback instead of a silent error state.

## Key Changes
- Changed `validateToken().then()` to `validateToken().finally()` to guarantee list refresh regardless of validation outcome
- Updated error handling logic to refresh the list on both success and failure cases
- Updated script version cache-buster from v3 to v4

## Implementation Details
Previously, the watchlist would only refresh if token validation succeeded (`if (ok) refreshList()`). This meant validation failures would leave the stat box displaying its HTML default "—" without any error message, creating a confusing user experience.

Now, `finally()` ensures `refreshList()` executes after validation completes, whether successful or not. This allows the UI to display appropriate error messages (like "token required") rather than appearing unresponsive.

https://claude.ai/code/session_01DvYeQDC6tAbnGjFsg4o1VK