### PR TITLE
Add KYC/CDD Tracker section bootstrap (16 canonical sections)

### DIFF
--- a/netlify/functions/setup-kyc-cdd-tracker-sections.mts
+++ b/netlify/functions/setup-kyc-cdd-tracker-sections.mts
@@ -1,0 +1,386 @@
+/**
+ * Setup KYC / CDD Tracker Sections — idempotent section bootstrap
+ * for the tenant-agnostic "KYC / CDD TRACKER — ALL ENTITIES" Asana
+ * project, exposed as an HTTP endpoint so operators can do it from
+ * the browser-only setup.html wizard (Step 9).
+ *
+ * POST /api/setup/kyc-cdd-tracker-sections
+ *
+ * Body:
+ *   { projectGid: "1234567890123456" }
+ *
+ * What it does:
+ *   1. Lists existing sections for the project via GET /projects/{gid}/sections
+ *   2. For each section, counts tasks via GET /sections/{gid}/tasks?opt_fields=gid&limit=1
+ *      (we only need to know if taskCount is 0 or >0, not the full count,
+ *      so we stop at limit=1 for cost)
+ *   3. Calls diffSections() (pure) to produce the create/keep/delete plan
+ *   4. Walks the plan:
+ *      - Creates missing canonical sections via POST /projects/{gid}/sections
+ *      - Deletes the "Untitled section" placeholder IF empty
+ *      - Reports orphans (operator custom sections) WITHOUT touching them
+ *   5. Returns the full per-step audit trail + regulatory anchor list
+ *
+ * Idempotent: safe to re-run. Name-matched sections are reused,
+ * never duplicated. Operator custom sections are NEVER deleted.
+ *
+ * Security:
+ *   POST + OPTIONS
+ *   Bearer HAWKEYE_BRAIN_TOKEN required
+ *   Rate limited 5 / 15 min (write-heavy endpoint)
+ *
+ * Regulatory basis:
+ *   FDL No.10/2025 Art.12-14 (CDD tier + thresholds)
+ *   FDL No.10/2025 Art.20-22 (CO continuous oversight)
+ *   FDL No.10/2025 Art.24    (10yr retention — provisioning audit)
+ *   FDL No.10/2025 Art.26-27 (STR / SAR section lane)
+ *   FDL No.10/2025 Art.29    (tipping-off prohibition — STR lane)
+ *   FDL No.10/2025 Art.35    (TFS screening lane)
+ *   Cabinet Res 134/2025 Art.7-10 (CDD data collection)
+ *   Cabinet Res 134/2025 Art.14   (EDD + PEP senior management + Board)
+ *   Cabinet Res 134/2025 Art.19   (internal review + four-eyes)
+ *   Cabinet Res 74/2020 Art.4-7   (TFS asset freeze, 24h EOCN)
+ *   Cabinet Decision 109/2023     (UBO register, >25% threshold)
+ */
+
+import type { Config, Context } from '@netlify/functions';
+import { getStore } from '@netlify/blobs';
+import { checkRateLimit } from './middleware/rate-limit.mts';
+import { authenticate } from './middleware/auth.mts';
+import {
+  KYC_CDD_TRACKER_SECTIONS,
+  diffSections,
+  type ExistingSection,
+} from '../../src/services/asana/kycCddTrackerSections';
+
+const ASANA_BASE = 'https://app.asana.com/api/1.0';
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin':
+    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://hawkeye-sterling-v2.netlify.app',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+  'Access-Control-Max-Age': '600',
+  Vary: 'Origin',
+} as const;
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return Response.json(body, {
+    ...init,
+    headers: { ...CORS_HEADERS, ...(init.headers ?? {}) },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Asana HTTP helpers — thin wrapper over fetch
+// ---------------------------------------------------------------------------
+
+async function asanaGet<T>(path: string, token: string): Promise<T> {
+  const res = await fetch(ASANA_BASE + path, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/json',
+    },
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Asana GET ${path} → ${res.status}: ${text.slice(0, 200)}`);
+  }
+  const json = (await res.json()) as { data: T };
+  return json.data;
+}
+
+async function asanaPost<T>(path: string, body: unknown, token: string): Promise<T> {
+  const res = await fetch(ASANA_BASE + path, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Asana POST ${path} → ${res.status}: ${text.slice(0, 200)}`);
+  }
+  const json = (await res.json()) as { data: T };
+  return json.data;
+}
+
+async function asanaDelete(path: string, token: string): Promise<void> {
+  const res = await fetch(ASANA_BASE + path, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Asana DELETE ${path} → ${res.status}: ${text.slice(0, 200)}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Request validation
+// ---------------------------------------------------------------------------
+
+interface BootstrapRequest {
+  projectGid: string;
+}
+
+function validate(
+  raw: unknown
+): { ok: true; req: BootstrapRequest } | { ok: false; error: string } {
+  if (!raw || typeof raw !== 'object') return { ok: false, error: 'body must be an object' };
+  const r = raw as Record<string, unknown>;
+  if (typeof r.projectGid !== 'string' || r.projectGid.length === 0 || r.projectGid.length > 32) {
+    return { ok: false, error: 'projectGid must be 1..32 chars' };
+  }
+  if (!/^\d+$/.test(r.projectGid)) {
+    return { ok: false, error: 'projectGid must contain only digits (Asana GID format)' };
+  }
+  return { ok: true, req: { projectGid: r.projectGid } };
+}
+
+// ---------------------------------------------------------------------------
+// Step log — structured audit trail returned in the response
+// ---------------------------------------------------------------------------
+
+interface Step {
+  op: 'list' | 'count_tasks' | 'diff' | 'create' | 'delete' | 'orphan';
+  detail: string;
+  ok: boolean;
+  gid?: string;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export default async (req: Request, context: Context): Promise<Response> => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+  }
+  if (req.method !== 'POST') {
+    return jsonResponse({ error: 'Method not allowed' }, { status: 405 });
+  }
+
+  const rl = await checkRateLimit(req, {
+    max: 5,
+    clientIp: context.ip,
+    namespace: 'setup-kyc-cdd-tracker-sections',
+  });
+  if (rl) return rl;
+
+  const auth = authenticate(req);
+  if (!auth.ok) return auth.response!;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return jsonResponse({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const v = validate(body);
+  if (!v.ok) return jsonResponse({ error: v.error }, { status: 400 });
+
+  const accessToken = process.env.ASANA_ACCESS_TOKEN;
+  if (!accessToken || accessToken.length < 16) {
+    return jsonResponse(
+      { error: 'ASANA_ACCESS_TOKEN env var missing or invalid' },
+      { status: 503 }
+    );
+  }
+
+  const { projectGid } = v.req;
+  const steps: Step[] = [];
+
+  // -------------------------------------------------------------------------
+  // Step 1 — list existing sections
+  // -------------------------------------------------------------------------
+  let rawExisting: Array<{ gid: string; name: string }>;
+  try {
+    rawExisting = await asanaGet<Array<{ gid: string; name: string }>>(
+      `/projects/${encodeURIComponent(projectGid)}/sections?opt_fields=gid,name&limit=100`,
+      accessToken
+    );
+    steps.push({
+      op: 'list',
+      detail: `Found ${rawExisting.length} existing section(s) in project ${projectGid}`,
+      ok: true,
+    });
+  } catch (err) {
+    return jsonResponse(
+      {
+        error: 'asana_list_sections_failed',
+        reason: err instanceof Error ? err.message : String(err),
+        projectGid,
+      },
+      { status: 502 }
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 2 — count tasks per section (only for the Untitled-section
+  // safety check; we stop at limit=1 because we only need to know
+  // 0 vs non-zero).
+  // -------------------------------------------------------------------------
+  const existing: ExistingSection[] = [];
+  for (const s of rawExisting) {
+    let taskCount = 0;
+    try {
+      const tasks = await asanaGet<Array<{ gid: string }>>(
+        `/sections/${encodeURIComponent(s.gid)}/tasks?opt_fields=gid&limit=1`,
+        accessToken
+      );
+      taskCount = tasks.length;
+    } catch (err) {
+      // Non-fatal — if we can't count, assume non-empty so we err on
+      // the side of NOT deleting the Untitled section.
+      taskCount = 1;
+      steps.push({
+        op: 'count_tasks',
+        detail: `Could not count tasks in section "${s.name}" — assuming non-empty for safety`,
+        ok: false,
+        gid: s.gid,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    existing.push({ gid: s.gid, name: s.name, taskCount });
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 3 — pure diff
+  // -------------------------------------------------------------------------
+  const diff = diffSections(KYC_CDD_TRACKER_SECTIONS, existing);
+  steps.push({
+    op: 'diff',
+    detail: `Plan: ${diff.toCreate.length} to create, ${diff.toKeep.length} to keep, ${diff.toDelete.length} to delete, ${diff.orphans.length} operator orphan(s) preserved`,
+    ok: true,
+  });
+
+  // -------------------------------------------------------------------------
+  // Step 4 — create missing canonical sections
+  // -------------------------------------------------------------------------
+  for (const spec of diff.toCreate) {
+    try {
+      const created = await asanaPost<{ gid: string }>(
+        `/projects/${encodeURIComponent(projectGid)}/sections`,
+        { data: { name: spec.name } },
+        accessToken
+      );
+      steps.push({
+        op: 'create',
+        detail: `Created section "${spec.name}" (${spec.regulatoryAnchor})`,
+        ok: true,
+        gid: created.gid,
+      });
+    } catch (err) {
+      steps.push({
+        op: 'create',
+        detail: `FAILED to create section "${spec.name}"`,
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 5 — delete the empty Untitled section placeholder (if any)
+  // -------------------------------------------------------------------------
+  for (const d of diff.toDelete) {
+    try {
+      await asanaDelete(`/sections/${encodeURIComponent(d.gid)}`, accessToken);
+      steps.push({
+        op: 'delete',
+        detail: `Deleted "${d.name}" (${d.reason})`,
+        ok: true,
+        gid: d.gid,
+      });
+    } catch (err) {
+      // Non-fatal — Asana sometimes refuses to delete the last
+      // section in a project. Log and continue.
+      steps.push({
+        op: 'delete',
+        detail: `Could not delete "${d.name}" — operator may need to remove manually`,
+        ok: false,
+        gid: d.gid,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 6 — report orphans (informational, never mutated)
+  // -------------------------------------------------------------------------
+  for (const o of diff.orphans) {
+    steps.push({
+      op: 'orphan',
+      detail: `Operator section preserved: "${o.name}" (${o.taskCount} task${o.taskCount === 1 ? '' : 's'})`,
+      ok: true,
+      gid: o.gid,
+    });
+  }
+
+  const createFailures = steps.filter((s) => s.op === 'create' && !s.ok).length;
+  const overallOk = createFailures === 0;
+
+  // -------------------------------------------------------------------------
+  // Audit log — 10-year retention per FDL Art.24
+  // -------------------------------------------------------------------------
+  try {
+    const audit = getStore('setup-audit');
+    await audit.setJSON(`kyc-cdd-tracker-sections/${projectGid}/${Date.now()}.json`, {
+      tsIso: new Date().toISOString(),
+      userId: auth.userId,
+      projectGid,
+      ok: overallOk,
+      created: diff.toCreate.length,
+      kept: diff.toKeep.length,
+      deleted: diff.toDelete.length,
+      orphans: diff.orphans.length,
+      createFailures,
+    });
+  } catch {
+    // non-fatal
+  }
+
+  return jsonResponse(
+    {
+      ok: overallOk,
+      projectGid,
+      summary: overallOk
+        ? `KYC/CDD Tracker provisioned: ${diff.toCreate.length} created, ${diff.toKeep.length} kept, ${diff.toDelete.length} deleted, ${diff.orphans.length} orphan(s) preserved.`
+        : `KYC/CDD Tracker partially provisioned: ${createFailures} section creation(s) failed. See steps for details.`,
+      canonicalSectionCount: KYC_CDD_TRACKER_SECTIONS.length,
+      created: diff.toCreate.length,
+      kept: diff.toKeep.length,
+      deleted: diff.toDelete.length,
+      orphans: diff.orphans.length,
+      steps,
+      regulatory: [
+        'FDL No.10/2025 Art.12-14',
+        'FDL No.10/2025 Art.20-22',
+        'FDL No.10/2025 Art.24',
+        'FDL No.10/2025 Art.26-27',
+        'FDL No.10/2025 Art.29',
+        'FDL No.10/2025 Art.35',
+        'Cabinet Res 134/2025 Art.7-10',
+        'Cabinet Res 134/2025 Art.14',
+        'Cabinet Res 134/2025 Art.19',
+        'Cabinet Res 74/2020 Art.4-7',
+        'Cabinet Decision 109/2023',
+      ],
+    },
+    { status: overallOk ? 200 : 502 }
+  );
+};
+
+export const config: Config = {
+  path: '/api/setup/kyc-cdd-tracker-sections',
+  method: ['POST', 'OPTIONS'],
+};

--- a/setup.html
+++ b/setup.html
@@ -324,8 +324,21 @@ cust-2,Bob Smith,tenant-a,Robert Smith,1985-04-15,GB,2026-04-10T00:00:00Z</pre>
 
   <!-- STEP 9 -->
   <div class="step">
-    <h2>Step 9 — You are live 🎉</h2>
-    <p>When Steps 6, 7 and 8 all show <span class="status ok">OK</span>, open the tool in a new tab and start using it.</p>
+    <h2>Step 9 — Provision KYC / CDD Tracker sections</h2>
+    <p class="muted">One click to provision the tenant-agnostic "KYC / CDD TRACKER — ALL ENTITIES" Asana project with all 16 canonical workflow sections (intake, exception lanes, CDD, EDD, approvals, terminal). Idempotent: existing sections are reused by name, the empty "Untitled section" placeholder is removed, and operator custom sections are preserved untouched.</p>
+    <label>KYC/CDD Tracker Asana project GID</label>
+    <input type="text" id="input-kyc-cdd-project-gid" placeholder="1234567890123456 (digits only, from the Asana project URL)">
+    <div class="row">
+      <button class="primary" id="btn-kyc-cdd-sections">📋 Provision KYC/CDD Tracker sections</button>
+      <span id="kyc-cdd-sections-status"></span>
+    </div>
+    <div class="output" id="kyc-cdd-sections-output">(enter project GID and click to provision)</div>
+  </div>
+
+  <!-- STEP 10 -->
+  <div class="step">
+    <h2>Step 10 — You are live 🎉</h2>
+    <p>When Steps 6, 7, 8 and 9 all show <span class="status ok">OK</span>, open the tool in a new tab and start using it.</p>
     <p><a id="link-tool" target="_blank">→ Open HAWKEYE STERLING</a></p>
     <p><a id="link-brain" target="_blank">→ Open Brain Console</a></p>
     <p><a id="link-status" target="_blank">→ Open public status page</a></p>
@@ -334,9 +347,9 @@ cust-2,Bob Smith,tenant-a,Robert Smith,1985-04-15,GB,2026-04-10T00:00:00Z</pre>
     </div>
   </div>
 
-  <!-- STEP 10 -->
+  <!-- STEP 11 -->
   <div class="step">
-    <h2>Step 10 — Post-setup checklist (human work, not the tool)</h2>
+    <h2>Step 11 — Post-setup checklist (human work, not the tool)</h2>
     <ul>
       <li>Register your firm with the <a href="https://goaml.uaefiu.gov.ae/" target="_blank">UAE FIU goAML portal</a></li>
       <li>Sign the <a href="https://www.anthropic.com/legal/data-processing" target="_blank">Anthropic Data Processing Agreement</a> (required for any EU-resident customer)</li>

--- a/setup.js
+++ b/setup.js
@@ -299,6 +299,36 @@
     });
   });
 
+  // --- Step 9: provision KYC/CDD Tracker sections ---
+  byId('btn-kyc-cdd-sections').addEventListener('click', function () {
+    readInputs();
+    var projectGid = byId('input-kyc-cdd-project-gid').value.trim();
+    if (!projectGid) {
+      setStatus('kyc-cdd-sections-status', 'err', 'Project GID required');
+      return;
+    }
+    if (!/^\d+$/.test(projectGid)) {
+      setStatus('kyc-cdd-sections-status', 'err', 'GID must be digits only');
+      return;
+    }
+    setStatus('kyc-cdd-sections-status', 'pending', 'Provisioning sections…');
+    var token = state.brainToken;
+    fetch(apiBase() + '/api/setup/kyc-cdd-tracker-sections', {
+      method: 'POST',
+      headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectGid: projectGid }),
+    }).then(function (r) {
+      return r.json().then(function (body) { return { status: r.status, body: body }; });
+    }).then(function (res) {
+      var ok = res.status < 400 && res.body && res.body.ok !== false;
+      setStatus('kyc-cdd-sections-status', ok ? 'ok' : 'err', ok ? 'Ready' : 'Failed');
+      writeOutput('kyc-cdd-sections-output', JSON.stringify(res.body, null, 2));
+    }).catch(function (err) {
+      setStatus('kyc-cdd-sections-status', 'err', 'Network error');
+      writeOutput('kyc-cdd-sections-output', String(err));
+    });
+  });
+
   // --- Live links ---
   function updateLinks() {
     var base = apiBase();

--- a/src/services/asana/kycCddTrackerSections.ts
+++ b/src/services/asana/kycCddTrackerSections.ts
@@ -1,0 +1,278 @@
+/**
+ * KYC / CDD Tracker Section Plan — pure specification for the
+ * sections that should exist in the tenant-agnostic
+ * "KYC / CDD TRACKER — ALL ENTITIES" Asana project.
+ *
+ * Why this exists:
+ *   The existing `tenantProvisioner.ts` covers the PER-TENANT
+ *   compliance programme project — one per customer entity (FG LLC,
+ *   FG BRANCH, MADISON, GRAMALTIN, NAPLES, ZOE). That project
+ *   tracks the tenant's own compliance lifecycle.
+ *
+ *   There is ALSO a tenant-agnostic "KYC / CDD TRACKER" project
+ *   that aggregates CDD workstreams across ALL entities — it's
+ *   where Luisa (MLRO) looks every morning to see who is pending
+ *   document collection, who is awaiting a sanctions screen, who
+ *   is blocked on UBO verification, and so on.
+ *
+ *   When the project was first created in Asana, only the happy-path
+ *   sections were populated (New Onboarding Queue, Standard CDD,
+ *   EDD Cases, Periodic Reviews, Exited / Rejected, Approved &
+ *   Archived). That omitted the "exception lanes" where compliance
+ *   work actually lives — Document Collection, Sanctions Match,
+ *   Source of Funds, UBO Verification, Four-Eyes Review, STR Filing,
+ *   Senior Management Approval, Board PEP Approval, etc.
+ *
+ *   This module is the canonical section plan. It is PURE — a list
+ *   of `{ name, regulatoryAnchor, rationale }` records that a
+ *   bootstrap endpoint walks against the Asana API to ensure every
+ *   section exists. The endpoint is idempotent: sections that
+ *   already exist are reused by name match, missing sections are
+ *   created, the "Untitled section" placeholder Asana auto-creates
+ *   on project creation is deleted if empty.
+ *
+ *   Pure function. No I/O, no state, safe for tests and for the
+ *   netlify function that consumes it.
+ *
+ * Regulatory basis:
+ *   FDL No.10/2025 Art.12-14 (CDD tier + thresholds)
+ *   FDL No.10/2025 Art.20-22 (CO continuous oversight)
+ *   FDL No.10/2025 Art.24    (10yr retention — every stage logged)
+ *   FDL No.10/2025 Art.26-27 (STR / SAR filing obligations)
+ *   FDL No.10/2025 Art.29    (tipping-off prohibition)
+ *   FDL No.10/2025 Art.35    (TFS screening)
+ *   Cabinet Res 134/2025 Art.7-10 (CDD tier-level data collection)
+ *   Cabinet Res 134/2025 Art.14   (EDD + PEP senior management + Board)
+ *   Cabinet Res 134/2025 Art.19   (internal review + four-eyes)
+ *   Cabinet Res 74/2020 Art.4-7   (TFS asset freeze, 24h EOCN)
+ *   Cabinet Decision 109/2023     (UBO register, >25% threshold)
+ *   FATF Rec 10 (CDD)
+ *   FATF Rec 12 (PEP — board approval)
+ *   FATF Rec 22 (DPMS CDD)
+ */
+
+/**
+ * A single section in the KYC / CDD Tracker project.
+ *
+ * `name` is the human-readable label the MLRO sees in Asana. Changes
+ * to name will make the idempotent bootstrap treat the section as
+ * new (no rename, just add), so pick names carefully.
+ *
+ * `regulatoryAnchor` is a short citation anchoring the stage to UAE
+ * regulation or FATF. Rendered in the Netlify function response and
+ * surfaced in the setup wizard output so the MLRO can explain to
+ * inspectors why each stage exists.
+ *
+ * `rationale` is plain-English operator-facing description.
+ *
+ * `isTerminal` marks the end-of-lifecycle sections (Exited /
+ * Rejected / Approved & Archived) that MUST be preserved at the
+ * bottom of the project and never reordered ahead of pending work.
+ */
+export interface KycCddTrackerSection {
+  readonly name: string;
+  readonly regulatoryAnchor: string;
+  readonly rationale: string;
+  readonly isTerminal?: boolean;
+}
+
+/**
+ * The canonical section plan, in top-to-bottom display order. The
+ * ordering matches the natural CDD lifecycle: intake → exception
+ * lanes → CDD proper → EDD → approvals → terminal.
+ *
+ * Do NOT reorder casually — the MLRO navigates this daily and any
+ * reorder needs a commit message that explains WHY.
+ */
+export const KYC_CDD_TRACKER_SECTIONS: readonly KycCddTrackerSection[] = [
+  {
+    name: '📥 Document Collection — Awaiting Customer',
+    regulatoryAnchor: 'FDL Art.12-14 / Cabinet Res 134/2025 Art.7-10',
+    rationale:
+      'Customer identification documents requested but not yet received. Sits here until the customer replies; if idle > 30 days, auto-escalate to CDD blocked.',
+  },
+  {
+    name: '🆕 New Onboarding Queue',
+    regulatoryAnchor: 'FDL Art.12 / FATF Rec 10',
+    rationale:
+      'New customer onboarding requests that have arrived but not yet been triaged. First stop for every new relationship.',
+  },
+  {
+    name: '🔎 Sanctions Screening In Progress',
+    regulatoryAnchor: 'FDL Art.35 / Cabinet Res 74/2020',
+    rationale:
+      'Active sanctions screen against UN, OFAC, EU, UK, UAE, EOCN lists. Every lead passes through here briefly before CDD completion.',
+  },
+  {
+    name: '👥 UBO Verification Pending',
+    regulatoryAnchor: 'Cabinet Decision 109/2023 (>25% UBO threshold)',
+    rationale:
+      'Beneficial ownership documentation incomplete. Must be resolved before any business relationship starts.',
+  },
+  {
+    name: '💰 Source of Funds / Wealth Pending',
+    regulatoryAnchor: 'FDL Art.14 / Cabinet Res 134/2025 Art.14',
+    rationale:
+      'SoF required for all customers; SoW required for high-risk and EDD cases. Blocker for approval until evidence is attached.',
+  },
+  {
+    name: '📝 Standard CDD — Pending Completion',
+    regulatoryAnchor: 'FDL Art.12-14 / FATF Rec 10',
+    rationale:
+      'Standard-tier CDD (not EDD) in progress. Awaiting one or more required fields from the CDD checklist.',
+  },
+  {
+    name: '📰 Adverse Media Under Review',
+    regulatoryAnchor: 'FATF Rec 10 / Cabinet Res 134/2025 Art.14',
+    rationale:
+      'Adverse media hit detected by the screening pipeline. Needs analyst assessment before the case can move forward.',
+  },
+  {
+    name: '🔴 EDD Cases — High Risk & PEPs',
+    regulatoryAnchor: 'Cabinet Res 134/2025 Art.14 / FATF Rec 12',
+    rationale:
+      'Enhanced Due Diligence workstream. High-risk jurisdiction, high-risk customer type, or PEP. Requires deeper evidence and senior sign-off.',
+  },
+  {
+    name: '👔 Awaiting Senior Management Approval (EDD)',
+    regulatoryAnchor: 'Cabinet Res 134/2025 Art.14',
+    rationale:
+      'EDD case ready for sign-off. Senior management must approve before the business relationship starts or continues.',
+  },
+  {
+    name: '🏛️ Awaiting Board Approval (PEP)',
+    regulatoryAnchor: 'Cabinet Res 134/2025 Art.14 / FATF Rec 12',
+    rationale:
+      'PEP relationships require Board approval, not just senior management. Highest-touch lane, typically rare.',
+  },
+  {
+    name: '👀 Four-Eyes Review Pending',
+    regulatoryAnchor: 'Cabinet Res 134/2025 Art.19',
+    rationale:
+      'Two distinct approvers required before freeze / escalate / high-risk decisions take effect. Deputy MLRO provides the second pair of eyes.',
+  },
+  {
+    name: '🚨 Sanctions Match — Blocked',
+    regulatoryAnchor: 'Cabinet Res 74/2020 Art.4-7 / FDL Art.29',
+    rationale:
+      '24-hour freeze clock running. CNMR filing due within 5 business days. DO NOT tip off the subject (FDL Art.29). MLRO-only.',
+  },
+  {
+    name: '📨 STR Filing Pending — 10bd clock',
+    regulatoryAnchor: 'FDL Art.26-27',
+    rationale:
+      'Suspicion raised, STR / SAR narrative must reach goAML within 10 business days. MLRO action required — do not comment in Asana about the subject.',
+  },
+  {
+    name: '🔄 Periodic Reviews Due',
+    regulatoryAnchor: 'Cabinet Res 134/2025 Art.19',
+    rationale:
+      'Scheduled review checkpoint. High-risk: every 3 months. Medium: 6 months. Low: 12 months. Missing a scheduled review is itself a finding.',
+  },
+  {
+    name: '⚠️ Exited / Rejected Customers',
+    regulatoryAnchor: 'FDL Art.24 (10-year retention)',
+    rationale:
+      'Customers exited voluntarily, rejected during onboarding, or terminated for compliance reasons. Retained for 10 years.',
+    isTerminal: true,
+  },
+  {
+    name: '✅ Approved & Archived',
+    regulatoryAnchor: 'FDL Art.24 (10-year retention)',
+    rationale:
+      'Fully approved, in good standing, moved out of the active queue. Periodic review still fires per the schedule above.',
+    isTerminal: true,
+  },
+];
+
+/**
+ * Count of sections in the canonical plan. Exported for test
+ * assertions and for the setup wizard summary line.
+ */
+export const KYC_CDD_TRACKER_SECTION_COUNT = KYC_CDD_TRACKER_SECTIONS.length;
+
+// ---------------------------------------------------------------------------
+// Diff helper — used by the bootstrap function to decide which
+// sections to create vs keep vs delete.
+// ---------------------------------------------------------------------------
+
+export interface ExistingSection {
+  readonly gid: string;
+  readonly name: string;
+  /** Task count, used only to decide whether a stray "Untitled section" is safe to delete. */
+  readonly taskCount?: number;
+}
+
+export interface SectionDiff {
+  /** Sections to create (in the canonical plan, not yet in Asana). */
+  readonly toCreate: readonly KycCddTrackerSection[];
+  /** Sections already present (by name match) — will be reused. */
+  readonly toKeep: ReadonlyArray<{
+    readonly name: string;
+    readonly gid: string;
+  }>;
+  /** Stray sections to delete. Currently only the empty "Untitled section" placeholder. */
+  readonly toDelete: ReadonlyArray<{
+    readonly name: string;
+    readonly gid: string;
+    readonly reason: string;
+  }>;
+  /** Sections present in Asana that are NOT in the canonical plan but are NOT safe to delete (e.g. custom operator sections with tasks). Reported for transparency. */
+  readonly orphans: ReadonlyArray<{
+    readonly name: string;
+    readonly gid: string;
+    readonly taskCount: number;
+  }>;
+}
+
+/**
+ * Compute the diff between the canonical section plan and the
+ * current state of an Asana project. Pure function.
+ *
+ * Rules:
+ *   - Canonical sections match against existing sections by EXACT
+ *     name equality. Case-sensitive, emoji-sensitive.
+ *   - "Untitled section" is a special case: Asana auto-creates it
+ *     on project creation. It is SAFE TO DELETE if empty
+ *     (taskCount === 0). If it contains tasks, it becomes an
+ *     orphan and is reported but not deleted.
+ *   - Any other section present in Asana but not in the canonical
+ *     plan is an orphan — reported but NEVER auto-deleted. The
+ *     operator may have added custom sections for their own
+ *     workflow and we must not destroy their work.
+ */
+export function diffSections(
+  canonical: readonly KycCddTrackerSection[],
+  existing: readonly ExistingSection[]
+): SectionDiff {
+  const existingByName = new Map(existing.map((s) => [s.name, s]));
+  const canonicalNames = new Set(canonical.map((s) => s.name));
+
+  const toCreate: KycCddTrackerSection[] = [];
+  const toKeep: Array<{ name: string; gid: string }> = [];
+  for (const spec of canonical) {
+    const match = existingByName.get(spec.name);
+    if (match) {
+      toKeep.push({ name: match.name, gid: match.gid });
+    } else {
+      toCreate.push(spec);
+    }
+  }
+
+  const toDelete: Array<{ name: string; gid: string; reason: string }> = [];
+  const orphans: Array<{ name: string; gid: string; taskCount: number }> = [];
+  for (const s of existing) {
+    if (canonicalNames.has(s.name)) continue;
+    if (s.name === 'Untitled section' && (s.taskCount ?? 0) === 0) {
+      toDelete.push({
+        name: s.name,
+        gid: s.gid,
+        reason: 'Asana auto-creates this placeholder on project creation. Empty — safe to remove.',
+      });
+      continue;
+    }
+    orphans.push({ name: s.name, gid: s.gid, taskCount: s.taskCount ?? 0 });
+  }
+
+  return { toCreate, toKeep, toDelete, orphans };
+}

--- a/tests/kycCddTrackerSections.test.ts
+++ b/tests/kycCddTrackerSections.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for src/services/asana/kycCddTrackerSections.ts — the pure
+ * diff/spec module that drives the /api/setup/kyc-cdd-tracker-sections
+ * endpoint.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  KYC_CDD_TRACKER_SECTIONS,
+  KYC_CDD_TRACKER_SECTION_COUNT,
+  diffSections,
+  type ExistingSection,
+} from '../src/services/asana/kycCddTrackerSections';
+
+describe('KYC_CDD_TRACKER_SECTIONS canonical plan', () => {
+  it('has exactly 16 sections', () => {
+    expect(KYC_CDD_TRACKER_SECTION_COUNT).toBe(16);
+    expect(KYC_CDD_TRACKER_SECTIONS).toHaveLength(16);
+  });
+
+  it('every section has a non-empty name and regulatory anchor', () => {
+    for (const s of KYC_CDD_TRACKER_SECTIONS) {
+      expect(s.name.length).toBeGreaterThan(0);
+      expect(s.regulatoryAnchor.length).toBeGreaterThan(0);
+      expect(s.rationale.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('exactly 2 terminal sections (Exited + Approved)', () => {
+    const terminal = KYC_CDD_TRACKER_SECTIONS.filter((s) => s.isTerminal);
+    expect(terminal).toHaveLength(2);
+    expect(terminal.map((s) => s.name)).toEqual([
+      '⚠️ Exited / Rejected Customers',
+      '✅ Approved & Archived',
+    ]);
+  });
+
+  it('terminal sections are the last 2 entries in display order', () => {
+    const last = KYC_CDD_TRACKER_SECTIONS.slice(-2);
+    expect(last.every((s) => s.isTerminal)).toBe(true);
+  });
+
+  it('no duplicate section names', () => {
+    const names = KYC_CDD_TRACKER_SECTIONS.map((s) => s.name);
+    const unique = new Set(names);
+    expect(unique.size).toBe(names.length);
+  });
+
+  it('every regulatory anchor cites at least one UAE law, Cabinet resolution, or FATF recommendation', () => {
+    const re = /FDL|Cabinet (Res|Decision)|FATF|UNSCR/;
+    for (const s of KYC_CDD_TRACKER_SECTIONS) {
+      expect(re.test(s.regulatoryAnchor)).toBe(true);
+    }
+  });
+});
+
+describe('diffSections — brand new project (nothing exists)', () => {
+  it('creates every canonical section and deletes nothing', () => {
+    const result = diffSections(KYC_CDD_TRACKER_SECTIONS, []);
+    expect(result.toCreate).toHaveLength(16);
+    expect(result.toKeep).toHaveLength(0);
+    expect(result.toDelete).toHaveLength(0);
+    expect(result.orphans).toHaveLength(0);
+  });
+});
+
+describe('diffSections — fully provisioned project (idempotent re-run)', () => {
+  it('keeps every canonical section and creates nothing', () => {
+    const existing: ExistingSection[] = KYC_CDD_TRACKER_SECTIONS.map((s, i) => ({
+      gid: `gid-${i}`,
+      name: s.name,
+    }));
+    const result = diffSections(KYC_CDD_TRACKER_SECTIONS, existing);
+    expect(result.toCreate).toHaveLength(0);
+    expect(result.toKeep).toHaveLength(16);
+    expect(result.toDelete).toHaveLength(0);
+    expect(result.orphans).toHaveLength(0);
+  });
+});
+
+describe('diffSections — partially provisioned (real-world screenshot state)', () => {
+  it('creates only the missing sections', () => {
+    // Exactly the state of the user's project from the screenshots:
+    // 7 existing sections (including the default Untitled section).
+    const existing: ExistingSection[] = [
+      { gid: 'g0', name: 'Untitled section', taskCount: 0 },
+      { gid: 'g1', name: '🆕 New Onboarding Queue', taskCount: 2 },
+      { gid: 'g2', name: '📝 Standard CDD — Pending Completion', taskCount: 4 },
+      { gid: 'g3', name: '🔴 EDD Cases — High Risk & PEPs', taskCount: 3 },
+      { gid: 'g4', name: '🔄 Periodic Reviews Due', taskCount: 4 },
+      { gid: 'g5', name: '⚠️ Exited / Rejected Customers', taskCount: 1 },
+      { gid: 'g6', name: '✅ Approved & Archived', taskCount: 1 },
+    ];
+    const result = diffSections(KYC_CDD_TRACKER_SECTIONS, existing);
+
+    // Keeps the 6 canonical sections already present.
+    expect(result.toKeep).toHaveLength(6);
+
+    // Creates the 10 exception-lane sections that were missing.
+    expect(result.toCreate).toHaveLength(10);
+    expect(result.toCreate.map((s) => s.name)).toEqual([
+      '📥 Document Collection — Awaiting Customer',
+      '🔎 Sanctions Screening In Progress',
+      '👥 UBO Verification Pending',
+      '💰 Source of Funds / Wealth Pending',
+      '📰 Adverse Media Under Review',
+      '👔 Awaiting Senior Management Approval (EDD)',
+      '🏛️ Awaiting Board Approval (PEP)',
+      '👀 Four-Eyes Review Pending',
+      '🚨 Sanctions Match — Blocked',
+      '📨 STR Filing Pending — 10bd clock',
+    ]);
+
+    // Deletes the empty Untitled section placeholder.
+    expect(result.toDelete).toHaveLength(1);
+    expect(result.toDelete[0]!.name).toBe('Untitled section');
+    expect(result.toDelete[0]!.gid).toBe('g0');
+
+    // No orphans.
+    expect(result.orphans).toHaveLength(0);
+  });
+});
+
+describe('diffSections — Untitled section protection rule', () => {
+  it('deletes empty Untitled section (the Asana placeholder)', () => {
+    const existing: ExistingSection[] = [{ gid: 'gX', name: 'Untitled section', taskCount: 0 }];
+    const result = diffSections(KYC_CDD_TRACKER_SECTIONS, existing);
+    expect(result.toDelete).toHaveLength(1);
+    expect(result.toDelete[0]!.reason).toMatch(/placeholder/i);
+  });
+
+  it('treats Untitled section with undefined taskCount as empty (safe to delete)', () => {
+    const existing: ExistingSection[] = [{ gid: 'gX', name: 'Untitled section' }];
+    const result = diffSections(KYC_CDD_TRACKER_SECTIONS, existing);
+    expect(result.toDelete).toHaveLength(1);
+  });
+
+  it('does NOT delete Untitled section if it has tasks — reports as orphan instead', () => {
+    const existing: ExistingSection[] = [{ gid: 'gX', name: 'Untitled section', taskCount: 3 }];
+    const result = diffSections(KYC_CDD_TRACKER_SECTIONS, existing);
+    expect(result.toDelete).toHaveLength(0);
+    expect(result.orphans).toHaveLength(1);
+    expect(result.orphans[0]!.name).toBe('Untitled section');
+    expect(result.orphans[0]!.taskCount).toBe(3);
+  });
+});
+
+describe('diffSections — operator custom sections (orphan handling)', () => {
+  it('never auto-deletes a custom section the operator added', () => {
+    const existing: ExistingSection[] = [
+      { gid: 'gC', name: '🌟 Luisa Special Workflow', taskCount: 5 },
+      { gid: 'gA', name: '🆕 New Onboarding Queue', taskCount: 2 },
+    ];
+    const result = diffSections(KYC_CDD_TRACKER_SECTIONS, existing);
+    expect(result.toDelete).toHaveLength(0);
+    expect(result.orphans).toHaveLength(1);
+    expect(result.orphans[0]!.name).toBe('🌟 Luisa Special Workflow');
+    expect(result.orphans[0]!.taskCount).toBe(5);
+  });
+
+  it('reports an empty custom section as orphan (still not deleted)', () => {
+    const existing: ExistingSection[] = [
+      { gid: 'gC', name: '📋 Custom Review Lane', taskCount: 0 },
+    ];
+    const result = diffSections(KYC_CDD_TRACKER_SECTIONS, existing);
+    expect(result.toDelete).toHaveLength(0);
+    expect(result.orphans).toHaveLength(1);
+  });
+});
+
+describe('diffSections — exact-match name rules', () => {
+  it('treats case-sensitive name differences as distinct', () => {
+    const existing: ExistingSection[] = [{ gid: 'g1', name: 'new onboarding queue', taskCount: 0 }];
+    const result = diffSections(KYC_CDD_TRACKER_SECTIONS, existing);
+    // Lowercase version doesn't match the canonical 🆕 emoji version.
+    expect(result.toCreate).toHaveLength(16);
+    expect(result.orphans).toHaveLength(1);
+  });
+
+  it('treats emoji-missing name as distinct', () => {
+    const existing: ExistingSection[] = [{ gid: 'g1', name: 'New Onboarding Queue', taskCount: 0 }];
+    const result = diffSections(KYC_CDD_TRACKER_SECTIONS, existing);
+    // Without the 🆕 emoji, doesn't match the canonical plan entry.
+    expect(result.toCreate).toHaveLength(16);
+    expect(result.orphans).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Completes the tenant-agnostic **KYC / CDD TRACKER — ALL ENTITIES** Asana project with the 10 exception-lane sections it was missing, and adds a one-click browser-only provisioner (setup.html Step 9) so operators can re-verify the section layout from any phone. Deletes the stray empty "Untitled section" Asana placeholder that was sitting at the top of the project.

## Why

From operator screenshots, the KYC/CDD Tracker project currently has 7 sections — 6 happy-path lanes + 1 empty `Untitled section` placeholder. That shape omits every **exception lane** where compliance work actually lives:

- Document Collection (waiting on customer)
- Sanctions Screening
- UBO Verification
- Source of Funds / Wealth
- Adverse Media Review
- EDD Senior Management Approval
- PEP Board Approval
- Four-Eyes Review
- Sanctions Match / Freeze
- STR Filing (10bd clock)

Every one of those maps to a specific UAE AML/CFT requirement (FDL No.10/2025, Cabinet Res 134/2025, Cabinet Res 74/2020, Cabinet Decision 109/2023, FATF Rec 10/12/22). Without them, the MLRO has nowhere to put cases that are waiting on UBO docs, SoF, Senior Management approval, or an STR deadline — everything collapses into "Standard CDD — Pending Completion" and the lanes become invisible.

## The canonical section plan (16 sections)

| # | Section | Regulatory anchor |
|---|---|---|
| 1 | 📥 Document Collection — Awaiting Customer | FDL Art.12-14 / Cabinet Res 134/2025 Art.7-10 |
| 2 | 🆕 New Onboarding Queue | FDL Art.12 / FATF Rec 10 |
| 3 | 🔎 Sanctions Screening In Progress | FDL Art.35 / Cabinet Res 74/2020 |
| 4 | 👥 UBO Verification Pending | Cabinet Decision 109/2023 (>25% threshold) |
| 5 | 💰 Source of Funds / Wealth Pending | FDL Art.14 / Cabinet Res 134/2025 Art.14 |
| 6 | 📝 Standard CDD — Pending Completion | FDL Art.12-14 / FATF Rec 10 |
| 7 | 📰 Adverse Media Under Review | FATF Rec 10 / Cabinet Res 134/2025 Art.14 |
| 8 | 🔴 EDD Cases — High Risk & PEPs | Cabinet Res 134/2025 Art.14 / FATF Rec 12 |
| 9 | 👔 Awaiting Senior Management Approval (EDD) | Cabinet Res 134/2025 Art.14 |
| 10 | 🏛️ Awaiting Board Approval (PEP) | Cabinet Res 134/2025 Art.14 / FATF Rec 12 |
| 11 | 👀 Four-Eyes Review Pending | Cabinet Res 134/2025 Art.19 |
| 12 | 🚨 Sanctions Match — Blocked | Cabinet Res 74/2020 Art.4-7 / FDL Art.29 |
| 13 | 📨 STR Filing Pending — 10bd clock | FDL Art.26-27 |
| 14 | 🔄 Periodic Reviews Due | Cabinet Res 134/2025 Art.19 |
| 15 | ⚠️ Exited / Rejected Customers (terminal) | FDL Art.24 (10yr retention) |
| 16 | ✅ Approved & Archived (terminal) | FDL Art.24 (10yr retention) |

## What changed

### New files

**`src/services/asana/kycCddTrackerSections.ts`** — pure specification module. Exports:
- `KYC_CDD_TRACKER_SECTIONS` — the canonical 16-section plan in display order, with regulatory anchors + rationale
- `KYC_CDD_TRACKER_SECTION_COUNT` — export for test assertions
- `diffSections(canonical, existing)` — pure diff function that returns `{ toCreate, toKeep, toDelete, orphans }`. The diff logic enforces three safety rules:
  1. Exact-match name equality (case + emoji sensitive)
  2. The Asana `Untitled section` placeholder is **safe to delete if empty**; **never if it has tasks**
  3. Any other section present in Asana but not in the canonical plan is an **orphan** — reported but **NEVER auto-deleted** (operator custom workflows are preserved)

**`tests/kycCddTrackerSections.test.ts`** — 16 unit tests covering:
- Canonical plan invariants (count, uniqueness, terminal section ordering, regulatory-anchor regex)
- Empty project → all 16 created, nothing else
- Fully provisioned project → all 16 kept, 0 created (idempotent)
- **Exact state from the operator screenshot** — 7 existing sections → 6 kept + 10 created + 1 deleted (the empty Untitled)
- Untitled section protection rule (empty + undefined taskCount → delete; non-empty → orphan)
- Operator custom section preservation (never auto-deleted regardless of task count)
- Exact-match name rules (lowercase / emoji-missing variants → orphan, not match)

**`netlify/functions/setup-kyc-cdd-tracker-sections.mts`** — HTTP endpoint at `POST /api/setup/kyc-cdd-tracker-sections`. Mirrors the existing `setup-asana-bootstrap.mts` pattern exactly:
- OPTIONS + POST only
- Bearer `HAWKEYE_BRAIN_TOKEN` auth via `authenticate()`
- Rate limited 5 / 15 min (write-heavy endpoint)
- Reads `ASANA_ACCESS_TOKEN` from env
- Lists sections via `GET /projects/{gid}/sections`, counts tasks via `GET /sections/{gid}/tasks?limit=1` (only need to know 0 vs non-zero, so we stop at limit=1 for cost)
- Runs `diffSections()` (pure) to produce the create/keep/delete plan
- Walks the plan: creates missing, deletes the empty Untitled, reports orphans without touching them
- Returns full per-step audit trail + Netlify Blobs audit record for 10yr retention (FDL Art.24)

### Edited files

**`setup.html`** — new Step 9 block inserted between existing Step 8 (Bootstrap Asana tenant) and the renumbered Step 10 "You are live". Single input (project GID), single button. Matches Step 8 UX exactly. Renumbered downstream: Step 9 → Step 10 (live), Step 10 → Step 11 (post-setup checklist).

**`setup.js`** — added `btn-kyc-cdd-sections` click handler that POSTs `{ projectGid }` to `/api/setup/kyc-cdd-tracker-sections` with the brain bearer token. Client-side validation: GID must be digits only. Error states mirror Step 8.

## Operator workflow

1. Open `https://hawkeye-sterling-v2.netlify.app/setup.html` on any phone
2. Scroll to **Step 9 — Provision KYC / CDD Tracker sections**
3. Paste the Asana project GID (digit-only, found in the Asana project URL)
4. Click **📋 Provision KYC/CDD Tracker sections**
5. See the per-step audit trail in the output box
6. Done — all 16 sections are present, Untitled placeholder is gone, operator custom sections preserved

Idempotent. Safe to re-run at any time. No terminal required.

## Safety guarantees

- **Operator custom sections are NEVER deleted.** If you added a custom lane called `🌟 Luisa Special Workflow`, the bootstrap sees it as an orphan, reports it in the response, and leaves it alone.
- **Untitled section is only deleted if empty.** If tasks somehow live in "Untitled section", the bootstrap reports it as an orphan and does not touch it. The operator can rename or move tasks manually.
- **Name matching is exact.** A renamed canonical section (e.g. operator removed an emoji) would result in the bootstrap creating a duplicate. Trade-off: safer than fuzzy matching which could merge distinct sections.
- **Everything is audited.** Every run writes a JSON record to the `setup-audit` Netlify Blobs store for 10-year retention per FDL Art.24.

## Quality gate (full CI run locally, Node 22)

| Check | Result |
|---|---|
| `prettier --check 'src/**/*.{ts,tsx}'` | ✅ clean |
| `tsc --noEmit` | ✅ clean |
| `eslint src/ --ext .ts,.tsx` | ✅ clean |
| `vitest run` (full suite) | ✅ **236 files / 3703 tests passing** |
| `vitest run tests/kycCddTrackerSections.test.ts` | ✅ **16/16 pass** (new) |

## Regulatory citation (CLAUDE.md §8)

This change touches `src/services/asana/` and `netlify/functions/`. The section plan and the HTTP endpoint cite their regulatory anchors in the module docstring per:

- **FDL No.10/2025** Art.12-14 (CDD), Art.20-22 (CO oversight), Art.24 (10yr retention), Art.26-27 (STR/SAR filing), Art.29 (tipping-off), Art.35 (TFS screening)
- **Cabinet Res 134/2025** Art.7-10 (CDD data), Art.14 (EDD + PEP approvals), Art.19 (four-eyes review)
- **Cabinet Res 74/2020** Art.4-7 (TFS asset freeze, 24h EOCN)
- **Cabinet Decision 109/2023** (UBO register, >25% threshold)
- **FATF Rec 10** (CDD), **Rec 12** (PEP Board approval), **Rec 22** (DPMS CDD)

No threshold, deadline, or decision pathway changed. `src/domain/constants.ts` untouched.

## Test plan

- [ ] CI runs `lint-and-test (20)` on this PR → green
- [ ] Merge → `hawkeye-sterling-v2` auto-deploy succeeds
- [ ] Operator opens `/setup.html` on phone → Step 9 visible
- [ ] Operator pastes KYC/CDD Tracker project GID → clicks button
- [ ] Response shows 10 sections created, 6 kept, 1 deleted (Untitled), 0 orphans
- [ ] Re-run Step 9 immediately → response shows 0 created, 16 kept, 0 deleted, 0 orphans (idempotent)
- [ ] Asana project now has 16 sections in the correct order, empty Untitled gone
- [ ] MLRO can reassign pending tasks to the new specific lanes

## Rollback

Fully reversible with `git revert`. The new section module, tests, and function are additive — reverting removes the feature without affecting any existing functionality. The setup.html step renumbering is also reverted cleanly. No data is destroyed by the bootstrap itself; only the empty Asana placeholder is removed, which Asana auto-recreates if a new empty project is seeded later.
