### PR TITLE
Add entity-lumping linter + scanner (per-entity CDD rule)

### DIFF
--- a/netlify/functions/scan-lumped-tasks.mts
+++ b/netlify/functions/scan-lumped-tasks.mts
@@ -1,0 +1,208 @@
+/**
+ * Scan Lumped Tasks — read-only scan of an Asana project to find
+ * tasks whose title lumps multiple legal entities together, which
+ * is a compliance-level rule violation per FDL Art.12-14 and
+ * Cabinet Res 134/2025 Art.7-10 (CDD data collection per entity).
+ *
+ * POST /api/setup/scan-lumped-tasks
+ *
+ * Body:
+ *   { projectGid: "1234567890123456" }
+ *
+ * What it does:
+ *   1. GET /projects/{gid}/tasks?opt_fields=gid,name (pagination via offset)
+ *   2. For each task, runs lintTaskTitle() (pure, no I/O)
+ *   3. Returns the structured scan report including per-lumped-task
+ *      detail (gid, name, entity count, entities)
+ *
+ * READ-ONLY — never mutates Asana. The MLRO uses the output to
+ * split tasks manually or can run the task-splitter endpoint
+ * (if/when implemented) with targeted gids.
+ *
+ * Security:
+ *   POST + OPTIONS
+ *   Bearer HAWKEYE_BRAIN_TOKEN required
+ *   Rate limited 5 / 15 min
+ *
+ * Regulatory basis:
+ *   FDL No.10/2025 Art.12-14 (CDD per customer)
+ *   FDL No.10/2025 Art.24    (10yr retention — per-entity audit)
+ *   FDL No.10/2025 Art.26-27 (STR / SAR per subject)
+ *   Cabinet Res 134/2025 Art.7-10 (CDD data collection per entity)
+ *   Cabinet Res 134/2025 Art.19   (internal review per case)
+ *   Cabinet Decision 109/2023     (UBO register per entity)
+ *   FATF Rec 10 (CDD)
+ *   FATF Rec 22 (DPMS CDD)
+ */
+
+import type { Config, Context } from '@netlify/functions';
+import { checkRateLimit } from './middleware/rate-limit.mts';
+import { authenticate } from './middleware/auth.mts';
+import {
+  scanForLumpedTasks,
+  type ExistingTask,
+} from '../../src/services/asana/entityLumpingLinter';
+
+const ASANA_BASE = 'https://app.asana.com/api/1.0';
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin':
+    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://hawkeye-sterling-v2.netlify.app',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+  'Access-Control-Max-Age': '600',
+  Vary: 'Origin',
+} as const;
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return Response.json(body, {
+    ...init,
+    headers: { ...CORS_HEADERS, ...(init.headers ?? {}) },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Asana fetcher — paginated task list over a project
+// ---------------------------------------------------------------------------
+
+async function fetchAllTasks(projectGid: string, token: string): Promise<ExistingTask[]> {
+  const all: ExistingTask[] = [];
+  let offset: string | null = null;
+  const pageSize = 100;
+  // Safety ceiling: if a project has more than 10_000 tasks we stop
+  // paginating. The MLRO can narrow the scope to a single section
+  // in a follow-up if this ever bites.
+  const maxPages = 100;
+
+  for (let page = 0; page < maxPages; page++) {
+    const params = new URLSearchParams({
+      opt_fields: 'gid,name',
+      limit: String(pageSize),
+    });
+    if (offset) params.set('offset', offset);
+
+    const url = `${ASANA_BASE}/projects/${encodeURIComponent(projectGid)}/tasks?${params.toString()}`;
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+      },
+      signal: AbortSignal.timeout(25_000),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(
+        `Asana GET /projects/${projectGid}/tasks → ${res.status}: ${text.slice(0, 200)}`
+      );
+    }
+    const json = (await res.json()) as {
+      data: Array<{ gid: string; name: string }>;
+      next_page?: { offset: string } | null;
+    };
+    for (const t of json.data) {
+      all.push({ gid: t.gid, name: t.name });
+    }
+    if (!json.next_page || !json.next_page.offset) break;
+    offset = json.next_page.offset;
+  }
+  return all;
+}
+
+// ---------------------------------------------------------------------------
+// Request validation
+// ---------------------------------------------------------------------------
+
+interface ScanRequest {
+  projectGid: string;
+}
+
+function validate(raw: unknown): { ok: true; req: ScanRequest } | { ok: false; error: string } {
+  if (!raw || typeof raw !== 'object') return { ok: false, error: 'body must be an object' };
+  const r = raw as Record<string, unknown>;
+  if (typeof r.projectGid !== 'string' || r.projectGid.length === 0 || r.projectGid.length > 32) {
+    return { ok: false, error: 'projectGid must be 1..32 chars' };
+  }
+  if (!/^\d+$/.test(r.projectGid)) {
+    return { ok: false, error: 'projectGid must contain only digits (Asana GID format)' };
+  }
+  return { ok: true, req: { projectGid: r.projectGid } };
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export default async (req: Request, context: Context): Promise<Response> => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+  }
+  if (req.method !== 'POST') {
+    return jsonResponse({ error: 'Method not allowed' }, { status: 405 });
+  }
+
+  const rl = await checkRateLimit(req, {
+    max: 5,
+    clientIp: context.ip,
+    namespace: 'scan-lumped-tasks',
+  });
+  if (rl) return rl;
+
+  const auth = authenticate(req);
+  if (!auth.ok) return auth.response!;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return jsonResponse({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const v = validate(body);
+  if (!v.ok) return jsonResponse({ error: v.error }, { status: 400 });
+
+  const accessToken = process.env.ASANA_ACCESS_TOKEN;
+  if (!accessToken || accessToken.length < 16) {
+    return jsonResponse(
+      { error: 'ASANA_ACCESS_TOKEN env var missing or invalid' },
+      { status: 503 }
+    );
+  }
+
+  const { projectGid } = v.req;
+
+  let tasks: ExistingTask[];
+  try {
+    tasks = await fetchAllTasks(projectGid, accessToken);
+  } catch (err) {
+    return jsonResponse(
+      {
+        error: 'asana_task_list_failed',
+        reason: err instanceof Error ? err.message : String(err),
+        projectGid,
+      },
+      { status: 502 }
+    );
+  }
+
+  // Pure scan — no I/O after this point.
+  const report = scanForLumpedTasks(tasks);
+
+  return jsonResponse(
+    {
+      ok: report.lumpedTasks.length === 0,
+      projectGid,
+      scanned: report.scanned,
+      cleanCount: report.cleanCount,
+      lumpedCount: report.lumpedTasks.length,
+      summary: report.summary,
+      findings: report.lumpedTasks,
+      regulatory: report.regulatory,
+    },
+    { status: 200 }
+  );
+};
+
+export const config: Config = {
+  path: '/api/setup/scan-lumped-tasks',
+  method: ['POST', 'OPTIONS'],
+};

--- a/setup.html
+++ b/setup.html
@@ -337,8 +337,21 @@ cust-2,Bob Smith,tenant-a,Robert Smith,1985-04-15,GB,2026-04-10T00:00:00Z</pre>
 
   <!-- STEP 10 -->
   <div class="step">
-    <h2>Step 10 — You are live 🎉</h2>
-    <p>When Steps 6, 7, 8 and 9 all show <span class="status ok">OK</span>, open the tool in a new tab and start using it.</p>
+    <h2>Step 10 — Scan for lumped entity tasks</h2>
+    <p class="muted">Compliance rule: <b>each legal entity must have its own dedicated Asana task.</b> Lumping multiple entities (e.g. "GRAMALTIN AS / NAPLES LLC / ZOE FZE — review") into one task breaks the per-entity audit trail required by FDL Art.24 and Cabinet Res 134/2025 Art.7-10. This scanner is read-only: it lists every task in the project whose title mentions 2+ entities, so you can split them manually in Asana.</p>
+    <label>Asana project GID to scan</label>
+    <input type="text" id="input-scan-project-gid" placeholder="1234567890123456 (digits only, from the Asana project URL)">
+    <div class="row">
+      <button class="primary" id="btn-scan-lumped">🔍 Scan for lumped tasks</button>
+      <span id="scan-lumped-status"></span>
+    </div>
+    <div class="output" id="scan-lumped-output">(enter project GID and click to scan)</div>
+  </div>
+
+  <!-- STEP 11 -->
+  <div class="step">
+    <h2>Step 11 — You are live 🎉</h2>
+    <p>When Steps 6, 7, 8, 9 and 10 all show <span class="status ok">OK</span>, open the tool in a new tab and start using it.</p>
     <p><a id="link-tool" target="_blank">→ Open HAWKEYE STERLING</a></p>
     <p><a id="link-brain" target="_blank">→ Open Brain Console</a></p>
     <p><a id="link-status" target="_blank">→ Open public status page</a></p>
@@ -347,9 +360,9 @@ cust-2,Bob Smith,tenant-a,Robert Smith,1985-04-15,GB,2026-04-10T00:00:00Z</pre>
     </div>
   </div>
 
-  <!-- STEP 11 -->
+  <!-- STEP 12 -->
   <div class="step">
-    <h2>Step 11 — Post-setup checklist (human work, not the tool)</h2>
+    <h2>Step 12 — Post-setup checklist (human work, not the tool)</h2>
     <ul>
       <li>Register your firm with the <a href="https://goaml.uaefiu.gov.ae/" target="_blank">UAE FIU goAML portal</a></li>
       <li>Sign the <a href="https://www.anthropic.com/legal/data-processing" target="_blank">Anthropic Data Processing Agreement</a> (required for any EU-resident customer)</li>

--- a/setup.js
+++ b/setup.js
@@ -273,6 +273,36 @@
     });
   });
 
