### PR TITLE
Retire compliance-analyzer.netlify.app; canonicalize hawkeye-sterling-v2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,7 +142,7 @@ ASANA_INSPECTOR_TEAM_GID=
 # Public base URL of the deployed analyzer — used by
 # `npm run asana:bootstrap:webhooks` to compute the receiver target.
 # If unset, the webhook bootstrap falls back to HAWKEYE_BRAIN_URL.
-PUBLIC_BASE_URL=https://compliance-analyzer.netlify.app
+PUBLIC_BASE_URL=https://hawkeye-sterling-v2.netlify.app
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -179,7 +179,7 @@ HAWKEYE_SOLO_MLRO_COOLDOWN_HOURS=24
 AUTH_SIGNING_SECRET=your-random-32-byte-hex-secret
 
 # Public URL of the deployed brain endpoint.
-HAWKEYE_BRAIN_URL=https://compliance-analyzer.netlify.app
+HAWKEYE_BRAIN_URL=https://hawkeye-sterling-v2.netlify.app
 
 # [REQUIRED FOR /api/brain/zk-cross-tenant] Shared salt used by the
 # zk cross-tenant attestation module. This salt is NOT a secret —

--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -10,7 +10,7 @@ name: Run Managed Agent
 #   HAWKEYE_BRAIN_TOKEN   — same value that's set in Netlify env vars
 #
 # Optional secrets:
-#   HAWKEYE_BRAIN_URL     — defaults to https://compliance-analyzer.netlify.app
+#   HAWKEYE_BRAIN_URL     — defaults to https://hawkeye-sterling-v2.netlify.app
 #   CACHET_BASE_URL       — if you want Cachet publishing
 #   CACHET_API_TOKEN      — pair with CACHET_BASE_URL
 #
@@ -63,7 +63,7 @@ jobs:
         id: run
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          HAWKEYE_BRAIN_URL: ${{ secrets.HAWKEYE_BRAIN_URL || 'https://compliance-analyzer.netlify.app' }}
+          HAWKEYE_BRAIN_URL: ${{ secrets.HAWKEYE_BRAIN_URL || 'https://hawkeye-sterling-v2.netlify.app' }}
           HAWKEYE_BRAIN_TOKEN: ${{ secrets.HAWKEYE_BRAIN_TOKEN }}
           CACHET_BASE_URL: ${{ secrets.CACHET_BASE_URL }}
           CACHET_API_TOKEN: ${{ secrets.CACHET_API_TOKEN }}

--- a/.github/workflows/autopilot.yml
+++ b/.github/workflows/autopilot.yml
@@ -49,7 +49,7 @@ jobs:
           # Brain HTTP endpoint — autopilot posts each critical alert
           # to /api/brain for persistent routing + agent consumption.
           # Skipped silently if either var is unset.
-          HAWKEYE_BRAIN_URL: ${{ secrets.HAWKEYE_BRAIN_URL || 'https://compliance-analyzer.netlify.app' }}
+          HAWKEYE_BRAIN_URL: ${{ secrets.HAWKEYE_BRAIN_URL || 'https://hawkeye-sterling-v2.netlify.app' }}
           HAWKEYE_BRAIN_TOKEN: ${{ secrets.HAWKEYE_BRAIN_TOKEN }}
           # Cachet status page — publish CRITICAL alerts if configured.
           CACHET_BASE_URL: ${{ secrets.CACHET_BASE_URL }}

--- a/.github/workflows/lbma-audit-pack.yml
+++ b/.github/workflows/lbma-audit-pack.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Generate LBMA audit pack
         env:
-          HAWKEYE_BRAIN_URL: ${{ secrets.HAWKEYE_BRAIN_URL || 'https://compliance-analyzer.netlify.app' }}
+          HAWKEYE_BRAIN_URL: ${{ secrets.HAWKEYE_BRAIN_URL || 'https://hawkeye-sterling-v2.netlify.app' }}
           HAWKEYE_BRAIN_TOKEN: ${{ secrets.HAWKEYE_BRAIN_TOKEN }}
         run: |
           mkdir -p history/lbma

--- a/.github/workflows/regulatory-watcher.yml
+++ b/.github/workflows/regulatory-watcher.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run regulatory watcher
         env:
-          HAWKEYE_BRAIN_URL: ${{ secrets.HAWKEYE_BRAIN_URL || 'https://compliance-analyzer.netlify.app' }}
+          HAWKEYE_BRAIN_URL: ${{ secrets.HAWKEYE_BRAIN_URL || 'https://hawkeye-sterling-v2.netlify.app' }}
           HAWKEYE_BRAIN_TOKEN: ${{ secrets.HAWKEYE_BRAIN_TOKEN }}
         run: |
           mkdir -p artifacts data

--- a/.github/workflows/rotate-brain-token.yml
+++ b/.github/workflows/rotate-brain-token.yml
@@ -64,7 +64,7 @@ jobs:
             echo "   value above → **Update secret**."
             echo
             echo "2. **Netlify env var** —"
-            echo "   https://app.netlify.com/sites/compliance-analyzer/configuration/env"
+            echo "   https://app.netlify.com/sites/hawkeye-sterling-v2/configuration/env"
             echo "   Find \`HAWKEYE_BRAIN_TOKEN\` → click Options → **Edit**"
             echo "   → paste the value → **Save**. Then go to the Deploys"
             echo "   tab and click **Trigger deploy → Deploy site** so"

--- a/.github/workflows/scheduled-screening.yml
+++ b/.github/workflows/scheduled-screening.yml
@@ -30,7 +30,7 @@ name: Scheduled Screening — Twice Daily
 #   ASANA_DEFAULT_ASSIGNEE_NAME   = Luisa Fernanda
 #
 # Optional variable (in the Variables tab — or also set as a secret, same effect):
-#   HAWKEYE_BRAIN_URL             defaults to compliance-analyzer.netlify.app
+#   HAWKEYE_BRAIN_URL             defaults to hawkeye-sterling-v2.netlify.app
 #
 # Regulatory basis:
 #   - FATF Rec 10 (ongoing customer due diligence)
@@ -85,8 +85,8 @@ jobs:
       - name: Run scheduled screening
         env:
           # Endpoint URL — reads from vars first (non-sensitive) with a
-          # safe default for compliance-analyzer.netlify.app.
-          HAWKEYE_BRAIN_URL: ${{ vars.HAWKEYE_BRAIN_URL || 'https://compliance-analyzer.netlify.app' }}
+          # safe default for hawkeye-sterling-v2.netlify.app.
+          HAWKEYE_BRAIN_URL: ${{ vars.HAWKEYE_BRAIN_URL || 'https://hawkeye-sterling-v2.netlify.app' }}
           # All other config read from secrets.* regardless of whether
           # the value is technically sensitive. This keeps setup simple
           # — you only touch ONE tab in GitHub Actions settings.

--- a/SETUP.md
+++ b/SETUP.md
@@ -18,7 +18,7 @@ The wizard:
 
 ```bash
 npx netlify-cli login        # browser opens → click Authorize
-npx netlify-cli link         # pick the compliance-analyzer site
+npx netlify-cli link         # pick the hawkeye-sterling-v2 site
 npx netlify-cli env:import .env
 ```
 
@@ -33,7 +33,7 @@ git commit --allow-empty -m "redeploy with new env vars" && git push
 ## Verify it's alive
 
 ```bash
-curl https://compliance-analyzer.netlify.app/.netlify/functions/asana-super-brain-autopilot-cron
+curl https://hawkeye-sterling-v2.netlify.app/.netlify/functions/asana-super-brain-autopilot-cron
 ```
 
 Expected response: `{"ok":true,"dispatched":N,...}`

--- a/agents/README.md
+++ b/agents/README.md
@@ -52,7 +52,7 @@ The install script:
 ```bash
 # Orchestrator env vars — host-side only, never mounted to the agent
 export ANTHROPIC_API_KEY=sk-ant-...
-export HAWKEYE_BRAIN_URL=https://compliance-analyzer.netlify.app
+export HAWKEYE_BRAIN_URL=https://hawkeye-sterling-v2.netlify.app
 export HAWKEYE_BRAIN_TOKEN=<32+ hex bearer token>
 export CACHET_BASE_URL=https://status.example.com   # optional
 export CACHET_API_TOKEN=<from Cachet Settings>       # optional

--- a/agents/incident-commander.yml
+++ b/agents/incident-commander.yml
@@ -233,7 +233,7 @@ skills:
 # orchestrator (scripts/agent-orchestrator.mjs) forwards them with auth.
 #
 #   ANTHROPIC_API_KEY      — to create agents, environments, sessions
-#   HAWKEYE_BRAIN_URL      — e.g. https://compliance-analyzer.netlify.app
+#   HAWKEYE_BRAIN_URL      — e.g. https://hawkeye-sterling-v2.netlify.app
 #   HAWKEYE_BRAIN_TOKEN    — 32+ hex-char bearer token for /api/brain
 #   CACHET_BASE_URL        — https://status.example.com
 #   CACHET_API_TOKEN       — Cachet UI → Settings → API

--- a/asana-workflow/SETUP_CHECKLIST.md
+++ b/asana-workflow/SETUP_CHECKLIST.md
@@ -110,7 +110,7 @@ Each project needs a webhook pointing at our webhook receiver:
 ```bash
 node scripts/asana-webhook-bootstrap.ts \
   --project $PROJECT_GID \
-  --target https://compliance-analyzer.netlify.app/api/asana-webhook
+  --target https://hawkeye-sterling-v2.netlify.app/api/asana-webhook
 ```
 
 The bootstrap script:
@@ -200,7 +200,7 @@ netlify functions:list --site $SITE_ID | grep cron
 Once everything is provisioned, run the smoke test:
 
 ```bash
-BASE_URL=https://compliance-analyzer.netlify.app \
+BASE_URL=https://hawkeye-sterling-v2.netlify.app \
 TENANT_ID=tenant-a \
   npm run smoke:asana
 ```

--- a/asana-workflow/WEBHOOKS.md
+++ b/asana-workflow/WEBHOOKS.md
@@ -17,7 +17,7 @@ Configured in Asana via:
 curl -X POST https://app.asana.com/api/1.0/webhooks \
   -H "Authorization: Bearer $ASANA_ACCESS_TOKEN" \
   -F "resource=$ASANA_WORKSPACE_GID" \
-  -F "target=https://compliance-analyzer.netlify.app/api/asana-webhook"
+  -F "target=https://hawkeye-sterling-v2.netlify.app/api/asana-webhook"
 ```
 
 ---

--- a/hawkeye-sterling-v2/DEPLOY_CHECKLIST.md
+++ b/hawkeye-sterling-v2/DEPLOY_CHECKLIST.md
@@ -193,7 +193,7 @@ root cause per CLAUDE.md §9.
 After Netlify reports a successful deploy, run the smoke suite:
 
 ```bash
-BASE_URL=https://compliance-analyzer.netlify.app \
+BASE_URL=https://hawkeye-sterling-v2.netlify.app \
   npm run smoke
 ```
 
@@ -219,7 +219,7 @@ netlify deploy:list --site $SITE_ID | head -5
 netlify rollback --site $SITE_ID --deploy <good-deploy-id>
 
 # Verify
-curl -fsSL https://compliance-analyzer.netlify.app/ > /dev/null
+curl -fsSL https://hawkeye-sterling-v2.netlify.app/ > /dev/null
 ```
 
 Rollback never resets blob state — only the function code. So a

--- a/hawkeye-sterling-v2/ENDPOINTS.md
+++ b/hawkeye-sterling-v2/ENDPOINTS.md
@@ -7,7 +7,7 @@ All endpoints share:
 - CORS origin via `HAWKEYE_ALLOWED_ORIGIN`
 - Strict input validation (each endpoint exports `__test__.validate`)
 
-Base URL: `https://compliance-analyzer.netlify.app`
+Base URL: `https://hawkeye-sterling-v2.netlify.app`
 
 ---
 

--- a/integrations/postman/hawkeye-brain.postman_collection.json
+++ b/integrations/postman/hawkeye-brain.postman_collection.json
@@ -5,7 +5,7 @@
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "variable": [
-    { "key": "baseUrl", "value": "https://compliance-analyzer.netlify.app", "type": "string" },
+    { "key": "baseUrl", "value": "https://hawkeye-sterling-v2.netlify.app", "type": "string" },
     { "key": "HAWKEYE_BRAIN_TOKEN", "value": "hk-brain-<replace-me>", "type": "string" },
     { "key": "tenantId", "value": "tenant-a", "type": "string" }
   ],

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,26 @@
 [build]
   publish = "."
   command = "echo deploy-v3.0-enhancements"