+  // --- Step 9: scan for lumped entity tasks ---
+  byId('btn-scan-lumped').addEventListener('click', function () {
+    readInputs();
+    var projectGid = byId('input-scan-project-gid').value.trim();
+    if (!projectGid) {
+      setStatus('scan-lumped-status', 'err', 'Project GID required');
+      return;
+    }
+    if (!/^\d+$/.test(projectGid)) {
+      setStatus('scan-lumped-status', 'err', 'GID must be digits only');
+      return;
+    }
+    setStatus('scan-lumped-status', 'pending', 'Scanning…');
+    var token = state.brainToken;
+    fetch(apiBase() + '/api/setup/scan-lumped-tasks', {
+      method: 'POST',
+      headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectGid: projectGid }),
+    }).then(function (r) {
+      return r.json().then(function (body) { return { status: r.status, body: body }; });
+    }).then(function (res) {
+      var ok = res.status < 400 && res.body && res.body.ok !== false;
+      setStatus('scan-lumped-status', ok ? 'ok' : 'err', ok ? 'Clean' : 'Findings');
+      writeOutput('scan-lumped-output', JSON.stringify(res.body, null, 2));
+    }).catch(function (err) {
+      setStatus('scan-lumped-status', 'err', 'Network error');
+      writeOutput('scan-lumped-output', String(err));
+    });
+  });
+
   // --- Step 8: bootstrap Asana ---
   byId('btn-bootstrap').addEventListener('click', function () {
     readInputs();

--- a/src/services/asana/entityLumpingLinter.ts
+++ b/src/services/asana/entityLumpingLinter.ts
@@ -1,0 +1,306 @@
+/**
+ * Entity Lumping Linter — detects compliance task titles that mention
+ * more than one legal entity from COMPANY_REGISTRY, so the dispatcher
+ * can reject them at creation time and the setup wizard can flag
+ * existing lumped tasks for operator cleanup.
+ *
+ * Why this exists:
+ *   UAE AML/CFT requires per-entity CDD records and audit trails.
+ *   Lumping multiple entities into a single Asana task destroys the
+ *   per-entity audit trail, breaks the four-eyes approver chain
+ *   (which key is pinned to which entity?), collapses the deadline
+ *   calendar (a single due date cannot enforce 3 different review
+ *   cycles), and makes the SLA enforcer unreliable.
+ *
+ *   An observed failure mode (from operator screenshots):
+ *
+ *     Standard CDD — Pending Completion:
+ *       FG LLC — CDD Outstanding Files Review
+ *       FG BRANCH — CDD Outstanding Files Review
+ *       MADISON LLC — CDD Outstanding Files Review
+ *       GRAMALTIN AS / NAPLES LLC / ZOE FZE — CDD Outstanding Files Review  ← LUMPED
+ *
+ *   Three distinct legal entities (Gramaltin, Naples, Zoe) were lumped
+ *   into a single task. The MLRO cannot tell from the task alone which
+ *   entity is blocking approval, and any document attached becomes
+ *   ambiguous evidence for audit purposes. This module prevents that
+ *   class of task from being created, and provides a diff tool the
+ *   setup wizard calls to report existing lumps.
+ *
+ *   Pure function. No I/O, no state, no network. Safe for tests and
+ *   for netlify functions.
+ *
+ * Regulatory basis:
+ *   FDL No.10/2025 Art.12-14 (CDD — per-customer obligation)
+ *   FDL No.10/2025 Art.24    (10yr retention — per-entity audit trail)
+ *   FDL No.10/2025 Art.26-27 (STR / SAR filing — per-subject)
+ *   Cabinet Res 134/2025 Art.7-10 (CDD data collection per entity)
+ *   Cabinet Res 134/2025 Art.19   (internal review per case)
+ *   Cabinet Decision 109/2023     (UBO register per entity)
+ *   FATF Rec 10 (CDD)
+ *   FATF Rec 22 (DPMS CDD)
+ */
+
+// ---------------------------------------------------------------------------
+// Entity alias table
+// ---------------------------------------------------------------------------
+
+/**
+ * One record per legal entity in COMPANY_REGISTRY, with the list of
+ * aliases an operator might reasonably type into an Asana task title.
+ *
+ * Hand-coded rather than auto-derived from COMPANY_REGISTRY because:
+ *
+ *   1. `FG LLC` and `FG BRANCH` both live under the `Fine Gold Group`
+ *      and would conflict if derived naively from the short name "FG".
+ *   2. Auto-derivation from the long legal name (e.g. "GRAMALTIN
+ *      KIYMETLI MADENLER RAFINERI SANAYI VE TICARET ANONIM SIRKETI")
+ *      would produce too many false positives on common tokens like
+ *      "TICARET" or "SANAYI".
+ *   3. The linter is a compliance tripwire — every entity in this
+ *      table is audit-visible. Hand-curation keeps operator intent
+ *      explicit.
+ *
+ * Match rules:
+ *   - Case-insensitive substring match against the task title
+ *   - Each alias is at least 4 characters (short tokens produce false
+ *     positives on unrelated words — e.g. "AS" would match any
+ *     sentence containing "as")
+ *   - The first matching alias per entity "wins" — the linter reports
+ *     at most one match per entity, never duplicates
+ */
+export interface EntityAliasRecord {
+  /** Stable id matching the COMPANY_REGISTRY entry. */
+  readonly entityId: string;
+  /** Display name used in linter error messages. */
+  readonly displayName: string;
+  /** Case-insensitive substrings that identify this entity in a task title. */
+  readonly aliases: readonly string[];
+}
+
+export const ENTITY_ALIASES: readonly EntityAliasRecord[] = [
+  {
+    entityId: 'company-1',
+    displayName: 'MADISON LLC',
+    aliases: ['MADISON LLC', 'MADISON L.L.C', 'MADISON JEWELLERY', 'MADISON'],
+  },
+  {
+    entityId: 'company-2',
+    displayName: 'NAPLES LLC',
+    aliases: ['NAPLES LLC', 'NAPLES L.L.C', 'NAPLES JEWELLERY', 'NAPLES'],
+  },
+  {
+    entityId: 'company-3',
+    displayName: 'GRAMALTIN AS',
+    aliases: ['GRAMALTIN AS', 'GRAMALTIN KIYMETLI', 'GRAMALTIN'],
+  },
+  {
+    entityId: 'company-4',
+    displayName: 'ZOE FZE',
+    aliases: ['ZOE FZE', 'ZOE PRECIOUS', 'ZOE (FZE)'],
+  },
+  {
+    entityId: 'company-5',
+    // FG LLC must be disambiguated from FG BRANCH. Aliases that
+    // match both ("FINE GOLD", "FG") are OMITTED — the linter is
+    // only confident a title names FG LLC when it explicitly says
+    // "FG LLC" / "FINE GOLD LLC" etc. Ambiguous "FG" mentions do
+    // not count as a match for either entity, preventing the
+    // linter from reporting a false lump.
+    displayName: 'FG LLC',
+    aliases: ['FG LLC', 'FINE GOLD LLC', 'FG L.L.C'],
+  },
+  {
+    entityId: 'company-6',
+    displayName: 'FG BRANCH',
+    aliases: ['FG BRANCH', 'FINE GOLD BRANCH', 'FG (BRANCH)', 'FINE GOLD (BRANCH)'],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Lint result
+// ---------------------------------------------------------------------------
+
+export interface LumpingMatch {
+  readonly entityId: string;
+  readonly displayName: string;
+  /** The alias that matched. */
+  readonly alias: string;
+  /** 0-based position of the match in the title (for debugging). */
+  readonly position: number;
+}
+
+export interface LumpingLintResult {
+  /** True if the title mentions 2 or more distinct entities. */
+  readonly isLumped: boolean;
+  /** Every distinct entity match, ordered by first-occurrence position. */
+  readonly matches: readonly LumpingMatch[];
+  /** Plain-English error message when `isLumped` is true, null otherwise. */
+  readonly error: string | null;
+  /** Regulatory anchor for the finding. */
+  readonly regulatory: string;
+}
+
+/**
+ * Lint a single task title. Pure function.
+ *
+ * Returns `isLumped: true` if the title mentions 2 or more distinct
+ * entities from `ENTITY_ALIASES`. The match list is ordered by
+ * first-occurrence position, so the caller can highlight the alias
+ * positions in the UI if needed.
+ *
+ * Empty / whitespace-only / `null` titles return a clean result
+ * (nothing to lint).
+ */
+export function lintTaskTitle(
+  title: string | undefined | null,
+  registry: readonly EntityAliasRecord[] = ENTITY_ALIASES
+): LumpingLintResult {
+  const clean = typeof title === 'string' ? title.trim() : '';
+  const regulatory = 'FDL Art.12-14 / Art.24 / Cabinet Res 134/2025 Art.7-10';
+
+  if (clean.length === 0) {
+    return { isLumped: false, matches: [], error: null, regulatory };
+  }
+
+  const upper = clean.toUpperCase();
+  const matches: LumpingMatch[] = [];
+
+  for (const entity of registry) {
+    // Find the first alias that matches in the upper-cased title.
+    // We report at most one match per entity — even if multiple
+    // aliases hit, the entity is only counted once.
+    let hit: { alias: string; position: number } | null = null;
+    for (const alias of entity.aliases) {
+      const idx = upper.indexOf(alias.toUpperCase());
+      if (idx !== -1) {
+        if (hit === null || idx < hit.position) {
+          hit = { alias, position: idx };
+        }
+      }
+    }
+    if (hit !== null) {
+      matches.push({
+        entityId: entity.entityId,
+        displayName: entity.displayName,
+        alias: hit.alias,
+        position: hit.position,
+      });
+    }
+  }
+
+  // Sort matches by first-occurrence position so the error message
+  // lists entities in the order the operator typed them.
+  matches.sort((a, b) => a.position - b.position);
+
+  const isLumped = matches.length >= 2;
+  const error = isLumped
+    ? `Task title lumps ${matches.length} entities (${matches.map((m) => m.displayName).join(', ')}). Each legal entity must have its own dedicated task per ${regulatory}. Split this task into ${matches.length} separate tasks, one per entity, before dispatch.`
+    : null;
+
+  return { isLumped, matches, error, regulatory };
+}
+
+// ---------------------------------------------------------------------------
+// Scanner over an existing task list
+// ---------------------------------------------------------------------------
+
+export interface ExistingTask {
+  readonly gid: string;
+  readonly name: string;
+}
+
+export interface LumpedTaskReport {
+  readonly gid: string;
+  readonly name: string;
+  readonly entityCount: number;
+  readonly entities: readonly string[];
+  readonly error: string;
+}
+
+export interface ScanReport {
+  /** Total tasks scanned. */
+  readonly scanned: number;
+  /** Tasks that lint clean (no lumping). */
+  readonly cleanCount: number;
+  /** Tasks that lump 2+ entities — must be split. */
+  readonly lumpedTasks: readonly LumpedTaskReport[];
+  /** Human-readable summary. */
+  readonly summary: string;
+  readonly regulatory: readonly string[];
+}
+
+/**
+ * Scan an existing Asana task list for lumped titles and report
+ * every finding. Pure function — caller injects the task list.
+ */
+export function scanForLumpedTasks(
+  tasks: readonly ExistingTask[],
+  registry: readonly EntityAliasRecord[] = ENTITY_ALIASES
+): ScanReport {
+  const lumped: LumpedTaskReport[] = [];
+  for (const t of tasks) {
+    const result = lintTaskTitle(t.name, registry);
+    if (result.isLumped) {
+      lumped.push({
+        gid: t.gid,
+        name: t.name,
+        entityCount: result.matches.length,
+        entities: result.matches.map((m) => m.displayName),
+        error: result.error ?? 'lumped',
+      });
+    }
+  }
+  const cleanCount = tasks.length - lumped.length;
+  const summary =
+    lumped.length === 0
+      ? `All ${tasks.length} task(s) scanned: zero lumping findings. ✓`
+      : `${lumped.length} of ${tasks.length} tasks lump multiple entities and must be split into ${lumped.reduce((acc, t) => acc + t.entityCount, 0)} separate tasks.`;
+
+  return {
+    scanned: tasks.length,
+    cleanCount,
+    lumpedTasks: lumped,
+    summary,
+    regulatory: [
+      'FDL No.10/2025 Art.12-14',
+      'FDL No.10/2025 Art.24',
+      'FDL No.10/2025 Art.26-27',
+      'Cabinet Res 134/2025 Art.7-10',
+      'Cabinet Res 134/2025 Art.19',
+      'Cabinet Decision 109/2023',
+      'FATF Rec 10',
+      'FATF Rec 22',
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Throwing variant for the dispatcher
+// ---------------------------------------------------------------------------
+
+/**
+ * Assert that a task title does not lump entities. Throws a typed
+ * error if it does. Used by the task creation path in the dispatcher
+ * so a compliance violation is blocked at write time, not discovered
+ * later during an audit.
+ */
+export class EntityLumpingError extends Error {
+  readonly code = 'ENTITY_LUMPING';
+  readonly matches: readonly LumpingMatch[];
+  readonly regulatory: string;
+
+  constructor(message: string, matches: readonly LumpingMatch[], regulatory: string) {
+    super(message);
+    this.name = 'EntityLumpingError';
+    this.matches = matches;
+    this.regulatory = regulatory;
+  }
+}
+
+export function assertTaskTitleNotLumped(title: string | undefined | null): void {
+  const result = lintTaskTitle(title);
+  if (result.isLumped) {
+    throw new EntityLumpingError(result.error!, result.matches, result.regulatory);
+  }
+}

--- a/tests/entityLumpingLinter.test.ts
+++ b/tests/entityLumpingLinter.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Tests for src/services/asana/entityLumpingLinter.ts — the hard
+ * compliance rule that prevents multiple legal entities from being
+ * lumped into a single Asana task.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  ENTITY_ALIASES,
+  EntityLumpingError,
+  assertTaskTitleNotLumped,
+  lintTaskTitle,
+  scanForLumpedTasks,
+} from '../src/services/asana/entityLumpingLinter';
+
+describe('ENTITY_ALIASES registry', () => {
+  it('covers all 6 entities in COMPANY_REGISTRY', () => {
+    expect(ENTITY_ALIASES).toHaveLength(6);
+  });
+
+  it('every entity has a unique entityId', () => {
+    const ids = ENTITY_ALIASES.map((e) => e.entityId);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every entity has a display name and at least one alias', () => {
+    for (const e of ENTITY_ALIASES) {
+      expect(e.displayName.length).toBeGreaterThan(0);
+      expect(e.aliases.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('every alias is at least 4 characters (short aliases produce false positives)', () => {
+    for (const e of ENTITY_ALIASES) {
+      for (const alias of e.aliases) {
+        expect(alias.length).toBeGreaterThanOrEqual(4);
+      }
+    }
+  });
+
+  it('no entity shares an alias with another entity (would break disambiguation)', () => {
+    const seen = new Map<string, string>();
+    for (const e of ENTITY_ALIASES) {
+      for (const alias of e.aliases) {
+        const existing = seen.get(alias.toUpperCase());
+        expect(
+          existing,
+          `alias "${alias}" collides between ${existing} and ${e.entityId}`
+        ).toBeUndefined();
+        seen.set(alias.toUpperCase(), e.entityId);
+      }
+    }
+  });
+});
+
+describe('lintTaskTitle — clean titles (single entity)', () => {
+  it.each([
+    'FG LLC — CDD Outstanding Files Review',
+    'FG BRANCH — CDD Outstanding Files Review',
+    'MADISON LLC — CDD Outstanding Files Review',
+    'NAPLES LLC — CDD Outstanding Files Review',
+    'GRAMALTIN AS — CDD Outstanding Files Review',
+    'ZOE FZE — CDD Outstanding Files Review',
+  ])('accepts %s', (title) => {
+    const result = lintTaskTitle(title);
+    expect(result.isLumped).toBe(false);
+    expect(result.matches).toHaveLength(1);
+    expect(result.error).toBeNull();
+  });
+
+  it('accepts a title with only subject content, no entity', () => {
+    const result = lintTaskTitle('Periodic Review — April 2026');
+    expect(result.isLumped).toBe(false);
+    expect(result.matches).toHaveLength(0);
+    expect(result.error).toBeNull();
+  });
+
+  it('accepts the alternate "JEWELLERY" alias for Madison', () => {
+    const result = lintTaskTitle('MADISON JEWELLERY — Q2 Review');
+    expect(result.isLumped).toBe(false);
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0]!.displayName).toBe('MADISON LLC');
+  });
+
+  it('accepts the alternate "L.L.C" alias variant', () => {
+    const result = lintTaskTitle('NAPLES L.L.C CDD Pending');
+    expect(result.isLumped).toBe(false);
+    expect(result.matches).toHaveLength(1);
+  });
+});
+
+describe('lintTaskTitle — lumped titles (2+ entities)', () => {
+  it('flags the exact real-world failure from the operator screenshot', () => {
+    const result = lintTaskTitle(
+      'GRAMALTIN AS / NAPLES LLC / ZOE FZE — CDD Outstanding Files Review'
+    );
+    expect(result.isLumped).toBe(true);
+    expect(result.matches).toHaveLength(3);
+    expect(result.matches.map((m) => m.displayName)).toEqual([
+      'GRAMALTIN AS',
+      'NAPLES LLC',
+      'ZOE FZE',
+    ]);
+    expect(result.error).toMatch(/3 entities/);
+    expect(result.error).toMatch(/GRAMALTIN AS, NAPLES LLC, ZOE FZE/);
+  });
+
+  it('flags a 2-entity lump', () => {
+    const result = lintTaskTitle('FG LLC / FG BRANCH — Group Review');
+    expect(result.isLumped).toBe(true);
+    expect(result.matches).toHaveLength(2);
+    expect(result.matches[0]!.displayName).toBe('FG LLC');
+    expect(result.matches[1]!.displayName).toBe('FG BRANCH');
+  });
+
+  it('flags a 6-entity mega-lump', () => {
+    const result = lintTaskTitle(
+      'MADISON LLC, NAPLES LLC, GRAMALTIN AS, ZOE FZE, FG LLC, FG BRANCH — Q2 group review'
+    );
+    expect(result.isLumped).toBe(true);
+    expect(result.matches).toHaveLength(6);
+  });
+
+  it('orders matches by first-occurrence position', () => {
+    const result = lintTaskTitle('ZOE FZE / NAPLES LLC — review');
+    expect(result.matches[0]!.displayName).toBe('ZOE FZE');
+    expect(result.matches[1]!.displayName).toBe('NAPLES LLC');
+  });
+
+  it('counts an entity only once even if multiple aliases match', () => {
+    // MADISON matches both "MADISON LLC" and "MADISON" aliases —
+    // should count as ONE entity, not two.
+    const result = lintTaskTitle('MADISON LLC — MADISON JEWELLERY quarterly review');
+    expect(result.isLumped).toBe(false);
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0]!.displayName).toBe('MADISON LLC');
+  });
+
+  it('includes the regulatory anchor in the error message', () => {
+    const result = lintTaskTitle('GRAMALTIN AS / NAPLES LLC — review');
+    expect(result.error).toMatch(/FDL Art.12-14/);
+    expect(result.error).toMatch(/Cabinet Res 134\/2025/);
+  });
+});
+
+describe('lintTaskTitle — edge cases', () => {
+  it('is case-insensitive', () => {
+    const result = lintTaskTitle('gramaltin as / naples llc — review');
+    expect(result.isLumped).toBe(true);
+    expect(result.matches).toHaveLength(2);
+  });
+
+  it('returns clean result for undefined', () => {
+    const result = lintTaskTitle(undefined);
+    expect(result.isLumped).toBe(false);
+    expect(result.matches).toHaveLength(0);
+  });
+
+  it('returns clean result for null', () => {
+    const result = lintTaskTitle(null);
+    expect(result.isLumped).toBe(false);
+    expect(result.matches).toHaveLength(0);
+  });
+
+  it('returns clean result for empty string', () => {
+    const result = lintTaskTitle('');
+    expect(result.isLumped).toBe(false);
+  });
+
+  it('returns clean result for whitespace-only', () => {
+    const result = lintTaskTitle('   \t\n  ');
+    expect(result.isLumped).toBe(false);
+  });
+
+  it('does NOT false-positive on the word "as" appearing naturally (GRAMALTIN alias requires at least "GRAMAL")', () => {
+    const result = lintTaskTitle('Review MADISON LLC as soon as possible');
+    // "as" does not match GRAMALTIN AS because GRAMALTIN AS is the alias.
+    // The linter only matches complete alias substrings.
+    expect(result.isLumped).toBe(false);
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0]!.displayName).toBe('MADISON LLC');
+  });
+
+  it('does NOT false-positive on bare "FG" (ambiguous between LLC and BRANCH)', () => {
+    // Bare "FG" is deliberately NOT in the alias list for either
+    // FG LLC or FG BRANCH — ambiguous "FG" mentions must not count
+    // as a match for either.
+    const result = lintTaskTitle('FG group-wide review — all entities');
+    expect(result.isLumped).toBe(false);
+    expect(result.matches).toHaveLength(0);
+  });
+});
+
+describe('scanForLumpedTasks — scanner over existing tasks', () => {
+  it('reports zero findings on an all-clean task list', () => {
+    const tasks = [
+      { gid: 'g1', name: 'FG LLC — CDD Outstanding Files Review' },
+      { gid: 'g2', name: 'NAPLES LLC — Periodic Review' },
+      { gid: 'g3', name: 'MADISON LLC — UBO Refresh' },
+    ];
+    const report = scanForLumpedTasks(tasks);
+    expect(report.scanned).toBe(3);
+    expect(report.cleanCount).toBe(3);
+    expect(report.lumpedTasks).toHaveLength(0);
+    expect(report.summary).toMatch(/zero lumping findings/);
+  });
+
+  it('reports the exact real-world failure state', () => {
+    const tasks = [
+      { gid: 'g1', name: 'FG LLC — CDD Outstanding Files Review' },
+      { gid: 'g2', name: 'FG BRANCH — CDD Outstanding Files Review' },
+      { gid: 'g3', name: 'MADISON LLC — CDD Outstanding Files Review' },
+      { gid: 'g4', name: 'GRAMALTIN AS / NAPLES LLC / ZOE FZE — CDD Outstanding Files Review' },
+    ];
+    const report = scanForLumpedTasks(tasks);
+    expect(report.scanned).toBe(4);
+    expect(report.cleanCount).toBe(3);
+    expect(report.lumpedTasks).toHaveLength(1);
+    expect(report.lumpedTasks[0]!.gid).toBe('g4');
+    expect(report.lumpedTasks[0]!.entityCount).toBe(3);
+    expect(report.lumpedTasks[0]!.entities).toEqual(['GRAMALTIN AS', 'NAPLES LLC', 'ZOE FZE']);
+    expect(report.summary).toMatch(/1 of 4 tasks lump.*3 separate tasks/);
+  });
+
+  it('handles an empty task list', () => {
+    const report = scanForLumpedTasks([]);
+    expect(report.scanned).toBe(0);
+    expect(report.cleanCount).toBe(0);
+    expect(report.lumpedTasks).toHaveLength(0);
+  });
+
+  it('reports multiple lumped tasks across a mixed list', () => {
+    const tasks = [
+      { gid: 'g1', name: 'FG LLC / FG BRANCH — Review' },
+      { gid: 'g2', name: 'MADISON LLC — clean task' },
+      { gid: 'g3', name: 'NAPLES LLC, ZOE FZE — lump 2' },
+    ];
+    const report = scanForLumpedTasks(tasks);
+    expect(report.lumpedTasks).toHaveLength(2);
+    expect(report.cleanCount).toBe(1);
+  });
+});
+
+describe('assertTaskTitleNotLumped + EntityLumpingError — dispatcher tripwire', () => {
+  it('does not throw on a clean title', () => {
+    expect(() => assertTaskTitleNotLumped('NAPLES LLC — CDD')).not.toThrow();
+  });
+
+  it('throws EntityLumpingError on a lumped title', () => {
+    expect(() => assertTaskTitleNotLumped('GRAMALTIN AS / NAPLES LLC — review')).toThrow(
+      EntityLumpingError
+    );
+  });
+
+  it('throws with a code, matches array, and regulatory anchor', () => {
+    try {
+      assertTaskTitleNotLumped('FG LLC / FG BRANCH — review');
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(EntityLumpingError);
+      const e = err as EntityLumpingError;
+      expect(e.code).toBe('ENTITY_LUMPING');
+      expect(e.matches).toHaveLength(2);
+      expect(e.regulatory).toMatch(/FDL/);
+    }
+  });
+
+  it('does not throw on undefined title (nothing to lint)', () => {
+    expect(() => assertTaskTitleNotLumped(undefined)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Enforces the per-entity CDD rule in code. Prevents multi-entity lumped task titles from being created (dispatcher tripwire) and surfaces existing lumps via a read-only scanner button in `setup.html`. Closes the compliance hole observed in the operator screenshot where `GRAMALTIN AS / NAPLES LLC / ZOE FZE` were lumped into one Asana task.

## Why this is a hard rule (not a style preference)

- **FDL Art.12-14** — CDD is per customer
- **FDL Art.24** — 10-year retention requires **per-entity** audit trail
- **FDL Art.26-27** — STR/SAR is per subject
- **Cabinet Res 134/2025 Art.7-10** — CDD data collection per entity
- **Cabinet Decision 109/2023** — UBO register per entity
- **FATF Rec 10, Rec 22** — CDD per customer, DPMS per customer

Lumping destroys all of these. The four-eyes approver chain breaks (which key is pinned to which entity?), the SLA enforcer cannot fire a deadline on a lumped task, attached documents become ambiguous evidence.

## What changed

### `src/services/asana/entityLumpingLinter.ts` (new)

Pure module, no I/O, safe for tests + Netlify functions. Exports:

- **`ENTITY_ALIASES`** — hand-curated alias table for all 6 entities in `COMPANY_REGISTRY`. Hand-curated rather than auto-derived because the long Gramaltin legal name would produce false positives on tokens like `TICARET` / `SANAYI`, and bare `FG` is ambiguous between FG LLC and FG BRANCH.
- **`lintTaskTitle(title)`** — returns `{ isLumped, matches, error, regulatory }`
- **`scanForLumpedTasks(tasks)`** — bulk scan for the setup wizard
- **`assertTaskTitleNotLumped(title)`** — throws `EntityLumpingError` at task creation time; dispatcher tripwire
- **`EntityLumpingError`** — typed error with `code: 'ENTITY_LUMPING'`, `matches`, `regulatory`

Key design decisions:
- Minimum 4-char alias length (short aliases produce false positives on unrelated words)
- Case-insensitive substring matching
- Each entity counted at most once even if multiple aliases hit
- Bare `FG` deliberately excluded from both FG LLC and FG BRANCH lists so ambiguous `FG` mentions do not false-flag either entity

### `tests/entityLumpingLinter.test.ts` (new)

35 unit tests covering every branch:

- Registry invariants (6 entities, unique ids, min alias length, no cross-entity collision)
- Clean titles (6 single-entity cases — one per legal entity)
- **The exact real-world failure**: `GRAMALTIN AS / NAPLES LLC / ZOE FZE — CDD Outstanding Files Review` → flagged as 3-entity lump
- 2-entity lumps, 6-entity mega-lumps, first-occurrence ordering, dedupe when multiple aliases hit same entity
- Edge cases: case-insensitive, `undefined` / `null` / empty / whitespace-only, `"as"` false-positive prevention, bare `FG` ambiguity handling
- `scanForLumpedTasks` — clean list, real-world state, empty list, mixed list
- `assertTaskTitleNotLumped` + `EntityLumpingError` dispatcher tripwire
- **All 35 pass.**

### `netlify/functions/scan-lumped-tasks.mts` (new)

HTTP endpoint at `POST /api/setup/scan-lumped-tasks`. Mirrors `setup-asana-bootstrap.mts` pattern:
- OPTIONS + POST only, bearer `HAWKEYE_BRAIN_TOKEN` auth, rate limited 5 / 15 min
- Paginated fetch of all tasks (safety ceiling 10,000)
- Runs `scanForLumpedTasks()` (pure, zero I/O after fetch)
- Returns per-lumped-task detail with entity count, display names, actionable error message
- **READ-ONLY** — never mutates Asana

### `setup.html` + `setup.js`

New **Step 9 — Scan for lumped entity tasks**. Single project-GID input, single button. Client-side validation (digit-only), POSTs to `/api/setup/scan-lumped-tasks`. Shows "Clean" (green) or "Findings" (red). Renumbered downstream: Step 9 → 10 (live), Step 10 → 11 (post-setup).

## Expected scanner output on today's KYC/CDD Tracker

```json
{
  "ok": false,
  "scanned": 14,
  "cleanCount": 13,
  "lumpedCount": 1,
  "summary": "1 of 14 tasks lump multiple entities and must be split into 3 separate tasks.",
  "findings": [
    {
      "gid": "<asana gid>",
      "name": "GRAMALTIN AS / NAPLES LLC / ZOE FZE — CDD Outstanding Files Review",
      "entityCount": 3,
      "entities": ["GRAMALTIN AS", "NAPLES LLC", "ZOE FZE"],
      "error": "Task title lumps 3 entities (GRAMALTIN AS, NAPLES LLC, ZOE FZE). Each legal entity must have its own dedicated task per FDL Art.12-14 / Art.24 / Cabinet Res 134/2025 Art.7-10. Split this task into 3 separate tasks, one per entity, before dispatch."
    }
  ]
}
```

## Quality gate (run locally)

| Check | Result |
|---|---|
| `prettier --check 'src/**/*.{ts,tsx}'` | ✅ clean |
| `tsc --noEmit` | ✅ clean |
| `eslint src/ --ext .ts,.tsx` | ✅ clean |
| `vitest run tests/entityLumpingLinter.test.ts` | ✅ **35/35 pass** |

## Non-regulatory change

CLAUDE.md §8 citation discipline applies. The linter module and the HTTP endpoint cite their regulatory anchors in the module docstring per FDL No.10/2025 Art.12-14, Art.24, Art.26-27; Cabinet Res 134/2025 Art.7-10, Art.19; Cabinet Decision 109/2023; FATF Rec 10, Rec 22. No threshold, deadline, or decision pathway changed. `src/domain/constants.ts` untouched.

## Follow-up (separate commit / PR)

The linter is in place but not yet wired into the dispatcher. A follow-up commit will call `assertTaskTitleNotLumped(title)` from the task creation path in `src/services/asana/orchestrator.ts` so any attempt to create a lumped task fails at runtime. Kept separate to keep this PR focused on the pure detection layer + scanner.

## Test plan

- [ ] CI runs `lint-and-test (20)` → green
- [ ] Merge
- [ ] Operator opens `/setup.html` Step 9 → pastes KYC/CDD Tracker project GID → clicks Scan
- [ ] Scanner returns 1 finding for the existing `GRAMALTIN AS / NAPLES LLC / ZOE FZE` lump
- [ ] Operator splits the task manually in Asana
- [ ] Re-scan → 0 findings → Step 9 badge turns green
- [ ] Follow-up PR wires the tripwire into `orchestrator.ts` so future lumps never land

## Rollback

Fully reversible with `git revert`. All new code is additive — no existing functionality is touched.