+  # Deploy-preview deduplication.
+  #
+  # This repo is linked to two Netlify sites:
+  #   1. "compliance-analyzer"  — legacy site, still the production
+  #      brain backend referenced by .github/workflows/*.yml
+  #      (autopilot, agent-run, regulatory-watcher, scheduled-screening,
+  #      lbma-audit-pack) via https://compliance-analyzer.netlify.app
+  #   2. "hawkeye-sterling-v2"  — current site, the canonical UI target
+  #
+  # Before this rule, every PR posted two deploy-preview comments
+  # (one per site) which was noisy. We cannot unlink the legacy site
+  # without breaking the GitHub workflows that hit its production URL,
+  # so we keep the site linked but suppress only its deploy-preview
+  # builds. Production (CONTEXT=production) and branch deploys
+  # (CONTEXT=branch-deploy) on either site are unaffected.
+  #
+  # Netlify ignore command: exit 0 = cancel the build, exit 1 = proceed.
+  # Both SITE_NAME and CONTEXT are read-only env vars injected by
+  # Netlify (see https://docs.netlify.com/configure-builds/environment-variables/).
+  ignore = "if [ \"$CONTEXT\" = \"deploy-preview\" ] && [ \"$SITE_NAME\" = \"compliance-analyzer\" ]; then echo 'skipping duplicate deploy-preview on legacy compliance-analyzer site'; exit 0; else exit 1; fi"
 
 [build.environment]
   # Exclude vendored third-party reference code from secrets scanning.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,21 +1,24 @@
 [build]
   publish = "."
   command = "echo deploy-v3.0-enhancements"
-  # Deploy-preview deduplication.
+  # Deploy-preview deduplication (belt-and-braces safety net).
   #
-  # This repo is linked to two Netlify sites:
-  #   1. "compliance-analyzer"  — legacy site, still the production
-  #      brain backend referenced by .github/workflows/*.yml
-  #      (autopilot, agent-run, regulatory-watcher, scheduled-screening,
-  #      lbma-audit-pack) via https://compliance-analyzer.netlify.app
-  #   2. "hawkeye-sterling-v2"  — current site, the canonical UI target
+  # Canonical site: "hawkeye-sterling-v2" (hawkeye-sterling-v2.netlify.app).
+  # All code, workflows, docs, and env var defaults have been migrated to
+  # this site. The legacy "compliance-analyzer" and "hawkeye-sterling"
+  # Netlify sites are expected to be blocked ("Stop builds") in the
+  # Netlify dashboard after merge.
   #
-  # Before this rule, every PR posted two deploy-preview comments
-  # (one per site) which was noisy. We cannot unlink the legacy site
-  # without breaking the GitHub workflows that hit its production URL,
-  # so we keep the site linked but suppress only its deploy-preview
-  # builds. Production (CONTEXT=production) and branch deploys
-  # (CONTEXT=branch-deploy) on either site are unaffected.
+  # This ignore rule is a second line of defense: if someone ever
+  # re-enables builds on the legacy "compliance-analyzer" site in the
+  # dashboard by mistake, it will still skip deploy-preview builds so
+  # PRs only post one preview comment. Production (CONTEXT=production)
+  # and branch deploys (CONTEXT=branch-deploy) are unaffected — they
+  # pass through and build normally, which is what you want while the
+  # legacy site is being decommissioned.
+  #
+  # Once the legacy site is fully deleted in the Netlify dashboard,
+  # this rule becomes a no-op and can be removed in a follow-up.
   #
   # Netlify ignore command: exit 0 = cancel the build, exit 1 = proceed.
   # Both SITE_NAME and CONTEXT are read-only env vars injected by

--- a/netlify/functions/approvals.mts
+++ b/netlify/functions/approvals.mts
@@ -62,7 +62,7 @@ function getSoloMlroCooldownHours(): number {
 
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin":
-    process.env.HAWKEYE_ALLOWED_ORIGIN ?? "https://compliance-analyzer.netlify.app",
+    process.env.HAWKEYE_ALLOWED_ORIGIN ?? "https://hawkeye-sterling-v2.netlify.app",
   "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
   "Access-Control-Allow-Headers": "Authorization, Content-Type",
   "Access-Control-Max-Age": "600",

--- a/netlify/functions/brain-analyze.mts
+++ b/netlify/functions/brain-analyze.mts
@@ -76,7 +76,7 @@ import { CaseReplayStore } from '../../src/services/caseReplayStore';
 const anthropicAdvisor = createAnthropicAdvisor({
   proxyUrl:
     (typeof process !== 'undefined' && process.env?.HAWKEYE_AI_PROXY_URL) ||
-    'https://compliance-analyzer.netlify.app/api/ai-proxy',
+    'https://hawkeye-sterling-v2.netlify.app/api/ai-proxy',
   bearerToken: typeof process !== 'undefined' ? process.env?.HAWKEYE_BRAIN_TOKEN : undefined,
 });
 
@@ -197,7 +197,7 @@ async function ensureTenantHydrated(tenantId: string): Promise<void> {
 
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin':
-    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://compliance-analyzer.netlify.app',
+    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://hawkeye-sterling-v2.netlify.app',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
   'Access-Control-Allow-Headers': 'Authorization, Content-Type',
   'Access-Control-Max-Age': '600',

--- a/netlify/functions/brain-break-glass.mts
+++ b/netlify/functions/brain-break-glass.mts
@@ -32,7 +32,7 @@ import { orchestrator as defaultOrchestrator } from '../../src/services/asana/or
 
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin':
-    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://compliance-analyzer.netlify.app',
+    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://hawkeye-sterling-v2.netlify.app',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
   'Access-Control-Allow-Headers': 'Authorization, Content-Type',
   'Access-Control-Max-Age': '600',

--- a/netlify/functions/brain-clamp-suggestion.mts
+++ b/netlify/functions/brain-clamp-suggestion.mts
@@ -36,7 +36,7 @@ import { orchestrator as defaultOrchestrator } from '../../src/services/asana/or
 
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin':
-    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://compliance-analyzer.netlify.app',
+    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://hawkeye-sterling-v2.netlify.app',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
   'Access-Control-Allow-Headers': 'Authorization, Content-Type',
   'Access-Control-Max-Age': '600',

--- a/netlify/functions/brain-correlate.mts
+++ b/netlify/functions/brain-correlate.mts
@@ -42,7 +42,7 @@ import { lintForTippingOff } from "../../src/services/tippingOffLinter";
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin":
     process.env.HAWKEYE_ALLOWED_ORIGIN ??
-    "https://compliance-analyzer.netlify.app",
+    "https://hawkeye-sterling-v2.netlify.app",
   "Access-Control-Allow-Methods": "POST, OPTIONS",
   "Access-Control-Allow-Headers": "Authorization, Content-Type",
   "Access-Control-Max-Age": "600",

--- a/netlify/functions/brain-diagnostics.mts
+++ b/netlify/functions/brain-diagnostics.mts
@@ -75,7 +75,7 @@ const ENSEMBLE_DEFAULT_RUNS = 5;
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin":
     process.env.HAWKEYE_ALLOWED_ORIGIN ??
-    "https://compliance-analyzer.netlify.app",
+    "https://hawkeye-sterling-v2.netlify.app",
   "Access-Control-Allow-Methods": "POST, OPTIONS",
   "Access-Control-Allow-Headers": "Authorization, Content-Type",
   "Access-Control-Max-Age": "600",

--- a/netlify/functions/brain-evidence-bundle.mts
+++ b/netlify/functions/brain-evidence-bundle.mts
@@ -44,7 +44,7 @@ import { createNetlifyBlobHandle } from '../../src/services/brainMemoryBlobStore
 
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin':
-    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://compliance-analyzer.netlify.app',
+    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://hawkeye-sterling-v2.netlify.app',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
   'Access-Control-Allow-Headers': 'Authorization, Content-Type',
   'Access-Control-Max-Age': '600',

--- a/netlify/functions/brain-health.mts
+++ b/netlify/functions/brain-health.mts
@@ -27,7 +27,7 @@ import { authenticate } from './middleware/auth.mts';
 
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin':
-    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://compliance-analyzer.netlify.app',
+    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://hawkeye-sterling-v2.netlify.app',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
   'Access-Control-Allow-Headers': 'Authorization, Content-Type',
   'Access-Control-Max-Age': '600',

--- a/netlify/functions/brain-hydrate.mts
+++ b/netlify/functions/brain-hydrate.mts
@@ -39,7 +39,7 @@ import {
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin":
     process.env.HAWKEYE_ALLOWED_ORIGIN ??
-    "https://compliance-analyzer.netlify.app",
+    "https://hawkeye-sterling-v2.netlify.app",
   "Access-Control-Allow-Methods": "POST, OPTIONS",
   "Access-Control-Allow-Headers": "Authorization, Content-Type",
   "Access-Control-Max-Age": "600",

--- a/netlify/functions/brain-outbound-queue.mts
+++ b/netlify/functions/brain-outbound-queue.mts
@@ -31,7 +31,7 @@ import { createNetlifyBlobHandle } from '../../src/services/brainMemoryBlobStore
 
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin':
-    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://compliance-analyzer.netlify.app',
+    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://hawkeye-sterling-v2.netlify.app',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
   'Access-Control-Allow-Headers': 'Authorization, Content-Type',
   'Access-Control-Max-Age': '600',

--- a/netlify/functions/brain-replay.mts
+++ b/netlify/functions/brain-replay.mts
@@ -45,7 +45,7 @@ import { createNetlifyBlobHandle } from '../../src/services/brainMemoryBlobStore
 
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin':
-    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://compliance-analyzer.netlify.app',
+    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://hawkeye-sterling-v2.netlify.app',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
   'Access-Control-Allow-Headers': 'Authorization, Content-Type',
   'Access-Control-Max-Age': '600',

--- a/netlify/functions/brain-telemetry.mts
+++ b/netlify/functions/brain-telemetry.mts
@@ -37,7 +37,7 @@ import { createNetlifyBlobHandle } from "../../src/services/brainMemoryBlobStore
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin":
     process.env.HAWKEYE_ALLOWED_ORIGIN ??
-    "https://compliance-analyzer.netlify.app",
+    "https://hawkeye-sterling-v2.netlify.app",
   "Access-Control-Allow-Methods": "POST, OPTIONS",
   "Access-Control-Allow-Headers": "Authorization, Content-Type",
   "Access-Control-Max-Age": "600",

--- a/netlify/functions/brain-zk-cross-tenant.mts
+++ b/netlify/functions/brain-zk-cross-tenant.mts
@@ -37,7 +37,7 @@ import { createNetlifyBlobHandle } from '../../src/services/brainMemoryBlobStore
 
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin':
-    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://compliance-analyzer.netlify.app',
+    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://hawkeye-sterling-v2.netlify.app',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
   'Access-Control-Allow-Headers': 'Authorization, Content-Type',
   'Access-Control-Max-Age': '600',

--- a/netlify/functions/brain.mts
+++ b/netlify/functions/brain.mts
@@ -30,7 +30,7 @@ import { authenticate } from "./middleware/auth.mts";
 // allow-origin per env var so cross-site requests can't forge identity.
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin":
-    process.env.HAWKEYE_ALLOWED_ORIGIN ?? "https://compliance-analyzer.netlify.app",
+    process.env.HAWKEYE_ALLOWED_ORIGIN ?? "https://hawkeye-sterling-v2.netlify.app",
   "Access-Control-Allow-Methods": "POST, OPTIONS",
   "Access-Control-Allow-Headers": "Authorization, Content-Type",
   "Access-Control-Max-Age": "600",

--- a/netlify/functions/inspector.mts
+++ b/netlify/functions/inspector.mts
@@ -43,7 +43,7 @@ type InspectorAuthority = (typeof VALID_AUTHORITIES)[number];
 
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin':
-    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://compliance-analyzer.netlify.app',
+    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://hawkeye-sterling-v2.netlify.app',
   'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
   'Access-Control-Allow-Headers': 'Authorization, Content-Type',
   'Access-Control-Max-Age': '600',

--- a/netlify/functions/setup-asana-bootstrap.mts
+++ b/netlify/functions/setup-asana-bootstrap.mts
@@ -44,7 +44,7 @@ const ASANA_BASE = 'https://app.asana.com/api/1.0';
 
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin':
-    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://compliance-analyzer.netlify.app',
+    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://hawkeye-sterling-v2.netlify.app',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
   'Access-Control-Allow-Headers': 'Authorization, Content-Type',
   'Access-Control-Max-Age': '600',

--- a/netlify/functions/setup-cohort-upload.mts
+++ b/netlify/functions/setup-cohort-upload.mts
@@ -37,7 +37,7 @@ const MAX_CSV_BYTES = 10 * 1024 * 1024; // 10 MB
 
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin':
-    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://compliance-analyzer.netlify.app',
+    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://hawkeye-sterling-v2.netlify.app',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
   'Access-Control-Allow-Headers': 'Authorization, Content-Type',
   'Access-Control-Max-Age': '600',

--- a/netlify/functions/watchlist.mts
+++ b/netlify/functions/watchlist.mts
@@ -58,7 +58,7 @@ const MAX_BODY_SIZE = 256 * 1024; // 256 KB — generous for ~5000 subjects
 
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin':
-    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://compliance-analyzer.netlify.app',
+    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://hawkeye-sterling-v2.netlify.app',
   'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
   'Access-Control-Allow-Headers': 'Authorization, Content-Type',
   'Access-Control-Max-Age': '600',

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -28,7 +28,7 @@ info:
   license:
     name: Proprietary
 servers:
-  - url: https://compliance-analyzer.netlify.app
+  - url: https://hawkeye-sterling-v2.netlify.app
     description: Production
   - url: http://localhost:8888
     description: Local Netlify Dev

--- a/scripts/agent-orchestrator.mjs
+++ b/scripts/agent-orchestrator.mjs
@@ -16,7 +16,7 @@
  *
  * Environment (orchestrator, host-side — never mounted to the agent):
  *   ANTHROPIC_API_KEY   — required
- *   HAWKEYE_BRAIN_URL   — e.g. https://compliance-analyzer.netlify.app
+ *   HAWKEYE_BRAIN_URL   — e.g. https://hawkeye-sterling-v2.netlify.app
  *   HAWKEYE_BRAIN_TOKEN — 32+ hex bearer token
  *   CACHET_BASE_URL     — optional
  *   CACHET_API_TOKEN    — optional

--- a/scripts/asana-project-bootstrap.ts
+++ b/scripts/asana-project-bootstrap.ts
@@ -25,12 +25,12 @@
  * Usage:
  *   ASANA_TOKEN=xxx \
  *   ASANA_WORKSPACE_GID=xxx \
- *   PUBLIC_BASE_URL=https://compliance-analyzer.netlify.app \
+ *   PUBLIC_BASE_URL=https://hawkeye-sterling-v2.netlify.app \
  *   npx tsx scripts/asana-project-bootstrap.ts                 # dry-run
  *
  *   ASANA_TOKEN=xxx \
  *   ASANA_WORKSPACE_GID=xxx \
- *   PUBLIC_BASE_URL=https://compliance-analyzer.netlify.app \
+ *   PUBLIC_BASE_URL=https://hawkeye-sterling-v2.netlify.app \
  *   npx tsx scripts/asana-project-bootstrap.ts --apply         # write
  *
  * Each step is idempotent — re-running after a partial run is safe

--- a/scripts/asana-webhook-bootstrap.ts
+++ b/scripts/asana-webhook-bootstrap.ts
@@ -30,7 +30,7 @@
  *
  * Usage:
  *   ASANA_TOKEN=xxx \
- *   PUBLIC_BASE_URL=https://compliance-analyzer.netlify.app \
+ *   PUBLIC_BASE_URL=https://hawkeye-sterling-v2.netlify.app \
  *   ASANA_WORKSPACE_GID=xxx \
  *   npx tsx scripts/asana-webhook-bootstrap.ts
  *

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -105,7 +105,7 @@ fi
 
 # -- HAWKEYE_BRAIN_URL -----------------------------------------------------
 if [[ -z "${HAWKEYE_BRAIN_URL:-}" ]]; then
-  HAWKEYE_BRAIN_URL="https://compliance-analyzer.netlify.app"
+  HAWKEYE_BRAIN_URL="https://hawkeye-sterling-v2.netlify.app"
   grep -v '^HAWKEYE_BRAIN_URL=' .env.local > .env.local.tmp 2>/dev/null || true
   printf 'HAWKEYE_BRAIN_URL=%s\n' "$HAWKEYE_BRAIN_URL" >> .env.local.tmp
   mv .env.local.tmp .env.local
@@ -120,7 +120,7 @@ printf '  /api/brain accepts the orchestrator requests.\n\n'
 printf '  Option A — Netlify CLI (if installed):\n'
 printf '    %snpx netlify env:set HAWKEYE_BRAIN_TOKEN "%s"%s\n\n' "$CYN" "$HAWKEYE_BRAIN_TOKEN" "$RST"
 printf '  Option B — Netlify web UI:\n'
-printf '    https://app.netlify.com/sites/compliance-analyzer/settings/env\n'
+printf '    https://app.netlify.com/sites/hawkeye-sterling-v2/settings/env\n'
 printf '    Key:   HAWKEYE_BRAIN_TOKEN\n'
 printf '    Value: %s%s%s\n' "$BOLD" "$HAWKEYE_BRAIN_TOKEN" "$RST"
 

--- a/scripts/regulatory-watcher.ts
+++ b/scripts/regulatory-watcher.ts
@@ -18,7 +18,7 @@
  * (`.github/workflows/regulatory-watcher.yml`).
  *
  * Environment:
- *   HAWKEYE_BRAIN_URL     — optional, defaults to compliance-analyzer.netlify.app
+ *   HAWKEYE_BRAIN_URL     — optional, defaults to hawkeye-sterling-v2.netlify.app
  *   HAWKEYE_BRAIN_TOKEN   — required to post brain events (otherwise skipped)
  *   REGULATORY_WATCH_OFFLINE=1 — skip HTTP fetches, use only local snapshots
  *
@@ -124,7 +124,7 @@ async function fetchContent(url: string): Promise<string | null> {
   try {
     const res = await fetch(url, {
       headers: {
-        'User-Agent': 'Hawkeye-Sterling-RegulatoryWatcher/1.0 (+compliance-analyzer.netlify.app)',
+        'User-Agent': 'Hawkeye-Sterling-RegulatoryWatcher/1.0 (+hawkeye-sterling-v2.netlify.app)',
         Accept: 'text/html,application/json,*/*',
       },
       signal: ctrl.signal,
@@ -171,7 +171,7 @@ async function publishChangeToBrain(
   oldHash: string | null,
   newHash: string,
 ): Promise<boolean> {
-  const base = process.env.HAWKEYE_BRAIN_URL ?? 'https://compliance-analyzer.netlify.app';
+  const base = process.env.HAWKEYE_BRAIN_URL ?? 'https://hawkeye-sterling-v2.netlify.app';
   const token = process.env.HAWKEYE_BRAIN_TOKEN;
   if (!token) {
     console.log(`  skip: HAWKEYE_BRAIN_TOKEN not set — event not published`);

--- a/scripts/scheduled-screening.ts
+++ b/scripts/scheduled-screening.ts
@@ -47,7 +47,7 @@
  *   ASANA_SCREENINGS_PROJECT_GID       Target project for alert tasks
  *   ASANA_WORKSPACE_GID                Workspace for user resolution
  *   ASANA_DEFAULT_ASSIGNEE_NAME        e.g. "Luisa Fernanda"
- *   HAWKEYE_BRAIN_URL                  defaults to compliance-analyzer.netlify.app
+ *   HAWKEYE_BRAIN_URL                  defaults to hawkeye-sterling-v2.netlify.app
  *   HAWKEYE_BRAIN_TOKEN                Bearer for /api/watchlist and /api/brain
  *   SCHEDULED_SCREENING_DRY_RUN        =1 to skip Asana + brain dispatches
  *   SCHEDULED_SCREENING_OFFLINE        =1 to skip adverse-media HTTP calls
@@ -98,7 +98,7 @@ interface RunConfig {
 
 function loadConfig(): RunConfig {
   return {
-    brainUrl: process.env.HAWKEYE_BRAIN_URL ?? 'https://compliance-analyzer.netlify.app',
+    brainUrl: process.env.HAWKEYE_BRAIN_URL ?? 'https://hawkeye-sterling-v2.netlify.app',
     brainToken: process.env.HAWKEYE_BRAIN_TOKEN,
     asanaToken: process.env.ASANA_TOKEN,
     asanaProjectGid: process.env.ASANA_SCREENINGS_PROJECT_GID,

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -204,7 +204,7 @@ async function main() {
     }
   }
   if (!env.HAWKEYE_BRAIN_URL) {
-    env.HAWKEYE_BRAIN_URL = 'https://compliance-analyzer.netlify.app';
+    env.HAWKEYE_BRAIN_URL = 'https://hawkeye-sterling-v2.netlify.app';
   }
   if (!env.PUBLIC_BASE_URL) {
     env.PUBLIC_BASE_URL = env.HAWKEYE_BRAIN_URL;
@@ -333,14 +333,14 @@ async function main() {
   console.log('Option B — Netlify dashboard:');
   console.log('');
   console.log('   1. Open https://app.netlify.com');
-  console.log('   2. Pick the compliance-analyzer site');
+  console.log('   2. Pick the hawkeye-sterling-v2 site');
   console.log('   3. Site settings → Environment variables');
   console.log('   4. Paste each KEY=VALUE from .env');
   console.log('   5. Click "Trigger redeploy"');
   console.log('');
   console.log('STEP 6 — Smoke-test the autopilot after the redeploy:');
   console.log('');
-  console.log('   curl https://compliance-analyzer.netlify.app/.netlify/functions/asana-super-brain-autopilot-cron');
+  console.log('   curl https://hawkeye-sterling-v2.netlify.app/.netlify/functions/asana-super-brain-autopilot-cron');
   console.log('');
   console.log('Expected: {"ok":true,"dispatched":N,...}');
   console.log('');

--- a/src/services/asana/tenantProvisioner.ts
+++ b/src/services/asana/tenantProvisioner.ts
@@ -288,7 +288,7 @@ function colorForTenant(tenantId: string): string {
 }
 
 const DEFAULT_WEBHOOK_TARGET =
-  'https://compliance-analyzer.netlify.app/api/asana-webhook';
+  'https://hawkeye-sterling-v2.netlify.app/api/asana-webhook';
 
 /**
  * Build the full provisioning plan for a tenant. Pure function. Same

--- a/src/services/envConfigValidator.ts
+++ b/src/services/envConfigValidator.ts
@@ -171,7 +171,7 @@ const SPEC: readonly EnvVarSpec[] = [
     category: 'brain',
     requirement: 'required',
     description: 'CORS origin allowlist. Comma-separated HTTPS URLs.',
-    example: 'https://compliance-analyzer.netlify.app',
+    example: 'https://hawkeye-sterling-v2.netlify.app',
     validate: nonEmpty('HAWKEYE_ALLOWED_ORIGIN'),
   },
   {
@@ -196,9 +196,9 @@ const SPEC: readonly EnvVarSpec[] = [
     category: 'proxy',
     requirement: 'optional',
     description: 'Proxy URL for the advisor call. Defaults to the same-site /api/ai-proxy.',
-    example: 'https://compliance-analyzer.netlify.app/api/ai-proxy',
+    example: 'https://hawkeye-sterling-v2.netlify.app/api/ai-proxy',
     validate: urlLike('HAWKEYE_AI_PROXY_URL'),
-    defaultFallback: 'https://compliance-analyzer.netlify.app/api/ai-proxy',
+    defaultFallback: 'https://hawkeye-sterling-v2.netlify.app/api/ai-proxy',
   },
   // Asana
   {

--- a/src/utils/asanaEnvCheck.ts
+++ b/src/utils/asanaEnvCheck.ts
@@ -415,7 +415,7 @@ function checkPublicUrl(ctx: CheckContext): void {
       envKey: 'PUBLIC_BASE_URL,HAWKEYE_BRAIN_URL',
       detail:
         'The webhook bootstrap script computes the receiver target from this. Without it, `npm run asana:bootstrap:webhooks` cannot subscribe webhooks.',
-      fix: 'Set PUBLIC_BASE_URL=https://compliance-analyzer.netlify.app in Netlify env vars.',
+      fix: 'Set PUBLIC_BASE_URL=https://hawkeye-sterling-v2.netlify.app in Netlify env vars.',
     });
     return;
   }

--- a/tests/asanaEnvCheck.test.ts
+++ b/tests/asanaEnvCheck.test.ts
@@ -19,7 +19,7 @@ function baselineEnv(): Record<string, string> {
   return {
     ASANA_TOKEN: 'tok',
     ASANA_WORKSPACE_GID: 'workspace-1',
-    PUBLIC_BASE_URL: 'https://compliance-analyzer.netlify.app',
+    PUBLIC_BASE_URL: 'https://hawkeye-sterling-v2.netlify.app',
     HAWKEYE_APPROVER_KEYS: 'user-mlro:abcdef0123456789,user-deputy:1111222233334444',
     // CFs — risk_level
     ASANA_CF_RISK_LEVEL_GID: 'cf-rl',
@@ -278,7 +278,7 @@ describe('checkAsanaDeployReadiness — webhook receiver URL', () => {
 
   it('blocks when PUBLIC_BASE_URL is HTTP not HTTPS', () => {
     const env = baselineEnv();
-    env.PUBLIC_BASE_URL = 'http://compliance-analyzer.netlify.app';
+    env.PUBLIC_BASE_URL = 'http://hawkeye-sterling-v2.netlify.app';
     const result = checkAsanaDeployReadiness(env);
     expect(result.ok).toBe(false);
     expect(
@@ -291,7 +291,7 @@ describe('checkAsanaDeployReadiness — webhook receiver URL', () => {
   it('falls back to HAWKEYE_BRAIN_URL when PUBLIC_BASE_URL is unset', () => {
     const env = baselineEnv();
     delete env.PUBLIC_BASE_URL;
-    env.HAWKEYE_BRAIN_URL = 'https://compliance-analyzer.netlify.app';
+    env.HAWKEYE_BRAIN_URL = 'https://hawkeye-sterling-v2.netlify.app';
     const result = checkAsanaDeployReadiness(env);
     expect(result.ok).toBe(true);
     expect(

--- a/tests/firstRunExperience.test.ts
+++ b/tests/firstRunExperience.test.ts
@@ -217,7 +217,7 @@ describe('emptyStates catalogue', () => {
 describe('envConfigValidator', () => {
   const goodEnv = {
     HAWKEYE_BRAIN_TOKEN: 'hk-brain-aaaaaaaaaaaaaaaaaaaaaaaaa', // ≥24 chars
-    HAWKEYE_ALLOWED_ORIGIN: 'https://compliance-analyzer.netlify.app',
+    HAWKEYE_ALLOWED_ORIGIN: 'https://hawkeye-sterling-v2.netlify.app',
     HAWKEYE_CROSS_TENANT_SALT: 'v2026Q2-salt-abcdefghij',
     ANTHROPIC_API_KEY: 'sk-ant-api03-XXXXXXXXXXXXXXXXX',
     ASANA_ACCESS_TOKEN: '1/0123456789012345:AAAAAAAAAAAAAAAAAA',


### PR DESCRIPTION
## Summary

Consolidates three Netlify sites down to one canonical deployment: **`hawkeye-sterling-v2.netlify.app`**. Every code-side reference to the legacy URL has been rewritten so the new site is the single source of truth, and a belt-and-braces `netlify.toml` `ignore` rule prevents duplicate deploy-preview comments during the transition.

**Why this exists.** The repo is linked to three Netlify sites:
- `hawkeye-sterling-v2` (canonical, keep)
- `compliance-analyzer` (legacy — still the production brain backend referenced by 5 scheduled GitHub workflows)
- `hawkeye-sterling` (orphan, zero code references)

Every PR was posting two deploy-preview comments (one per auto-building site), and the GitHub scheduled jobs were talking to the legacy brain instead of the living one. After this PR + the post-merge dashboard steps below, only `hawkeye-sterling-v2` is active.

## What changed (code)

### Commit 1 — `8aa6689` — safety-net `ignore` rule
`netlify.toml` gets an `ignore` command that cancels the build **only** when `CONTEXT=deploy-preview` AND `SITE_NAME=compliance-analyzer`. Production and branch deploys on either site are unaffected. This is the belt-and-braces layer: even if someone accidentally re-enables the legacy site in the dashboard later, PRs still only get one preview comment.

### Commit 2 — `33836b7` — 47-file canonicalization rename

**GitHub workflows (6 files)** — `HAWKEYE_BRAIN_URL` fallback defaults in `agent-run.yml`, `autopilot.yml`, `lbma-audit-pack.yml`, `regulatory-watcher.yml`, `scheduled-screening.yml`, and the Netlify dashboard URL in `rotate-brain-token.yml`'s operator summary output. The 5 scheduled jobs now default to the living brain.

**Netlify Functions (22 files)** — `HAWKEYE_ALLOWED_ORIGIN` CORS fallback defaults in `brain.mts`, `brain-analyze.mts`, `brain-break-glass.mts`, `brain-clamp-suggestion.mts`, `brain-correlate.mts`, `brain-diagnostics.mts`, `brain-evidence-bundle.mts`, `brain-health.mts`, `brain-hydrate.mts`, `brain-outbound-queue.mts`, `brain-replay.mts`, `brain-telemetry.mts`, `brain-zk-cross-tenant.mts`, `inspector.mts`, `approvals.mts`, `watchlist.mts`, `setup-asana-bootstrap.mts`, `setup-cohort-upload.mts`.

**Source code (3 files)** — `src/services/asana/tenantProvisioner.ts` (`DEFAULT_WEBHOOK_TARGET`), `src/services/envConfigValidator.ts` (examples + `defaultFallback`), `src/utils/asanaEnvCheck.ts` (fix hint).

**Tests (2 files)** — `tests/asanaEnvCheck.test.ts`, `tests/firstRunExperience.test.ts`. Fixture URLs only; assertions test behavior (HTTP rejection, fallback order), not the literal domain.

**Scripts (7 files)** — `scripts/setup.mjs`, `scripts/bootstrap.sh`, `scripts/agent-orchestrator.mjs`, `scripts/regulatory-watcher.ts`, `scripts/scheduled-screening.ts`, `scripts/asana-project-bootstrap.ts`, `scripts/asana-webhook-bootstrap.ts`. Default URLs, user-agent strings, and operator-facing CLI output.

**Docs and config (8 files)** — `openapi.yaml` (production server URL), `integrations/postman/hawkeye-brain.postman_collection.json` (`baseUrl`), `.env.example`, `SETUP.md`, `agents/README.md`, `agents/incident-commander.yml`, `asana-workflow/SETUP_CHECKLIST.md`, `asana-workflow/WEBHOOKS.md`, `hawkeye-sterling-v2/DEPLOY_CHECKLIST.md`, `hawkeye-sterling-v2/ENDPOINTS.md`.

**`netlify.toml`** — comment block above the `ignore` rule updated to reflect the new reality (workflows no longer depend on the legacy URL; the rule is now purely a safety net in case the legacy site is ever re-enabled in the dashboard by mistake).

## What intentionally was NOT renamed

- **GitHub repo URL** (`github.com/trex0092/compliance-analyzer`) — only the Netlify site is being renamed, not the repo itself.
- **`aiGovernance` self-audit target string `'compliance-analyzer'`** — internal project identifier for the code-as-audited-system, not a URL. The system is still called compliance-analyzer regardless of which site it deploys to.
- **`sbom.yml` artifact filenames** — project name, not a URL.
- **`src/services/multiModelScreening.ts` OpenRouter HTTP-Referer `https://hawkeye-sterling.app`** — a different custom domain, not the Netlify site.
- **`vendor/**`** — read-only upstream.
- **`package-lock.json`, `ops/cachet/composer.json`, `docs/research/*.md`** — project-name references, not URLs.

## Quality gate

- ✅ `tsc --noEmit`: passed (preexisting `baseUrl` deprecation warning is unrelated to this change).
- ⚠️ `vitest run`: could not execute in the dev session (no `node_modules`). CI will run it on this PR. The rename is mechanical string replacement and the 3 tests that touch the renamed URL use it as fixture data — assertions test behavior, not the literal string.
- ⚠️ `eslint`: could not execute (preexisting ESLint 9 config migration issue, not caused by this change).

## Post-merge checklist (web-UI only — no terminal required)

These steps must be done manually after merge because the code session has no credentials for Asana, Netlify, or GitHub dashboards. All steps work from a phone browser.

### Phase 1 — Merge + auto-deploy
1. **Merge this PR to `main`.**
2. Wait for Netlify auto-deploy on `hawkeye-sterling-v2` → confirm **Published** status in the Netlify dashboard.

### Phase 2 — GitHub secrets / variables
3. Go to `https://github.com/trex0092/compliance-analyzer/settings/secrets/actions` → update `HAWKEYE_BRAIN_URL` secret to `https://hawkeye-sterling-v2.netlify.app`. (Or delete it — the new code default will kick in.)
4. Same page → **Variables** tab → if `HAWKEYE_BRAIN_URL` exists as a variable, update it too (`scheduled-screening.yml` uses `vars.` not `secrets.`).
5. **Actions tab → Run workflow** manually on `Scheduled Screening` or `Regulatory Watcher` against `main`. Confirm green run against the new URL before retiring the legacy site.

### Phase 3 — Netlify env vars
6. Netlify dashboard → `hawkeye-sterling-v2` → **Site configuration → Environment variables**:
   - `HAWKEYE_ALLOWED_ORIGIN` = `https://hawkeye-sterling-v2.netlify.app`
   - `PUBLIC_BASE_URL` = `https://hawkeye-sterling-v2.netlify.app`
   - Confirm these also exist: `HAWKEYE_BRAIN_TOKEN`, `ASANA_ACCESS_TOKEN`, `ASANA_WORKSPACE_GID`, `HAWKEYE_CROSS_TENANT_SALT`, `HAWKEYE_APPROVER_KEYS`, `JWT_SIGNING_SECRET`, `BCRYPT_PEPPER`, `ANTHROPIC_API_KEY`, plus any Asana project GIDs your tenants use.
7. Trigger a fresh deploy so the functions pick up the new env: Netlify dashboard → **Deploys → Trigger deploy → Deploy site**.

### Phase 4 — Re-register Asana webhooks (browser-only, no terminal)
8. Open **`https://hawkeye-sterling-v2.netlify.app/setup.html`** in any browser (mobile works).
9. Scroll to **Step 8 — Bootstrap Asana for this tenant**.
10. Enter the tenant id (default `tenant-a`) and click **🏗 Bootstrap Asana tenant**.
11. This calls `POST /api/setup/asana-bootstrap` which is **idempotent** — it reuses existing Asana projects, sections, and custom fields, and re-registers the webhook receiver to the new URL. No existing task data is touched.
12. Wait for `OK` confirmation in the output box before closing.

### Phase 5 — Retire the legacy sites
13. Netlify dashboard → `hawkeye-sterling` (the orphan) → **Site configuration → Build & deploy → Stop builds**. Zero code references, completely safe.
14. Netlify dashboard → `compliance-analyzer` → **Stop builds**. Only do this after Phases 2-4 are confirmed working.
15. Wait 24 hours. Watch the scheduled workflows (`autopilot` daily 06:00 UTC, `regulatory-watcher` daily 05:30 UTC, `scheduled-screening` daily 06:00 + 14:00 UTC, `lbma-audit-pack` weekly Mon 07:00 UTC). All should be green against the new URL.
16. (Optional) After a week of green runs, delete the legacy sites entirely: Netlify dashboard → each legacy site → **Site configuration → Danger zone → Delete this site**.

## Weaponization verification — prove both brains are firing at 100%

After Phase 4, verify Asana ↔ Brain is fully bidirectional:

1. **Brain health (tool brain):** open `https://hawkeye-sterling-v2.netlify.app` → Brain Console → confirm all 19+ weaponized subsystems report OK. Or hit `POST /api/brain/health` from the in-app Verify button on `setup.html` Step 6.
2. **Asana → Brain (inbound webhook):** in Asana, open any task in the `KYC / CDD TRACKER` project and add a comment. Within 2 seconds, the `asana-webhook` function logs in Netlify should show the incoming event. Delete the test comment.
3. **Brain → Asana (outbound task creation):** manually trigger the `autopilot` workflow in GitHub Actions. Confirm the daily autopilot run creates or updates tasks in the expected Asana projects (e.g. `GOAML / REGULATORY REPORTING — ALL ENTITIES 2026` for regulatory filings, `SCREENINGS` for sanctions scans).
4. **Scheduled brain cycles:** verify at least one run each of `autopilot`, `regulatory-watcher`, and `scheduled-screening` completes green against the new URL.

If any leg fails, the logs in Netlify function logs + GitHub Actions logs will name the missing env var or webhook target exactly.

## Test plan

- [ ] CI runs `vitest run`, `tsc --noEmit`, `eslint` on this PR → all green
- [ ] Merge to `main` → `hawkeye-sterling-v2` auto-deploy succeeds
- [ ] Phase 2: `HAWKEYE_BRAIN_URL` secret/variable updated in GitHub
- [ ] Phase 2: one manual scheduled-workflow run succeeds against new URL
- [ ] Phase 3: Netlify env vars confirmed on `hawkeye-sterling-v2`, deploy triggered
- [ ] Phase 4: `setup.html` Step 8 bootstrap runs clean, returns OK
- [ ] Weaponization verification steps 1-4 all pass
- [ ] Phase 5: `hawkeye-sterling` (orphan) stopped in Netlify dashboard
- [ ] Phase 5: `compliance-analyzer` (legacy) stopped in Netlify dashboard
- [ ] 24-hour watch: all scheduled workflows green against new URL

## Rollback

If anything goes wrong, this PR is fully reversible:
- `git revert 33836b7` restores the old URL defaults (workflows go back to hitting the legacy site).
- The `netlify.toml` safety-net rule in `8aa6689` remains in place and keeps stopping the duplicate deploy-preview comments even without the rest of the PR.
- Asana `setup.html` Step 8 is idempotent and can be re-run at any time with any `PUBLIC_BASE_URL` to point webhooks back at the old URL if needed.
- No existing Asana task data, no database records, no compliance state is mutated by any step of this PR.
