### PR TITLE
Customer Profile v2 foundation — domain + validator + expiry alerter

### DIFF
--- a/src/domain/customerProfile.ts
+++ b/src/domain/customerProfile.ts
@@ -1,0 +1,458 @@
+/**
+ * Customer Profile v2 — full KYC / CDD data model.
+ *
+ * Why this exists:
+ *   The existing `CustomerProfile` in src/domain/customers.ts is a
+ *   minimal skeleton — legal name, id, risk rating, PEP/sanctions
+ *   status flags. That skeleton is enough for the brain to run
+ *   screening on, but it is not enough to pass a UAE DPMS MoE
+ *   inspection, which requires:
+ *
+ *     - Licence number + issuer + issue/expiry date
+ *     - Business model explanation (plain language)
+ *     - Expected monthly volume + transaction count
+ *     - Full shareholder / UBO chain with >25% threshold
+ *     - Managers / directors / authorised signatories
+ *     - Emirates ID + passport numbers + expiry dates for every
+ *       natural person, with 10yr retention (FDL Art.24)
+ *     - Source of funds / wealth evidence references
+ *     - Per-tier review cadence (SDD 12mo, CDD 6mo, EDD 3mo)
+ *
+ *   This module is the canonical data model. PURE — types + constants
+ *   + helper pure functions. No I/O, no state, no network. Safe for
+ *   tests, netlify functions, and the React UI layer.
+ *
+ *   The existing `COMPANY_REGISTRY` (src/domain/customers.ts) stays as
+ *   a read-only seed of the 6 entities known to the tool today.
+ *   Customer Profile v2 is a SEPARATE, richer store that the
+ *   orchestrator upgrades to as new CDD data comes in.
+ *
+ * Regulatory basis:
+ *   FDL No.10/2025 Art.12-14   (CDD — every field below is mandatory)
+ *   FDL No.10/2025 Art.24      (10yr retention per entity)
+ *   Cabinet Res 134/2025 Art.7-10 (CDD data collection per tier)
+ *   Cabinet Res 134/2025 Art.14   (EDD + PEP Board approval)
+ *   Cabinet Decision 109/2023     (UBO register >25% threshold)
+ *   MoE Circular 08/AML/2021      (DPMS sector — licence expiry check)
+ *   FATF Rec 10 (CDD), Rec 11 (record-keeping), Rec 12 (PEP)
+ *
+ * Date format: dd/mm/yyyy per CLAUDE.md §6 (UAE compliance standard).
+ *   ISO 8601 is used only for timestamps (audit log fields).
+ */
+
+// ---------------------------------------------------------------------------
+// Primitive types
+// ---------------------------------------------------------------------------
+
+/**
+ * dd/mm/yyyy date string per CLAUDE.md §6. This is a branded string
+ * type — the validator in customerProfileValidator.ts enforces the
+ * format at the system boundary so downstream code can trust it.
+ */
+export type DateDdMmYyyy = string;
+
+/** ISO 8601 timestamp for audit fields (createdAt, lastReviewedAt). */
+export type IsoTimestamp = string;
+
+/** ISO-3166 alpha-2 country code (e.g. "AE", "GB", "US"). */
+export type CountryCodeIso2 = string;
+
+/**
+ * UAE Emirates ID number format: 784-YYYY-NNNNNNN-N.
+ * The first 3 digits are the UAE ISD code (784), next 4 = birth year,
+ * next 7 = serial, last 1 = check digit.
+ */
+export type EmiratesIdNumber = string;
+
+// ---------------------------------------------------------------------------
+// Enums / string unions
+// ---------------------------------------------------------------------------
+
+export type CustomerType = 'natural' | 'legal';
+
+export type LicenseStatus = 'active' | 'expired' | 'suspended' | 'cancelled';
+
+export type CustomerSector =
+  | 'precious-metals'
+  | 'precious-metals-refining'
+  | 'precious-metals-trading'
+  | 'jewellery-retail'
+  | 'jewellery-manufacturing'
+  | 'bullion-trading'
+  | 'other';
+
+export type RiskTier = 'low' | 'medium' | 'high';
+
+export type ScreeningStatus = 'pending' | 'clear' | 'potential' | 'confirmed_frozen';
+
+export type PepStatus = 'clear' | 'potential' | 'confirmed';
+
+export type EvidenceStatus = 'pending' | 'declared' | 'verified' | 'not_applicable';
+
+export type EntityStructure = 'standalone' | 'headquarters' | 'branch' | 'subsidiary';
+
+export type ManagerRole =
+  | 'director'
+  | 'general-manager'
+  | 'authorised-signatory'
+  | 'mlro'
+  | 'co'
+  | 'board-member'
+  | 'other';
+
+// ---------------------------------------------------------------------------
+// Attachment reference
+// ---------------------------------------------------------------------------
+
+/**
+ * A pointer to a document stored in the Netlify Blob store. Used for
+ * licence PDFs, Emirates ID scans, passport copies, SoF evidence,
+ * SoW evidence, UBO certificates, etc.
+ *
+ * Never store the document body here — only the blob key + sha256
+ * for tamper detection.
+ */
+export interface AttachmentRef {
+  readonly blobKey: string;
+  readonly filename: string;
+  readonly mimeType: string;
+  readonly uploadedAt: IsoTimestamp;
+  readonly uploadedBy: string;
+  /** SHA-256 hex of the content at upload time. Used for tamper detection. */
+  readonly sha256: string;
+}
+
+// ---------------------------------------------------------------------------
+// Shareholder / UBO record
+// ---------------------------------------------------------------------------
+
+/**
+ * A shareholder is any person or entity that holds equity in the
+ * customer. If they hold ≥ `UBO_OWNERSHIP_THRESHOLD_PERCENT` (25% per
+ * Cabinet Decision 109/2023), they are classified as a UBO and require
+ * enhanced verification + 15-working-day re-verification on any
+ * ownership change.
+ */
+export interface ShareholderRecord {
+  readonly id: string;
+  readonly type: CustomerType;
+  readonly fullName: string;
+  /** Ownership percentage, 0..100. Summed across all shareholders must not exceed 100. */
+  readonly ownershipPercent: number;
+
+  // ----- Natural-person fields (required when type === 'natural') -----
+  readonly dateOfBirth?: DateDdMmYyyy;
+  readonly nationality?: CountryCodeIso2;
+  readonly emiratesIdNumber?: EmiratesIdNumber;
+  readonly emiratesIdExpiry?: DateDdMmYyyy;
+  readonly passportNumber?: string;
+  readonly passportCountry?: CountryCodeIso2;
+  readonly passportExpiry?: DateDdMmYyyy;
+  readonly residentialAddress?: string;
+
+  // ----- Legal-entity fields (required when type === 'legal') -----
+  readonly registrationCountry?: CountryCodeIso2;
+  readonly registrationNumber?: string;
+  /**
+   * Upward chain of parent entities terminating in an ultimate
+   * natural-person UBO. Stored as customer ids so the UI can
+   * traverse. Only populated for `type === 'legal'`.
+   */
+  readonly parentChain?: readonly string[];
+
+  // ----- Screening (applies to both natural + legal) -----
+  readonly pepCheckStatus: PepStatus;
+  readonly sanctionsCheckStatus: ScreeningStatus;
+  readonly adverseMediaCheckStatus: 'pending' | 'clear' | 'hits' | 'cleared';
+  readonly lastScreenedAt?: IsoTimestamp;
+
+  // ----- UBO-specific (Cabinet Decision 109/2023) -----
+  readonly uboVerifiedAt?: DateDdMmYyyy;
+  /**
+   * Deadline for UBO re-verification after the most recent ownership
+   * change. Set to 15 working days from the change event per Cabinet
+   * Decision 109/2023. Computed by the business-days util.
+   */
+  readonly uboReverificationDueAt?: DateDdMmYyyy;
+
+  // ----- Evidence -----
+  readonly evidenceAttachments?: readonly AttachmentRef[];
+}
+
+// ---------------------------------------------------------------------------
+// Manager / director / authorised signatory record
+// ---------------------------------------------------------------------------
+
+/**
+ * A manager / director / authorised signatory. Distinct from a
+ * shareholder: a manager may own 0% equity but still have operational
+ * control. The MLRO + CO roles are special cases — their presence is
+ * required by Cabinet Res 134/2025 Art.19 (four-eyes review) and
+ * FDL Art.20-22 (CO oversight).
+ */
+export interface ManagerRecord {
+  readonly id: string;
+  readonly fullName: string;
+  readonly role: ManagerRole;
+  /** Free-text title when `role === 'other'`. */
+  readonly roleTitle?: string;
+
+  // ----- Identity (natural-person only — managers are always natural people) -----
+  readonly dateOfBirth: DateDdMmYyyy;
+  readonly nationality: CountryCodeIso2;
+  readonly emiratesIdNumber?: EmiratesIdNumber;
+  readonly emiratesIdExpiry?: DateDdMmYyyy;
+  readonly passportNumber: string;
+  readonly passportCountry: CountryCodeIso2;
+  readonly passportExpiry: DateDdMmYyyy;
+
+  // ----- Authority -----
+  readonly appointmentDate: DateDdMmYyyy;
+  /** Signing authority cap in AED. Undefined = no cap. */
+  readonly authorityLimitAed?: number;
+  /** Can this manager confirm a sanctions freeze decision? */
+  readonly isSanctionsAuthority: boolean;
+  /** Can this manager file an STR? */
+  readonly isStrFilingAuthority: boolean;
+
+  // ----- Screening -----
+  readonly pepCheckStatus: PepStatus;
+  readonly sanctionsCheckStatus: ScreeningStatus;
+  readonly adverseMediaCheckStatus: 'pending' | 'clear' | 'hits' | 'cleared';
+  readonly lastScreenedAt?: IsoTimestamp;
+
+  // ----- Evidence -----
+  readonly evidenceAttachments?: readonly AttachmentRef[];
+}
+
+// ---------------------------------------------------------------------------
+// Customer Profile v2 — the canonical shape
+// ---------------------------------------------------------------------------
+
+/**
+ * Full CDD record for a single customer. Every field below maps to
+ * a specific UAE AML/CFT or FATF requirement. Producers of this type
+ * (the UI form, the orchestrator, the auto-ingest endpoint) must all
+ * go through the validator in customerProfileValidator.ts so missing
+ * or expired fields are surfaced to the MLRO before persistence.
+ */
+export interface CustomerProfileV2 {
+  readonly schemaVersion: 2;
+
+  // ----- Identity -----
+  readonly id: string;
+  readonly legalName: string;
+  readonly tradingName?: string;
+  readonly customerType: CustomerType;
+
+  // ----- Registration -----
+  readonly country: CountryCodeIso2;
+  readonly jurisdiction: string;
+  readonly licenseNumber: string;
+  readonly licenseIssuer: string;
+  readonly licenseIssueDate: DateDdMmYyyy;
+  readonly licenseExpiryDate: DateDdMmYyyy;
+  readonly licenseStatus: LicenseStatus;
+
+  // ----- Business -----
+  readonly businessModel: string;
+  readonly activity: string;
+  readonly sector: CustomerSector;
+  readonly expectedMonthlyVolumeAed: number;
+  readonly expectedTransactionCountPerMonth: number;
+
+  // ----- Risk posture -----
+  readonly riskRating: RiskTier;
+  readonly riskRatingAssignedAt: DateDdMmYyyy;
+  readonly riskRatingExpiresAt: DateDdMmYyyy;
+  readonly pepStatus: PepStatus;
+  readonly sanctionsStatus: ScreeningStatus;
+
+  // ----- Source of funds / wealth -----
+  readonly sourceOfFundsStatus: EvidenceStatus;
+  readonly sourceOfFundsEvidence?: readonly AttachmentRef[];
+  readonly sourceOfWealthStatus: EvidenceStatus;
+  readonly sourceOfWealthEvidence?: readonly AttachmentRef[];
+
+  // ----- People -----
+  readonly shareholders: readonly ShareholderRecord[];
+  readonly managers: readonly ManagerRecord[];
+
+  // ----- Relationships -----
+  readonly groupId?: string;
+  readonly groupName?: string;
+  readonly entityType: EntityStructure;
+
+  // ----- Audit -----
+  readonly createdAt: IsoTimestamp;
+  readonly lastReviewedAt?: IsoTimestamp;
+  readonly lastReviewerUserId?: string;
+  readonly nextReviewDueAt: DateDdMmYyyy;
+  /**
+   * Retention deadline computed as `createdAt + 10 years` per
+   * FDL Art.24. Stored for fast query — the scheduled retention
+   * cleanup job walks this field to find expirable records.
+   */
+  readonly recordRetentionUntil: DateDdMmYyyy;
+}
+
+// ---------------------------------------------------------------------------
+// Regulatory constants — single source of truth
+// ---------------------------------------------------------------------------
+
+/**
+ * Cabinet Decision 109/2023: a shareholder becomes a UBO at 25%
+ * beneficial ownership. Changes here must also update
+ * src/domain/constants.ts (the canonical AML constants file) and
+ * bump REGULATORY_CONSTANTS_VERSION.
+ */
+export const UBO_OWNERSHIP_THRESHOLD_PERCENT = 25;
+
+/** Cabinet Decision 109/2023: UBO re-verification deadline (working days). */
+export const UBO_REVERIFICATION_WORKING_DAYS = 15;
+
+/**
+ * Periodic review cadence per risk tier (in months). Missing a
+ * scheduled review is itself a Cabinet Res 134/2025 Art.19 finding.
+ */
+export const PERIODIC_REVIEW_MONTHS: Readonly<Record<RiskTier, number>> = {
+  low: 12,
+  medium: 6,
+  high: 3,
+};
+
+/**
+ * FDL Art.24 retention period in years. Every customer record must
+ * be preserved for at least 10 years after the relationship ends.
+ */
+export const RECORD_RETENTION_YEARS = 10;
+
+/**
+ * Expiry alert windows in days. When an attached document's expiry
+ * date falls within any of these windows, the expiry alerter emits
+ * an Asana task. Multiple windows let the MLRO see early (90d),
+ * mid (60d), and urgent (30d/7d) reminders.
+ */
+export const EXPIRY_ALERT_WINDOWS_DAYS: readonly number[] = [90, 60, 30, 7] as const;
+
+// ---------------------------------------------------------------------------
+// Pure helpers — date arithmetic used by validator + alerter
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a dd/mm/yyyy string into a Date. Returns `null` if the format
+ * is invalid (e.g. `"13/25/2026"` or `"not-a-date"`).
+ *
+ * Strict parser — rejects any variation (no dashes, no ISO, no
+ * leading/trailing whitespace after trim). Month and day must be
+ * zero-padded or single-digit (1-12, 1-31). Year must be 4 digits.
+ */
+export function parseDdMmYyyy(value: DateDdMmYyyy | undefined | null): Date | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  const m = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/.exec(trimmed);
+  if (!m) return null;
+  const day = parseInt(m[1]!, 10);
+  const month = parseInt(m[2]!, 10);
+  const year = parseInt(m[3]!, 10);
+  if (month < 1 || month > 12) return null;
+  if (day < 1 || day > 31) return null;
+  // JavaScript Date constructor takes 0-indexed month.
+  const d = new Date(Date.UTC(year, month - 1, day));
+  // Reject if the Date constructor silently rolled over an invalid
+  // day-of-month (e.g. 31/02/2026 → 3rd March).
+  if (d.getUTCFullYear() !== year || d.getUTCMonth() !== month - 1 || d.getUTCDate() !== day) {
+    return null;
+  }
+  return d;
+}
+
+/**
+ * Format a Date back to the dd/mm/yyyy string used everywhere in the
+ * customer profile. Uses UTC components to avoid timezone drift.
+ */
+export function formatDdMmYyyy(date: Date): DateDdMmYyyy {
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const year = date.getUTCFullYear();
+  return `${day}/${month}/${year}`;
+}
+
+/**
+ * Compute the number of whole days between two dates (floor of the
+ * absolute difference). Used by the expiry alerter to match a date
+ * against the alert windows.
+ */
+export function daysBetween(a: Date, b: Date): number {
+  const MS_PER_DAY = 1000 * 60 * 60 * 24;
+  return Math.floor((b.getTime() - a.getTime()) / MS_PER_DAY);
+}
+
+/**
+ * Add N years to a date (calendar years, preserving month and day).
+ * Used by `createdAt + 10yr` retention computation and by periodic
+ * review scheduling.
+ */
+export function addYears(date: Date, years: number): Date {
+  const d = new Date(date.getTime());
+  d.setUTCFullYear(d.getUTCFullYear() + years);
+  return d;
+}
+
+/**
+ * Add N months to a date. Handles month-end edge cases (e.g.
+ * 31/01 + 1 month = 28/02, not invalid).
+ */
+export function addMonths(date: Date, months: number): Date {
+  const d = new Date(date.getTime());
+  const targetMonth = d.getUTCMonth() + months;
+  d.setUTCDate(1); // avoid rollover
+  d.setUTCMonth(targetMonth);
+  // Clamp day to last valid day of the target month.
+  const daysInTarget = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 0)).getUTCDate();
+  const originalDay = date.getUTCDate();
+  d.setUTCDate(Math.min(originalDay, daysInTarget));
+  return d;
+}
+
+// ---------------------------------------------------------------------------
+// UBO classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a shareholder as a UBO based on the ownership threshold.
+ * Pure — takes a shareholder record and returns the boolean. The
+ * orchestrator uses this to populate the `isUbo` projection in the
+ * UI layer; the validator uses it to enforce that every UBO has
+ * the UBO-specific evidence fields populated.
+ */
+export function isShareholderUbo(s: ShareholderRecord): boolean {
+  return s.ownershipPercent >= UBO_OWNERSHIP_THRESHOLD_PERCENT;
+}
+
+/**
+ * Return the subset of shareholders classified as UBOs. Used by the
+ * UBO register view and by the Cabinet Decision 109/2023 compliance
+ * report.
+ */
+export function extractUbos(
+  shareholders: readonly ShareholderRecord[]
+): readonly ShareholderRecord[] {
+  return shareholders.filter(isShareholderUbo);
+}
+
+/**
+ * Compute the next periodic review deadline for a customer based on
+ * their risk tier. Pure — takes the current review date and tier,
+ * returns the next due date.
+ */
+export function computeNextReviewDue(lastReviewDate: Date, tier: RiskTier): Date {
+  return addMonths(lastReviewDate, PERIODIC_REVIEW_MONTHS[tier]);
+}
+
+/**
+ * Compute the record retention deadline per FDL Art.24.
+ */
+export function computeRetentionUntil(createdAt: Date): Date {
+  return addYears(createdAt, RECORD_RETENTION_YEARS);
+}

--- a/src/services/customerExpiryAlerter.ts
+++ b/src/services/customerExpiryAlerter.ts
@@ -1,0 +1,367 @@
+/**
+ * Customer Expiry Alerter — pure expiry detection that walks a list
+ * of CustomerProfileV2 records and returns a prioritised list of
+ * expiring documents bucketed by alert window (90d / 60d / 30d / 7d).
+ *
+ * Why this exists:
+ *   The MLRO cannot track expiring licences, Emirates IDs, passports,
+ *   UBO re-verification deadlines, and periodic review schedules by
+ *   hand across 6+ entities × N shareholders × N managers. Without a
+ *   single "what is expiring next" report, critical documents slip
+ *   past their deadline and become MoE inspection findings.
+ *
+ *   This module is the pure engine. It takes a list of profiles +
+ *   today's date and returns every expiring artefact, sorted by
+ *   urgency. The cron wrapper (a future Netlify scheduled function)
+ *   consumes this and creates Asana tasks in the correct KYC/CDD
+ *   Tracker section ("Periodic Reviews Due", "Document Collection —
+ *   Awaiting Customer", etc.).
+ *
+ *   Pure. No I/O, no state. Deterministic — same input → same output.
+ *
+ * Regulatory basis:
+ *   FDL No.10/2025 Art.20-22 (CO continuous oversight)
+ *   FDL No.10/2025 Art.24    (10yr retention — expiring records
+ *                              trigger refresh, not deletion)
+ *   Cabinet Res 134/2025 Art.19 (periodic review cadence)
+ *   Cabinet Decision 109/2023    (UBO re-verification 15 working days)
+ *   MoE Circular 08/AML/2021     (DPMS licence validity)
+ */
+
+import {
+  type CustomerProfileV2,
+  type ManagerRecord,
+  type ShareholderRecord,
+  type DateDdMmYyyy,
+  EXPIRY_ALERT_WINDOWS_DAYS,
+  daysBetween,
+  parseDdMmYyyy,
+} from '../domain/customerProfile';
+
+// ---------------------------------------------------------------------------
+// Alert types
+// ---------------------------------------------------------------------------
+
+export type ExpiryArtefactKind =
+  | 'licence'
+  | 'customer-emirates-id'
+  | 'customer-passport'
+  | 'shareholder-emirates-id'
+  | 'shareholder-passport'
+  | 'manager-emirates-id'
+  | 'manager-passport'
+  | 'ubo-reverification'
+  | 'periodic-review'
+  | 'risk-rating-expiry'
+  | 'record-retention';
+
+export type ExpirySeverity = 'expired' | 'urgent' | 'soon' | 'upcoming';
+
+export interface ExpiryAlert {
+  /** Stable id built from customerId + kind + subjectId + expiryDate. */
+  readonly id: string;
+  readonly customerId: string;
+  readonly customerLegalName: string;
+  readonly kind: ExpiryArtefactKind;
+  /** id of the shareholder / manager / UBO this alert is about (empty if the customer itself). */
+  readonly subjectId: string;
+  /** Display name of the subject (customer name, shareholder name, manager name). */
+  readonly subjectName: string;
+  readonly expiryDate: DateDdMmYyyy;
+  /**
+   * Days from `asOf` to expiry. Negative if already expired. The
+   * sorter uses this ascending so the most urgent alerts appear first.
+   */
+  readonly daysUntilExpiry: number;
+  readonly severity: ExpirySeverity;
+  /**
+   * Which alert window bucket this entry falls into. `null` if
+   * outside every configured window (sanity check — should never
+   * happen if the caller filters correctly).
+   */
+  readonly windowDays: number | null;
+  readonly regulatory: string;
+  /** Plain-English description for the Asana task body. */
+  readonly message: string;
+}
+
+export interface ExpiryReport {
+  readonly asOfIso: string;
+  readonly scannedProfiles: number;
+  readonly alerts: readonly ExpiryAlert[];
+  /** Count per severity for dashboard rollup. */
+  readonly counts: Readonly<Record<ExpirySeverity, number>>;
+  readonly summary: string;
+  readonly regulatory: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// Window / severity classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the tightest alert window that contains `daysUntilExpiry`.
+ * For already-expired documents (negative days), returns `null` —
+ * the classifier promotes them to severity='expired' directly.
+ *
+ * Windows are defined in customerProfile.ts as
+ * EXPIRY_ALERT_WINDOWS_DAYS. Default: [90, 60, 30, 7].
+ */
+export function classifyWindow(daysUntilExpiry: number): number | null {
+  if (daysUntilExpiry < 0) return null;
+  // Sort windows ascending so "tightest (smallest)" wins.
+  const sorted = [...EXPIRY_ALERT_WINDOWS_DAYS].sort((a, b) => a - b);
+  for (const w of sorted) {
+    if (daysUntilExpiry <= w) return w;
+  }
+  return null;
+}
+
+export function classifySeverity(daysUntilExpiry: number): ExpirySeverity | null {
+  if (daysUntilExpiry < 0) return 'expired';
+  if (daysUntilExpiry <= 7) return 'urgent';
+  if (daysUntilExpiry <= 30) return 'soon';
+  if (daysUntilExpiry <= 90) return 'upcoming';
+  return null; // outside any alert window
+}
+
+// ---------------------------------------------------------------------------
+// Pure alert constructors
+// ---------------------------------------------------------------------------
+
+function makeAlert(
+  customer: CustomerProfileV2,
+  kind: ExpiryArtefactKind,
+  subjectId: string,
+  subjectName: string,
+  expiryDate: DateDdMmYyyy,
+  asOf: Date,
+  regulatory: string,
+  messagePrefix: string
+): ExpiryAlert | null {
+  const parsed = parseDdMmYyyy(expiryDate);
+  if (parsed === null) return null;
+  const daysUntilExpiry = daysBetween(asOf, parsed);
+  const severity = classifySeverity(daysUntilExpiry);
+  if (severity === null) return null; // outside window, don't alert
+  const windowDays = classifyWindow(daysUntilExpiry);
+  const id = `${customer.id}:${kind}:${subjectId || 'self'}:${expiryDate}`;
+  const whenPhrase =
+    daysUntilExpiry < 0
+      ? `expired ${Math.abs(daysUntilExpiry)} day(s) ago`
+      : `expires in ${daysUntilExpiry} day(s)`;
+  return {
+    id,
+    customerId: customer.id,
+    customerLegalName: customer.legalName,
+    kind,
+    subjectId,
+    subjectName,
+    expiryDate,
+    daysUntilExpiry,
+    severity,
+    windowDays,
+    regulatory,
+    message: `${messagePrefix} — ${whenPhrase} (${expiryDate})`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-subject extractors
+// ---------------------------------------------------------------------------
+
+function extractCustomerAlerts(c: CustomerProfileV2, asOf: Date, out: ExpiryAlert[]): void {
+  const licenceAlert = makeAlert(
+    c,
+    'licence',
+    '',
+    c.legalName,
+    c.licenseExpiryDate,
+    asOf,
+    'MoE Circular 08/AML/2021',
+    `Trade licence ${c.licenseNumber} for ${c.legalName}`
+  );
+  if (licenceAlert) out.push(licenceAlert);
+
+  if (c.riskRatingExpiresAt) {
+    const riskAlert = makeAlert(
+      c,
+      'risk-rating-expiry',
+      '',
+      c.legalName,
+      c.riskRatingExpiresAt,
+      asOf,
+      'Cabinet Res 134/2025 Art.19',
+      `Risk rating review (${c.riskRating}) for ${c.legalName}`
+    );
+    if (riskAlert) out.push(riskAlert);
+  }
+
+  if (c.nextReviewDueAt) {
+    const reviewAlert = makeAlert(
+      c,
+      'periodic-review',
+      '',
+      c.legalName,
+      c.nextReviewDueAt,
+      asOf,
+      'Cabinet Res 134/2025 Art.19',
+      `Periodic review due for ${c.legalName} (${c.riskRating} tier)`
+    );
+    if (reviewAlert) out.push(reviewAlert);
+  }
+
+  if (c.recordRetentionUntil) {
+    const retentionAlert = makeAlert(
+      c,
+      'record-retention',
+      '',
+      c.legalName,
+      c.recordRetentionUntil,
+      asOf,
+      'FDL Art.24',
+      `Record retention deadline for ${c.legalName} (10-year period)`
+    );
+    if (retentionAlert) out.push(retentionAlert);
+  }
+}
+
+function extractShareholderAlerts(
+  c: CustomerProfileV2,
+  s: ShareholderRecord,
+  asOf: Date,
+  out: ExpiryAlert[]
+): void {
+  if (s.emiratesIdExpiry) {
+    const alert = makeAlert(
+      c,
+      'shareholder-emirates-id',
+      s.id,
+      s.fullName,
+      s.emiratesIdExpiry,
+      asOf,
+      'FDL Art.12-14',
+      `Emirates ID for shareholder ${s.fullName} (${c.legalName})`
+    );
+    if (alert) out.push(alert);
+  }
+  if (s.passportExpiry) {
+    const alert = makeAlert(
+      c,
+      'shareholder-passport',
+      s.id,
+      s.fullName,
+      s.passportExpiry,
+      asOf,
+      'FDL Art.12-14',
+      `Passport for shareholder ${s.fullName} (${c.legalName})`
+    );
+    if (alert) out.push(alert);
+  }
+  if (s.uboReverificationDueAt) {
+    const alert = makeAlert(
+      c,
+      'ubo-reverification',
+      s.id,
+      s.fullName,
+      s.uboReverificationDueAt,
+      asOf,
+      'Cabinet Decision 109/2023',
+      `UBO re-verification for ${s.fullName} (${c.legalName})`
+    );
+    if (alert) out.push(alert);
+  }
+}
+
+function extractManagerAlerts(
+  c: CustomerProfileV2,
+  m: ManagerRecord,
+  asOf: Date,
+  out: ExpiryAlert[]
+): void {
+  if (m.emiratesIdExpiry) {
+    const alert = makeAlert(
+      c,
+      'manager-emirates-id',
+      m.id,
+      m.fullName,
+      m.emiratesIdExpiry,
+      asOf,
+      'FDL Art.12-14',
+      `Emirates ID for manager ${m.fullName} (${c.legalName}, role=${m.role})`
+    );
+    if (alert) out.push(alert);
+  }
+  // Manager passport is always required — always check expiry.
+  const alert = makeAlert(
+    c,
+    'manager-passport',
+    m.id,
+    m.fullName,
+    m.passportExpiry,
+    asOf,
+    'FDL Art.12-14',
+    `Passport for manager ${m.fullName} (${c.legalName}, role=${m.role})`
+  );
+  if (alert) out.push(alert);
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk every customer in the list, emit an alert for every artefact
+ * whose expiry date falls inside an alert window (default
+ * [90, 60, 30, 7] days) or is already expired. Pure function.
+ *
+ * Sort order: by daysUntilExpiry ascending, so most-urgent (most-
+ * negative for already-expired, smallest positive for upcoming)
+ * appears first.
+ */
+export function scanExpiries(
+  customers: readonly CustomerProfileV2[],
+  asOf: Date = new Date()
+): ExpiryReport {
+  const alerts: ExpiryAlert[] = [];
+
+  for (const c of customers) {
+    extractCustomerAlerts(c, asOf, alerts);
+    for (const s of c.shareholders ?? []) {
+      extractShareholderAlerts(c, s, asOf, alerts);
+    }
+    for (const m of c.managers ?? []) {
+      extractManagerAlerts(c, m, asOf, alerts);
+    }
+  }
+
+  alerts.sort((a, b) => a.daysUntilExpiry - b.daysUntilExpiry);
+
+  const counts: Record<ExpirySeverity, number> = {
+    expired: 0,
+    urgent: 0,
+    soon: 0,
+    upcoming: 0,
+  };
+  for (const a of alerts) counts[a.severity]++;
+
+  const summary =
+    alerts.length === 0
+      ? `No expiring documents in the next ${Math.max(...EXPIRY_ALERT_WINDOWS_DAYS)} days across ${customers.length} customer(s).`
+      : `${alerts.length} expiring artefact(s) across ${customers.length} customer(s): ${counts.expired} expired, ${counts.urgent} urgent (≤7d), ${counts.soon} soon (≤30d), ${counts.upcoming} upcoming (≤90d).`;
+
+  return {
+    asOfIso: asOf.toISOString(),
+    scannedProfiles: customers.length,
+    alerts,
+    counts,
+    summary,
+    regulatory: [
+      'FDL No.10/2025 Art.20-22',
+      'FDL No.10/2025 Art.24',
+      'Cabinet Res 134/2025 Art.19',
+      'Cabinet Decision 109/2023',
+      'MoE Circular 08/AML/2021',
+    ],
+  };
+}

--- a/src/services/customerProfileValidator.ts
+++ b/src/services/customerProfileValidator.ts
@@ -1,0 +1,573 @@
+/**
+ * Customer Profile Validator — pure structural + regulatory validator
+ * for CustomerProfileV2 records. Runs at the system boundary (HTTP
+ * ingress, UI save, CSV import) so every downstream consumer can
+ * trust the shape.
+ *
+ * Why this exists:
+ *   The v2 profile has ~40 fields. A React form cannot enforce all
+ *   the cross-field invariants (ownership summing ≤100, UBO threshold
+ *   implies evidence present, licence status must match licence
+ *   expiry date, every natural-person manager must have a passport
+ *   expiry in the future, etc.). Those invariants live here.
+ *
+ *   Pure function. No I/O, no state, no network. Returns a structured
+ *   report with per-field findings so the UI can render inline error
+ *   messages AND the audit log can record exactly which rule fired.
+ *
+ * Regulatory basis:
+ *   FDL No.10/2025 Art.12-14 (every CDD field is mandatory)
+ *   FDL No.10/2025 Art.24    (10yr retention — validated records only)
+ *   Cabinet Res 134/2025 Art.7-10 (CDD data collection per tier)
+ *   Cabinet Res 134/2025 Art.14   (EDD + PEP senior/board approval)
+ *   Cabinet Decision 109/2023     (UBO register, >25% threshold,
+ *                                   15-working-day re-verification)
+ *   MoE Circular 08/AML/2021      (DPMS licence validity check)
+ *   FATF Rec 10 (CDD), Rec 12 (PEP)
+ */
+
+import {
+  type CustomerProfileV2,
+  type ManagerRecord,
+  type ShareholderRecord,
+  type DateDdMmYyyy,
+  type EmiratesIdNumber,
+  UBO_OWNERSHIP_THRESHOLD_PERCENT,
+  parseDdMmYyyy,
+  isShareholderUbo,
+} from '../domain/customerProfile';
+
+// ---------------------------------------------------------------------------
+// Finding types
+// ---------------------------------------------------------------------------
+
+export type FindingSeverity = 'blocker' | 'warning' | 'info';
+
+export interface ValidationFinding {
+  /** Dot-path into the profile e.g. "managers[2].passportExpiry". */
+  readonly path: string;
+  readonly severity: FindingSeverity;
+  readonly message: string;
+  readonly regulatory: string;
+}
+
+export interface ValidationReport {
+  readonly ok: boolean;
+  readonly blockerCount: number;
+  readonly warningCount: number;
+  readonly infoCount: number;
+  readonly findings: readonly ValidationFinding[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * UAE Emirates ID format: 784-YYYY-NNNNNNN-N. Strict validator —
+ * rejects anything that doesn't match the four-group pattern with
+ * hyphens. The 784 prefix is the UAE ISD code and is mandatory.
+ */
+export function isValidEmiratesId(value: EmiratesIdNumber | undefined | null): boolean {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  return /^784-\d{4}-\d{7}-\d$/.test(trimmed);
+}
+
+/**
+ * ISO-3166 alpha-2 shape check — exactly 2 uppercase letters.
+ * Does NOT validate against the full ISO list (that would be a
+ * 250-entry lookup table), but catches 99% of operator typos.
+ */
+export function isValidCountryCode(value: string | undefined | null): boolean {
+  if (typeof value !== 'string') return false;
+  return /^[A-Z]{2}$/.test(value.trim());
+}
+
+/** Returns true if the given dd/mm/yyyy date is strictly in the past. */
+export function isExpired(date: DateDdMmYyyy | undefined | null, asOf: Date): boolean {
+  const parsed = parseDdMmYyyy(date);
+  if (parsed === null) return false;
+  return parsed.getTime() < asOf.getTime();
+}
+
+/** Returns true if the given dd/mm/yyyy date is strictly in the future. */
+export function isInFuture(date: DateDdMmYyyy | undefined | null, asOf: Date): boolean {
+  const parsed = parseDdMmYyyy(date);
+  if (parsed === null) return false;
+  return parsed.getTime() > asOf.getTime();
+}
+
+// ---------------------------------------------------------------------------
+// Finding accumulator
+// ---------------------------------------------------------------------------
+
+class FindingAccumulator {
+  readonly findings: ValidationFinding[] = [];
+
+  blocker(path: string, message: string, regulatory: string): void {
+    this.findings.push({ path, severity: 'blocker', message, regulatory });
+  }
+
+  warning(path: string, message: string, regulatory: string): void {
+    this.findings.push({ path, severity: 'warning', message, regulatory });
+  }
+
+  info(path: string, message: string, regulatory: string): void {
+    this.findings.push({ path, severity: 'info', message, regulatory });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Individual validators
+// ---------------------------------------------------------------------------
+
+function validateIdentity(p: CustomerProfileV2, acc: FindingAccumulator): void {
+  if (!p.id || p.id.trim().length === 0) {
+    acc.blocker('id', 'Customer id is required', 'FDL Art.12-14');
+  }
+  if (!p.legalName || p.legalName.trim().length === 0) {
+    acc.blocker('legalName', 'Legal name is required', 'FDL Art.12-14');
+  }
+  if (p.customerType !== 'natural' && p.customerType !== 'legal') {
+    acc.blocker('customerType', 'customerType must be "natural" or "legal"', 'FDL Art.12-14');
+  }
+}
+
+function validateRegistration(p: CustomerProfileV2, acc: FindingAccumulator, asOf: Date): void {
+  if (!isValidCountryCode(p.country)) {
+    acc.blocker(
+      'country',
+      `country must be ISO-3166 alpha-2 (e.g. "AE"), got "${p.country}"`,
+      'FDL Art.12-14'
+    );
+  }
+  if (!p.jurisdiction || p.jurisdiction.trim().length === 0) {
+    acc.blocker('jurisdiction', 'jurisdiction is required', 'FDL Art.12');
+  }
+  if (!p.licenseNumber || p.licenseNumber.trim().length === 0) {
+    acc.blocker('licenseNumber', 'licenseNumber is required', 'MoE Circular 08/AML/2021');
+  }
+  if (!p.licenseIssuer || p.licenseIssuer.trim().length === 0) {
+    acc.blocker('licenseIssuer', 'licenseIssuer is required', 'MoE Circular 08/AML/2021');
+  }
+
+  const issueDate = parseDdMmYyyy(p.licenseIssueDate);
+  if (issueDate === null) {
+    acc.blocker(
+      'licenseIssueDate',
+      `licenseIssueDate must be dd/mm/yyyy, got "${p.licenseIssueDate}"`,
+      'FDL Art.12'
+    );
+  }
+  const expiryDate = parseDdMmYyyy(p.licenseExpiryDate);
+  if (expiryDate === null) {
+    acc.blocker(
+      'licenseExpiryDate',
+      `licenseExpiryDate must be dd/mm/yyyy, got "${p.licenseExpiryDate}"`,
+      'MoE Circular 08/AML/2021'
+    );
+  }
+
+  // Cross-field: issue date must be before expiry date
+  if (issueDate && expiryDate && issueDate.getTime() >= expiryDate.getTime()) {
+    acc.blocker(
+      'licenseExpiryDate',
+      'licenseExpiryDate must be strictly after licenseIssueDate',
+      'FDL Art.12'
+    );
+  }
+
+  // Cross-field: licenseStatus must match actual expiry
+  if (expiryDate) {
+    const isPastExpiry = expiryDate.getTime() < asOf.getTime();
+    if (isPastExpiry && p.licenseStatus === 'active') {
+      acc.blocker(
+        'licenseStatus',
+        'licenseStatus is "active" but licenseExpiryDate is in the past — update to "expired"',
+        'MoE Circular 08/AML/2021'
+      );
+    }
+  }
+}
+
+function validateBusiness(p: CustomerProfileV2, acc: FindingAccumulator): void {
+  if (!p.businessModel || p.businessModel.trim().length < 10) {
+    acc.warning(
+      'businessModel',
+      'businessModel should be at least 10 characters of plain-language description',
+      'Cabinet Res 134/2025 Art.7-10'
+    );
+  }
+  if (!p.activity || p.activity.trim().length === 0) {
+    acc.blocker('activity', 'activity is required', 'FDL Art.12-14');
+  }
+  if (typeof p.expectedMonthlyVolumeAed !== 'number' || p.expectedMonthlyVolumeAed < 0) {
+    acc.blocker(
+      'expectedMonthlyVolumeAed',
+      'expectedMonthlyVolumeAed must be a non-negative number',
+      'Cabinet Res 134/2025 Art.7-10'
+    );
+  }
+  if (
+    typeof p.expectedTransactionCountPerMonth !== 'number' ||
+    p.expectedTransactionCountPerMonth < 0
+  ) {
+    acc.blocker(
+      'expectedTransactionCountPerMonth',
+      'expectedTransactionCountPerMonth must be a non-negative number',
+      'Cabinet Res 134/2025 Art.7-10'
+    );
+  }
+}
+
+function validateRiskPosture(p: CustomerProfileV2, acc: FindingAccumulator): void {
+  const validTiers = ['low', 'medium', 'high'] as const;
+  if (!validTiers.includes(p.riskRating)) {
+    acc.blocker('riskRating', 'riskRating must be low/medium/high', 'Cabinet Res 134/2025 Art.5');
+  }
+  if (parseDdMmYyyy(p.riskRatingAssignedAt) === null) {
+    acc.blocker(
+      'riskRatingAssignedAt',
+      `riskRatingAssignedAt must be dd/mm/yyyy, got "${p.riskRatingAssignedAt}"`,
+      'Cabinet Res 134/2025 Art.19'
+    );
+  }
+  if (parseDdMmYyyy(p.riskRatingExpiresAt) === null) {
+    acc.blocker(
+      'riskRatingExpiresAt',
+      `riskRatingExpiresAt must be dd/mm/yyyy, got "${p.riskRatingExpiresAt}"`,
+      'Cabinet Res 134/2025 Art.19'
+    );
+  }
+}
+
+function validateSourceOfFunds(p: CustomerProfileV2, acc: FindingAccumulator): void {
+  if (
+    p.sourceOfFundsStatus === 'verified' &&
+    (!p.sourceOfFundsEvidence || p.sourceOfFundsEvidence.length === 0)
+  ) {
+    acc.blocker(
+      'sourceOfFundsEvidence',
+      'sourceOfFundsStatus is "verified" but no evidence attachments are present',
+      'FDL Art.14'
+    );
+  }
+  if (p.riskRating === 'high' && p.sourceOfWealthStatus === 'pending') {
+    acc.warning(
+      'sourceOfWealthStatus',
+      'High-risk customer must have source-of-wealth verified per Cabinet Res 134/2025 Art.14',
+      'Cabinet Res 134/2025 Art.14'
+    );
+  }
+  if (
+    p.sourceOfWealthStatus === 'verified' &&
+    (!p.sourceOfWealthEvidence || p.sourceOfWealthEvidence.length === 0)
+  ) {
+    acc.blocker(
+      'sourceOfWealthEvidence',
+      'sourceOfWealthStatus is "verified" but no evidence attachments are present',
+      'Cabinet Res 134/2025 Art.14'
+    );
+  }
+}
+
+function validateShareholders(
+  shareholders: readonly ShareholderRecord[],
+  acc: FindingAccumulator,
+  asOf: Date
+): void {
+  // Rule 1: total ownership cannot exceed 100%
+  const totalOwnership = shareholders.reduce((sum, s) => sum + (s.ownershipPercent ?? 0), 0);
+  if (totalOwnership > 100.01) {
+    // 0.01 tolerance for rounding
+    acc.blocker(
+      'shareholders',
+      `Total shareholder ownership is ${totalOwnership.toFixed(2)}%, must be ≤100%`,
+      'Cabinet Decision 109/2023'
+    );
+  }
+
+  // Rule 2: per-shareholder checks
+  shareholders.forEach((s, idx) => {
+    const path = `shareholders[${idx}]`;
+    if (!s.id || s.id.trim().length === 0) {
+      acc.blocker(`${path}.id`, 'shareholder id is required', 'Cabinet Decision 109/2023');
+    }
+    if (!s.fullName || s.fullName.trim().length === 0) {
+      acc.blocker(
+        `${path}.fullName`,
+        'shareholder fullName is required',
+        'Cabinet Decision 109/2023'
+      );
+    }
+    if (
+      typeof s.ownershipPercent !== 'number' ||
+      s.ownershipPercent < 0 ||
+      s.ownershipPercent > 100
+    ) {
+      acc.blocker(
+        `${path}.ownershipPercent`,
+        'ownershipPercent must be a number 0..100',
+        'Cabinet Decision 109/2023'
+      );
+    }
+
+    if (s.type === 'natural') {
+      if (!s.nationality || !isValidCountryCode(s.nationality)) {
+        acc.blocker(
+          `${path}.nationality`,
+          'nationality is required (ISO-3166 alpha-2) for natural-person shareholders',
+          'FDL Art.12-14'
+        );
+      }
+      if (!s.dateOfBirth || parseDdMmYyyy(s.dateOfBirth) === null) {
+        acc.blocker(
+          `${path}.dateOfBirth`,
+          'dateOfBirth (dd/mm/yyyy) is required for natural-person shareholders',
+          'FDL Art.12-14'
+        );
+      }
+      // Emirates ID: required IF the shareholder is UAE national
+      if (s.nationality === 'AE') {
+        if (!s.emiratesIdNumber || !isValidEmiratesId(s.emiratesIdNumber)) {
+          acc.blocker(
+            `${path}.emiratesIdNumber`,
+            'UAE-national shareholders must have a valid Emirates ID (784-YYYY-NNNNNNN-N)',
+            'FDL Art.12-14'
+          );
+        }
+        if (!s.emiratesIdExpiry || parseDdMmYyyy(s.emiratesIdExpiry) === null) {
+          acc.blocker(
+            `${path}.emiratesIdExpiry`,
+            'Emirates ID expiry date is required',
+            'FDL Art.12-14'
+          );
+        } else if (isExpired(s.emiratesIdExpiry, asOf)) {
+          acc.warning(
+            `${path}.emiratesIdExpiry`,
+            `Emirates ID expired on ${s.emiratesIdExpiry}`,
+            'FDL Art.12-14'
+          );
+        }
+      }
+      // Passport: required for non-UAE nationals
+      if (s.nationality && s.nationality !== 'AE') {
+        if (!s.passportNumber) {
+          acc.blocker(
+            `${path}.passportNumber`,
+            'Non-UAE-national shareholders must have a passport number',
+            'FDL Art.12-14'
+          );
+        }
+        if (!s.passportExpiry || parseDdMmYyyy(s.passportExpiry) === null) {
+          acc.blocker(
+            `${path}.passportExpiry`,
+            'Passport expiry date is required',
+            'FDL Art.12-14'
+          );
+        } else if (isExpired(s.passportExpiry, asOf)) {
+          acc.warning(
+            `${path}.passportExpiry`,
+            `Passport expired on ${s.passportExpiry}`,
+            'FDL Art.12-14'
+          );
+        }
+      }
+    } else if (s.type === 'legal') {
+      if (!s.registrationCountry || !isValidCountryCode(s.registrationCountry)) {
+        acc.blocker(
+          `${path}.registrationCountry`,
+          'registrationCountry is required for legal-entity shareholders',
+          'Cabinet Decision 109/2023'
+        );
+      }
+      if (!s.registrationNumber) {
+        acc.blocker(
+          `${path}.registrationNumber`,
+          'registrationNumber is required for legal-entity shareholders',
+          'Cabinet Decision 109/2023'
+        );
+      }
+    }
+
+    // UBO-specific rules (Cabinet Decision 109/2023)
+    if (isShareholderUbo(s)) {
+      if (!s.uboVerifiedAt) {
+        acc.blocker(
+          `${path}.uboVerifiedAt`,
+          `Shareholder owns ≥${UBO_OWNERSHIP_THRESHOLD_PERCENT}% and must have a UBO verification date`,
+          'Cabinet Decision 109/2023'
+        );
+      }
+      // PEP status is always decided (clear/potential/confirmed) — no
+      // "pending" variant in the type. A 'potential' PEP UBO warrants
+      // a flag because Board approval becomes mandatory if confirmed.
+      if (s.pepCheckStatus === 'potential') {
+        acc.warning(
+          `${path}.pepCheckStatus`,
+          'UBO shareholder flagged as potential PEP — escalate for Board approval determination',
+          'FATF Rec 12'
+        );
+      }
+      if (s.sanctionsCheckStatus === 'pending') {
+        acc.warning(
+          `${path}.sanctionsCheckStatus`,
+          'UBO shareholder still has sanctions check pending',
+          'FDL Art.35'
+        );
+      }
+      if (!s.evidenceAttachments || s.evidenceAttachments.length === 0) {
+        acc.warning(
+          `${path}.evidenceAttachments`,
+          'UBO shareholder should have at least one evidence attachment (ID, registration, etc.)',
+          'Cabinet Decision 109/2023'
+        );
+      }
+    }
+  });
+
+  // Rule 3: at least one UBO if there are any shareholders
+  if (shareholders.length > 0 && !shareholders.some(isShareholderUbo)) {
+    acc.warning(
+      'shareholders',
+      'No shareholder owns ≥25% — confirm this is deliberate (flat ownership) and identify the ultimate natural-person UBO via parent chain',
+      'Cabinet Decision 109/2023'
+    );
+  }
+}
+
+function validateManagers(
+  managers: readonly ManagerRecord[],
+  acc: FindingAccumulator,
+  asOf: Date
+): void {
+  if (managers.length === 0) {
+    acc.warning(
+      'managers',
+      'Customer has no managers / directors / authorised signatories recorded',
+      'FDL Art.20-22'
+    );
+    return;
+  }
+
+  managers.forEach((m, idx) => {
+    const path = `managers[${idx}]`;
+    if (!m.id || m.id.trim().length === 0) {
+      acc.blocker(`${path}.id`, 'manager id is required', 'FDL Art.20-22');
+    }
+    if (!m.fullName || m.fullName.trim().length === 0) {
+      acc.blocker(`${path}.fullName`, 'manager fullName is required', 'FDL Art.20-22');
+    }
+    if (!m.nationality || !isValidCountryCode(m.nationality)) {
+      acc.blocker(
+        `${path}.nationality`,
+        'manager nationality is required (ISO-3166 alpha-2)',
+        'FDL Art.12-14'
+      );
+    }
+    if (!m.dateOfBirth || parseDdMmYyyy(m.dateOfBirth) === null) {
+      acc.blocker(
+        `${path}.dateOfBirth`,
+        'manager dateOfBirth (dd/mm/yyyy) is required',
+        'FDL Art.12-14'
+      );
+    }
+    if (!m.passportNumber || m.passportNumber.trim().length === 0) {
+      acc.blocker(`${path}.passportNumber`, 'manager passportNumber is required', 'FDL Art.12-14');
+    }
+    if (!m.passportExpiry || parseDdMmYyyy(m.passportExpiry) === null) {
+      acc.blocker(
+        `${path}.passportExpiry`,
+        'manager passportExpiry (dd/mm/yyyy) is required',
+        'FDL Art.12-14'
+      );
+    } else if (isExpired(m.passportExpiry, asOf)) {
+      acc.blocker(
+        `${path}.passportExpiry`,
+        `manager passport expired on ${m.passportExpiry} — cannot act for the entity`,
+        'FDL Art.12-14'
+      );
+    }
+    // If UAE national, require valid Emirates ID
+    if (m.nationality === 'AE') {
+      if (!m.emiratesIdNumber || !isValidEmiratesId(m.emiratesIdNumber)) {
+        acc.blocker(
+          `${path}.emiratesIdNumber`,
+          'UAE-national manager must have a valid Emirates ID (784-YYYY-NNNNNNN-N)',
+          'FDL Art.12-14'
+        );
+      }
+      if (m.emiratesIdExpiry && isExpired(m.emiratesIdExpiry, asOf)) {
+        acc.warning(
+          `${path}.emiratesIdExpiry`,
+          `manager Emirates ID expired on ${m.emiratesIdExpiry}`,
+          'FDL Art.12-14'
+        );
+      }
+    }
+    if (!m.appointmentDate || parseDdMmYyyy(m.appointmentDate) === null) {
+      acc.blocker(
+        `${path}.appointmentDate`,
+        'manager appointmentDate (dd/mm/yyyy) is required',
+        'Cabinet Res 134/2025 Art.19'
+      );
+    }
+  });
+
+  // Require at least one MLRO + one CO for Cabinet Res 134/2025 Art.19 compliance
+  const hasMlro = managers.some((m) => m.role === 'mlro');
+  const hasCo = managers.some((m) => m.role === 'co');
+  if (!hasMlro) {
+    acc.warning(
+      'managers',
+      'No manager with role "mlro" — FDL Art.20-22 requires a designated MLRO',
+      'FDL Art.20-22'
+    );
+  }
+  if (!hasCo) {
+    acc.warning(
+      'managers',
+      'No manager with role "co" — FDL Art.20-22 requires a designated Compliance Officer',
+      'FDL Art.20-22'
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a CustomerProfileV2 record. Pure function.
+ *
+ * @param profile  The profile to validate (shape is trusted as V2).
+ * @param asOf     The "current time" against which expiry dates are
+ *                 checked. Tests inject a fixed date for determinism.
+ */
+export function validateCustomerProfile(
+  profile: CustomerProfileV2,
+  asOf: Date = new Date()
+): ValidationReport {
+  const acc = new FindingAccumulator();
+
+  validateIdentity(profile, acc);
+  validateRegistration(profile, acc, asOf);
+  validateBusiness(profile, acc);
+  validateRiskPosture(profile, acc);
+  validateSourceOfFunds(profile, acc);
+  validateShareholders(profile.shareholders ?? [], acc, asOf);
+  validateManagers(profile.managers ?? [], acc, asOf);
+
+  const blockerCount = acc.findings.filter((f) => f.severity === 'blocker').length;
+  const warningCount = acc.findings.filter((f) => f.severity === 'warning').length;
+  const infoCount = acc.findings.filter((f) => f.severity === 'info').length;
+
+  return {
+    ok: blockerCount === 0,
+    blockerCount,
+    warningCount,
+    infoCount,
+    findings: acc.findings,
+  };
+}

--- a/tests/customerExpiryAlerter.test.ts
+++ b/tests/customerExpiryAlerter.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Tests for src/services/customerExpiryAlerter.ts.
+ */
+import { describe, expect, it } from 'vitest';
+import type {
+  CustomerProfileV2,
+  ManagerRecord,
+  ShareholderRecord,
+} from '../src/domain/customerProfile';
+import {
+  classifySeverity,
+  classifyWindow,
+  scanExpiries,
+} from '../src/services/customerExpiryAlerter';
+
+const TODAY = new Date(Date.UTC(2026, 3, 15)); // 15 April 2026
+
+function addDays(base: Date, days: number): Date {
+  const d = new Date(base.getTime());
+  d.setUTCDate(d.getUTCDate() + days);
+  return d;
+}
+
+function toDdMmYyyy(date: Date): string {
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const year = date.getUTCFullYear();
+  return `${day}/${month}/${year}`;
+}
+
+function inDaysFromToday(days: number): string {
+  return toDdMmYyyy(addDays(TODAY, days));
+}
+
+function makeProfile(overrides: Partial<CustomerProfileV2> = {}): CustomerProfileV2 {
+  const m: ManagerRecord = {
+    id: 'mgr-1',
+    fullName: 'Test Manager',
+    role: 'mlro',
+    dateOfBirth: '01/01/1980',
+    nationality: 'AE',
+    emiratesIdNumber: '784-1980-1234567-1',
+    emiratesIdExpiry: inDaysFromToday(365),
+    passportNumber: 'A1',
+    passportCountry: 'AE',
+    passportExpiry: inDaysFromToday(365),
+    appointmentDate: '01/01/2024',
+    isSanctionsAuthority: true,
+    isStrFilingAuthority: true,
+    pepCheckStatus: 'clear',
+    sanctionsCheckStatus: 'clear',
+    adverseMediaCheckStatus: 'clear',
+  };
+  return {
+    schemaVersion: 2,
+    id: 'cust-1',
+    legalName: 'Test Customer L.L.C',
+    customerType: 'legal',
+    country: 'AE',
+    jurisdiction: 'Dubai',
+    licenseNumber: 'LIC-1',
+    licenseIssuer: 'DET',
+    licenseIssueDate: '01/01/2024',
+    licenseExpiryDate: inDaysFromToday(365),
+    licenseStatus: 'active',
+    businessModel: 'Test business model',
+    activity: 'Test',
+    sector: 'jewellery-retail',
+    expectedMonthlyVolumeAed: 100_000,
+    expectedTransactionCountPerMonth: 10,
+    riskRating: 'medium',
+    riskRatingAssignedAt: '01/01/2026',
+    riskRatingExpiresAt: inDaysFromToday(365),
+    pepStatus: 'clear',
+    sanctionsStatus: 'clear',
+    sourceOfFundsStatus: 'verified',
+    sourceOfWealthStatus: 'not_applicable',
+    shareholders: [],
+    managers: [m],
+    entityType: 'standalone',
+    createdAt: '2026-01-01T00:00:00Z',
+    nextReviewDueAt: inDaysFromToday(365),
+    recordRetentionUntil: inDaysFromToday(3650),
+    ...overrides,
+  };
+}
+
+describe('classifyWindow', () => {
+  it('puts 5 days into the 7-day bucket', () => {
+    expect(classifyWindow(5)).toBe(7);
+  });
+  it('puts 7 days exactly into the 7-day bucket', () => {
+    expect(classifyWindow(7)).toBe(7);
+  });
+  it('puts 20 days into the 30-day bucket', () => {
+    expect(classifyWindow(20)).toBe(30);
+  });
+  it('puts 45 days into the 60-day bucket', () => {
+    expect(classifyWindow(45)).toBe(60);
+  });
+  it('puts 85 days into the 90-day bucket', () => {
+    expect(classifyWindow(85)).toBe(90);
+  });
+  it('returns null for 100+ days (outside all windows)', () => {
+    expect(classifyWindow(100)).toBeNull();
+  });
+  it('returns null for negative days (already expired)', () => {
+    expect(classifyWindow(-5)).toBeNull();
+  });
+});
+
+describe('classifySeverity', () => {
+  it('negative days → expired', () => {
+    expect(classifySeverity(-1)).toBe('expired');
+    expect(classifySeverity(-100)).toBe('expired');
+  });
+  it('0-7 days → urgent', () => {
+    expect(classifySeverity(0)).toBe('urgent');
+    expect(classifySeverity(7)).toBe('urgent');
+  });
+  it('8-30 days → soon', () => {
+    expect(classifySeverity(8)).toBe('soon');
+    expect(classifySeverity(30)).toBe('soon');
+  });
+  it('31-90 days → upcoming', () => {
+    expect(classifySeverity(45)).toBe('upcoming');
+    expect(classifySeverity(90)).toBe('upcoming');
+  });
+  it('>90 days → null (outside window)', () => {
+    expect(classifySeverity(91)).toBeNull();
+  });
+});
+
+describe('scanExpiries — happy path', () => {
+  it('returns no alerts when nothing is expiring within 90 days', () => {
+    const profile = makeProfile({
+      licenseExpiryDate: inDaysFromToday(180),
+      riskRatingExpiresAt: inDaysFromToday(180),
+      nextReviewDueAt: inDaysFromToday(180),
+      recordRetentionUntil: inDaysFromToday(3650),
+    });
+    const report = scanExpiries([profile], TODAY);
+    expect(report.alerts).toHaveLength(0);
+    expect(report.counts.expired).toBe(0);
+  });
+
+  it('returns the customer licence when it expires in 60 days', () => {
+    const profile = makeProfile({
+      licenseExpiryDate: inDaysFromToday(60),
+      riskRatingExpiresAt: inDaysFromToday(180),
+      nextReviewDueAt: inDaysFromToday(180),
+    });
+    const report = scanExpiries([profile], TODAY);
+    expect(report.alerts.length).toBeGreaterThan(0);
+    const licence = report.alerts.find((a) => a.kind === 'licence');
+    expect(licence).toBeDefined();
+    expect(licence!.daysUntilExpiry).toBe(60);
+    expect(licence!.severity).toBe('upcoming');
+    expect(licence!.windowDays).toBe(60);
+  });
+
+  it('flags an expired document as severity=expired', () => {
+    const profile = makeProfile({
+      licenseExpiryDate: inDaysFromToday(-10),
+    });
+    const report = scanExpiries([profile], TODAY);
+    const licence = report.alerts.find((a) => a.kind === 'licence');
+    expect(licence).toBeDefined();
+    expect(licence!.severity).toBe('expired');
+    expect(licence!.daysUntilExpiry).toBe(-10);
+    expect(licence!.message).toMatch(/expired 10 day/);
+  });
+});
+
+describe('scanExpiries — urgency bucketing', () => {
+  it.each([
+    [5, 'urgent', 7],
+    [15, 'soon', 30],
+    [45, 'upcoming', 60],
+    [85, 'upcoming', 90],
+  ] as const)('%d days → severity=%s window=%d', (days, sev, win) => {
+    const profile = makeProfile({
+      licenseExpiryDate: inDaysFromToday(days),
+      riskRatingExpiresAt: inDaysFromToday(365),
+      nextReviewDueAt: inDaysFromToday(365),
+    });
+    const report = scanExpiries([profile], TODAY);
+    const licence = report.alerts.find((a) => a.kind === 'licence');
+    expect(licence).toBeDefined();
+    expect(licence!.severity).toBe(sev);
+    expect(licence!.windowDays).toBe(win);
+  });
+});
+
+describe('scanExpiries — shareholder alerts', () => {
+  it('emits alerts for shareholder Emirates ID + passport expiries', () => {
+    const shareholder: ShareholderRecord = {
+      id: 'sh-1',
+      type: 'natural',
+      fullName: 'UBO Person',
+      ownershipPercent: 60,
+      dateOfBirth: '01/01/1970',
+      nationality: 'AE',
+      emiratesIdNumber: '784-1970-1111111-1',
+      emiratesIdExpiry: inDaysFromToday(20),
+      passportExpiry: inDaysFromToday(60),
+      uboVerifiedAt: '01/01/2026',
+      uboReverificationDueAt: inDaysFromToday(10),
+      pepCheckStatus: 'clear',
+      sanctionsCheckStatus: 'clear',
+      adverseMediaCheckStatus: 'clear',
+    };
+    const profile = makeProfile({
+      shareholders: [shareholder],
+      licenseExpiryDate: inDaysFromToday(365),
+      riskRatingExpiresAt: inDaysFromToday(365),
+      nextReviewDueAt: inDaysFromToday(365),
+    });
+    const report = scanExpiries([profile], TODAY);
+    expect(report.alerts.find((a) => a.kind === 'shareholder-emirates-id')).toBeDefined();
+    expect(report.alerts.find((a) => a.kind === 'shareholder-passport')).toBeDefined();
+    expect(report.alerts.find((a) => a.kind === 'ubo-reverification')).toBeDefined();
+  });
+});
+
+describe('scanExpiries — manager alerts', () => {
+  it('emits a manager passport alert when it expires in 10 days', () => {
+    const profile = makeProfile({
+      managers: [
+        {
+          id: 'mgr-1',
+          fullName: 'Test Manager',
+          role: 'mlro',
+          dateOfBirth: '01/01/1980',
+          nationality: 'AE',
+          emiratesIdNumber: '784-1980-1234567-1',
+          emiratesIdExpiry: inDaysFromToday(365),
+          passportNumber: 'A1',
+          passportCountry: 'AE',
+          passportExpiry: inDaysFromToday(10),
+          appointmentDate: '01/01/2024',
+          isSanctionsAuthority: true,
+          isStrFilingAuthority: true,
+          pepCheckStatus: 'clear',
+          sanctionsCheckStatus: 'clear',
+          adverseMediaCheckStatus: 'clear',
+        },
+      ],
+      licenseExpiryDate: inDaysFromToday(365),
+      riskRatingExpiresAt: inDaysFromToday(365),
+      nextReviewDueAt: inDaysFromToday(365),
+    });
+    const report = scanExpiries([profile], TODAY);
+    const mgrPassport = report.alerts.find((a) => a.kind === 'manager-passport');
+    expect(mgrPassport).toBeDefined();
+    expect(mgrPassport!.daysUntilExpiry).toBe(10);
+    expect(mgrPassport!.severity).toBe('soon');
+  });
+});
+
+describe('scanExpiries — sorting', () => {
+  it('sorts alerts by daysUntilExpiry ascending', () => {
+    const profile = makeProfile({
+      licenseExpiryDate: inDaysFromToday(50),
+      riskRatingExpiresAt: inDaysFromToday(10),
+      nextReviewDueAt: inDaysFromToday(30),
+      recordRetentionUntil: inDaysFromToday(3650),
+    });
+    const report = scanExpiries([profile], TODAY);
+    const days = report.alerts.map((a) => a.daysUntilExpiry);
+    for (let i = 0; i < days.length - 1; i++) {
+      expect(days[i]!).toBeLessThanOrEqual(days[i + 1]!);
+    }
+  });
+});
+
+describe('scanExpiries — counts + summary', () => {
+  it('counts per severity', () => {
+    const profile = makeProfile({
+      licenseExpiryDate: inDaysFromToday(-5), // expired
+      riskRatingExpiresAt: inDaysFromToday(5), // urgent
+      nextReviewDueAt: inDaysFromToday(25), // soon
+      recordRetentionUntil: inDaysFromToday(60), // upcoming
+    });
+    const report = scanExpiries([profile], TODAY);
+    expect(report.counts.expired).toBeGreaterThanOrEqual(1);
+    expect(report.counts.urgent).toBeGreaterThanOrEqual(1);
+    expect(report.counts.soon).toBeGreaterThanOrEqual(1);
+    expect(report.counts.upcoming).toBeGreaterThanOrEqual(1);
+  });
+  it('emits a clean summary when nothing is expiring', () => {
+    const profile = makeProfile({
+      licenseExpiryDate: inDaysFromToday(365),
+      riskRatingExpiresAt: inDaysFromToday(365),
+      nextReviewDueAt: inDaysFromToday(365),
+      recordRetentionUntil: inDaysFromToday(3650),
+      managers: [
+        {
+          id: 'mgr-1',
+          fullName: 'OK',
+          role: 'mlro',
+          dateOfBirth: '01/01/1980',
+          nationality: 'AE',
+          emiratesIdNumber: '784-1980-1234567-1',
+          emiratesIdExpiry: inDaysFromToday(365),
+          passportNumber: 'A1',
+          passportCountry: 'AE',
+          passportExpiry: inDaysFromToday(365),
+          appointmentDate: '01/01/2024',
+          isSanctionsAuthority: true,
+          isStrFilingAuthority: true,
+          pepCheckStatus: 'clear',
+          sanctionsCheckStatus: 'clear',
+          adverseMediaCheckStatus: 'clear',
+        },
+      ],
+    });
+    const report = scanExpiries([profile], TODAY);
+    expect(report.summary).toMatch(/No expiring documents/);
+  });
+});

--- a/tests/customerProfile.test.ts
+++ b/tests/customerProfile.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tests for src/domain/customerProfile.ts — pure helpers + constants.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  PERIODIC_REVIEW_MONTHS,
+  RECORD_RETENTION_YEARS,
+  UBO_OWNERSHIP_THRESHOLD_PERCENT,
+  UBO_REVERIFICATION_WORKING_DAYS,
+  addMonths,
+  addYears,
+  computeNextReviewDue,
+  computeRetentionUntil,
+  daysBetween,
+  extractUbos,
+  formatDdMmYyyy,
+  isShareholderUbo,
+  parseDdMmYyyy,
+  type ShareholderRecord,
+} from '../src/domain/customerProfile';
+
+describe('regulatory constants', () => {
+  it('UBO threshold matches Cabinet Decision 109/2023', () => {
+    expect(UBO_OWNERSHIP_THRESHOLD_PERCENT).toBe(25);
+  });
+  it('UBO re-verification window matches Cabinet Decision 109/2023', () => {
+    expect(UBO_REVERIFICATION_WORKING_DAYS).toBe(15);
+  });
+  it('record retention matches FDL Art.24', () => {
+    expect(RECORD_RETENTION_YEARS).toBe(10);
+  });
+  it('periodic review cadence per tier', () => {
+    expect(PERIODIC_REVIEW_MONTHS.low).toBe(12);
+    expect(PERIODIC_REVIEW_MONTHS.medium).toBe(6);
+    expect(PERIODIC_REVIEW_MONTHS.high).toBe(3);
+  });
+});
+
+describe('parseDdMmYyyy', () => {
+  it('parses a valid dd/mm/yyyy date', () => {
+    const d = parseDdMmYyyy('15/04/2026');
+    expect(d).not.toBeNull();
+    expect(d!.getUTCFullYear()).toBe(2026);
+    expect(d!.getUTCMonth()).toBe(3); // April = index 3
+    expect(d!.getUTCDate()).toBe(15);
+  });
+  it('parses a single-digit day/month', () => {
+    const d = parseDdMmYyyy('5/4/2026');
+    expect(d).not.toBeNull();
+    expect(d!.getUTCDate()).toBe(5);
+    expect(d!.getUTCMonth()).toBe(3);
+  });
+  it('rejects month > 12', () => {
+    expect(parseDdMmYyyy('01/13/2026')).toBeNull();
+  });
+  it('rejects day > 31', () => {
+    expect(parseDdMmYyyy('32/01/2026')).toBeNull();
+  });
+  it('rejects 31/02/2026 (February never has 31 days)', () => {
+    expect(parseDdMmYyyy('31/02/2026')).toBeNull();
+  });
+  it('rejects 30/02/2026', () => {
+    expect(parseDdMmYyyy('30/02/2026')).toBeNull();
+  });
+  it('accepts 29/02/2024 (leap year)', () => {
+    const d = parseDdMmYyyy('29/02/2024');
+    expect(d).not.toBeNull();
+  });
+  it('rejects 29/02/2026 (non-leap year)', () => {
+    expect(parseDdMmYyyy('29/02/2026')).toBeNull();
+  });
+  it('rejects ISO format', () => {
+    expect(parseDdMmYyyy('2026-04-15')).toBeNull();
+  });
+  it('rejects text', () => {
+    expect(parseDdMmYyyy('tomorrow')).toBeNull();
+  });
+  it('rejects undefined/null/empty', () => {
+    expect(parseDdMmYyyy(undefined)).toBeNull();
+    expect(parseDdMmYyyy(null)).toBeNull();
+    expect(parseDdMmYyyy('')).toBeNull();
+  });
+  it('rejects wrong separator', () => {
+    expect(parseDdMmYyyy('15-04-2026')).toBeNull();
+  });
+  it('rejects 2-digit year', () => {
+    expect(parseDdMmYyyy('15/04/26')).toBeNull();
+  });
+});
+
+describe('formatDdMmYyyy', () => {
+  it('formats with zero-padding', () => {
+    const d = new Date(Date.UTC(2026, 3, 5)); // 5 April 2026
+    expect(formatDdMmYyyy(d)).toBe('05/04/2026');
+  });
+  it('round-trips with parseDdMmYyyy', () => {
+    const original = '15/04/2026';
+    const parsed = parseDdMmYyyy(original);
+    expect(parsed).not.toBeNull();
+    expect(formatDdMmYyyy(parsed!)).toBe(original);
+  });
+});
+
+describe('daysBetween', () => {
+  it('returns 0 for the same instant', () => {
+    const d = new Date(Date.UTC(2026, 0, 1));
+    expect(daysBetween(d, d)).toBe(0);
+  });
+  it('returns positive for a future target', () => {
+    const a = new Date(Date.UTC(2026, 0, 1));
+    const b = new Date(Date.UTC(2026, 0, 11));
+    expect(daysBetween(a, b)).toBe(10);
+  });
+  it('returns negative for a past target', () => {
+    const a = new Date(Date.UTC(2026, 0, 11));
+    const b = new Date(Date.UTC(2026, 0, 1));
+    expect(daysBetween(a, b)).toBe(-10);
+  });
+});
+
+describe('addYears', () => {
+  it('adds 10 years correctly (retention)', () => {
+    const d = new Date(Date.UTC(2026, 3, 15));
+    const d2 = addYears(d, 10);
+    expect(d2.getUTCFullYear()).toBe(2036);
+    expect(d2.getUTCMonth()).toBe(3);
+    expect(d2.getUTCDate()).toBe(15);
+  });
+});
+
+describe('addMonths', () => {
+  it('adds 6 months from April', () => {
+    const d = new Date(Date.UTC(2026, 3, 15));
+    const d2 = addMonths(d, 6);
+    expect(d2.getUTCMonth()).toBe(9); // October
+    expect(d2.getUTCDate()).toBe(15);
+  });
+  it('handles month-end clamp correctly (31 Jan + 1mo = 28 Feb)', () => {
+    const d = new Date(Date.UTC(2026, 0, 31));
+    const d2 = addMonths(d, 1);
+    expect(d2.getUTCMonth()).toBe(1); // February
+    expect(d2.getUTCDate()).toBe(28); // Feb 2026 has 28 days
+  });
+});
+
+describe('isShareholderUbo', () => {
+  function makeShareholder(percent: number): ShareholderRecord {
+    return {
+      id: 's1',
+      type: 'natural',
+      fullName: 'Test',
+      ownershipPercent: percent,
+      pepCheckStatus: 'clear',
+      sanctionsCheckStatus: 'clear',
+      adverseMediaCheckStatus: 'clear',
+    };
+  }
+  it('classifies 25% exactly as UBO (boundary)', () => {
+    expect(isShareholderUbo(makeShareholder(25))).toBe(true);
+  });
+  it('classifies 24.99% as non-UBO', () => {
+    expect(isShareholderUbo(makeShareholder(24.99))).toBe(false);
+  });
+  it('classifies 50% as UBO', () => {
+    expect(isShareholderUbo(makeShareholder(50))).toBe(true);
+  });
+  it('classifies 0% as non-UBO', () => {
+    expect(isShareholderUbo(makeShareholder(0))).toBe(false);
+  });
+});
+
+describe('extractUbos', () => {
+  it('returns only UBOs from a mixed list', () => {
+    const shareholders: ShareholderRecord[] = [
+      {
+        id: 'a',
+        type: 'natural',
+        fullName: 'Alice',
+        ownershipPercent: 60,
+        pepCheckStatus: 'clear',
+        sanctionsCheckStatus: 'clear',
+        adverseMediaCheckStatus: 'clear',
+      },
+      {
+        id: 'b',
+        type: 'natural',
+        fullName: 'Bob',
+        ownershipPercent: 20,
+        pepCheckStatus: 'clear',
+        sanctionsCheckStatus: 'clear',
+        adverseMediaCheckStatus: 'clear',
+      },
+      {
+        id: 'c',
+        type: 'natural',
+        fullName: 'Carol',
+        ownershipPercent: 20,
+        pepCheckStatus: 'clear',
+        sanctionsCheckStatus: 'clear',
+        adverseMediaCheckStatus: 'clear',
+      },
+    ];
+    const ubos = extractUbos(shareholders);
+    expect(ubos).toHaveLength(1);
+    expect(ubos[0]!.id).toBe('a');
+  });
+});
+
+describe('computeNextReviewDue', () => {
+  it('high-risk → 3 months', () => {
+    const base = new Date(Date.UTC(2026, 0, 15));
+    const next = computeNextReviewDue(base, 'high');
+    expect(next.getUTCMonth()).toBe(3); // April
+  });
+  it('medium → 6 months', () => {
+    const base = new Date(Date.UTC(2026, 0, 15));
+    const next = computeNextReviewDue(base, 'medium');
+    expect(next.getUTCMonth()).toBe(6); // July
+  });
+  it('low → 12 months', () => {
+    const base = new Date(Date.UTC(2026, 0, 15));
+    const next = computeNextReviewDue(base, 'low');
+    expect(next.getUTCFullYear()).toBe(2027);
+    expect(next.getUTCMonth()).toBe(0);
+  });
+});
+
+describe('computeRetentionUntil', () => {
+  it('createdAt + 10 years', () => {
+    const created = new Date(Date.UTC(2026, 3, 15));
+    const retention = computeRetentionUntil(created);
+    expect(retention.getUTCFullYear()).toBe(2036);
+  });
+});

--- a/tests/customerProfileValidator.test.ts
+++ b/tests/customerProfileValidator.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Tests for src/services/customerProfileValidator.ts.
+ */
+import { describe, expect, it } from 'vitest';
+import type {
+  CustomerProfileV2,
+  ManagerRecord,
+  ShareholderRecord,
+} from '../src/domain/customerProfile';
+import {
+  isExpired,
+  isInFuture,
+  isValidCountryCode,
+  isValidEmiratesId,
+  validateCustomerProfile,
+} from '../src/services/customerProfileValidator';
+
+const TODAY = new Date(Date.UTC(2026, 3, 15)); // 15 April 2026
+
+function makeValidProfile(): CustomerProfileV2 {
+  const manager: ManagerRecord = {
+    id: 'mgr-1',
+    fullName: 'Ahmed Al Falasi',
+    role: 'mlro',
+    dateOfBirth: '01/01/1980',
+    nationality: 'AE',
+    emiratesIdNumber: '784-1980-1234567-1',
+    emiratesIdExpiry: '01/01/2030',
+    passportNumber: 'A12345678',
+    passportCountry: 'AE',
+    passportExpiry: '01/01/2030',
+    appointmentDate: '01/01/2024',
+    isSanctionsAuthority: true,
+    isStrFilingAuthority: true,
+    pepCheckStatus: 'clear',
+    sanctionsCheckStatus: 'clear',
+    adverseMediaCheckStatus: 'clear',
+  };
+  const co: ManagerRecord = {
+    ...manager,
+    id: 'mgr-2',
+    role: 'co',
+    fullName: 'Fatima Al Mansoori',
+    emiratesIdNumber: '784-1985-7654321-2',
+  };
+  const shareholder: ShareholderRecord = {
+    id: 'sh-1',
+    type: 'natural',
+    fullName: 'Sheikh Holder',
+    ownershipPercent: 60,
+    dateOfBirth: '01/01/1970',
+    nationality: 'AE',
+    emiratesIdNumber: '784-1970-1111111-1',
+    emiratesIdExpiry: '01/01/2030',
+    uboVerifiedAt: '01/01/2026',
+    pepCheckStatus: 'clear',
+    sanctionsCheckStatus: 'clear',
+    adverseMediaCheckStatus: 'clear',
+    evidenceAttachments: [
+      {
+        blobKey: 'evidence/sh-1-eid.pdf',
+        filename: 'eid.pdf',
+        mimeType: 'application/pdf',
+        uploadedAt: '2026-01-01T00:00:00Z',
+        uploadedBy: 'mlro',
+        sha256: 'a'.repeat(64),
+      },
+    ],
+  };
+  return {
+    schemaVersion: 2,
+    id: 'cust-1',
+    legalName: 'MADISON JEWELLERY TRADING L.L.C',
+    customerType: 'legal',
+    country: 'AE',
+    jurisdiction: 'Dubai',
+    licenseNumber: 'DET-123456',
+    licenseIssuer: 'Dubai DET',
+    licenseIssueDate: '01/01/2024',
+    licenseExpiryDate: '01/01/2027',
+    licenseStatus: 'active',
+    businessModel: 'Wholesale jewellery trading to UAE retailers',
+    activity: 'Jewellery Trading',
+    sector: 'jewellery-retail',
+    expectedMonthlyVolumeAed: 500_000,
+    expectedTransactionCountPerMonth: 20,
+    riskRating: 'medium',
+    riskRatingAssignedAt: '01/01/2026',
+    riskRatingExpiresAt: '01/07/2026',
+    pepStatus: 'clear',
+    sanctionsStatus: 'clear',
+    sourceOfFundsStatus: 'verified',
+    sourceOfFundsEvidence: [
+      {
+        blobKey: 'evidence/sof.pdf',
+        filename: 'sof.pdf',
+        mimeType: 'application/pdf',
+        uploadedAt: '2026-01-01T00:00:00Z',
+        uploadedBy: 'mlro',
+        sha256: 'b'.repeat(64),
+      },
+    ],
+    sourceOfWealthStatus: 'not_applicable',
+    shareholders: [shareholder],
+    managers: [manager, co],
+    entityType: 'standalone',
+    createdAt: '2026-01-01T00:00:00Z',
+    nextReviewDueAt: '01/07/2026',
+    recordRetentionUntil: '01/01/2036',
+  };
+}
+
+describe('isValidEmiratesId', () => {
+  it('accepts valid format', () => {
+    expect(isValidEmiratesId('784-1980-1234567-1')).toBe(true);
+  });
+  it('rejects missing 784 prefix', () => {
+    expect(isValidEmiratesId('123-1980-1234567-1')).toBe(false);
+  });
+  it('rejects missing hyphens', () => {
+    expect(isValidEmiratesId('784198012345671')).toBe(false);
+  });
+  it('rejects wrong segment lengths', () => {
+    expect(isValidEmiratesId('784-19-1234567-1')).toBe(false);
+    expect(isValidEmiratesId('784-1980-123456-1')).toBe(false);
+    expect(isValidEmiratesId('784-1980-1234567-12')).toBe(false);
+  });
+  it('rejects undefined/null/empty', () => {
+    expect(isValidEmiratesId(undefined)).toBe(false);
+    expect(isValidEmiratesId(null)).toBe(false);
+    expect(isValidEmiratesId('')).toBe(false);
+  });
+});
+
+describe('isValidCountryCode', () => {
+  it.each(['AE', 'GB', 'US', 'FR'])('accepts %s', (code) => {
+    expect(isValidCountryCode(code)).toBe(true);
+  });
+  it('rejects lowercase', () => {
+    expect(isValidCountryCode('ae')).toBe(false);
+  });
+  it('rejects 3-letter alpha-3', () => {
+    expect(isValidCountryCode('ARE')).toBe(false);
+  });
+  it('rejects full country name', () => {
+    expect(isValidCountryCode('United Arab Emirates')).toBe(false);
+  });
+});
+
+describe('isExpired / isInFuture', () => {
+  it('detects an expired date', () => {
+    expect(isExpired('01/01/2025', TODAY)).toBe(true);
+    expect(isInFuture('01/01/2025', TODAY)).toBe(false);
+  });
+  it('detects a future date', () => {
+    expect(isInFuture('01/01/2027', TODAY)).toBe(true);
+    expect(isExpired('01/01/2027', TODAY)).toBe(false);
+  });
+  it('returns false for null inputs', () => {
+    expect(isExpired(null, TODAY)).toBe(false);
+    expect(isInFuture(undefined, TODAY)).toBe(false);
+  });
+});
+
+describe('validateCustomerProfile — valid profile', () => {
+  it('produces no blockers for a fully valid profile', () => {
+    const profile = makeValidProfile();
+    const report = validateCustomerProfile(profile, TODAY);
+    expect(report.ok).toBe(true);
+    expect(report.blockerCount).toBe(0);
+  });
+});
+
+describe('validateCustomerProfile — identity', () => {
+  it('blocks when id is missing', () => {
+    const profile = { ...makeValidProfile(), id: '' };
+    const report = validateCustomerProfile(profile, TODAY);
+    expect(report.findings.some((f) => f.path === 'id' && f.severity === 'blocker')).toBe(true);
+  });
+  it('blocks when legalName is missing', () => {
+    const profile = { ...makeValidProfile(), legalName: '' };
+    const report = validateCustomerProfile(profile, TODAY);
+    expect(report.findings.some((f) => f.path === 'legalName' && f.severity === 'blocker')).toBe(
+      true
+    );
+  });
+});
+
+describe('validateCustomerProfile — registration', () => {
+  it('blocks invalid country code', () => {
+    const profile = { ...makeValidProfile(), country: 'United Arab Emirates' };
+    const report = validateCustomerProfile(profile, TODAY);
+    expect(report.findings.some((f) => f.path === 'country')).toBe(true);
+  });
+  it('blocks invalid licenseIssueDate format', () => {
+    const profile = { ...makeValidProfile(), licenseIssueDate: '2024-01-01' };
+    const report = validateCustomerProfile(profile, TODAY);
+    expect(report.findings.some((f) => f.path === 'licenseIssueDate')).toBe(true);
+  });
+  it('blocks when licenseStatus is "active" but expiry is past', () => {
+    const profile = {
+      ...makeValidProfile(),
+      licenseExpiryDate: '01/01/2025',
+      licenseStatus: 'active' as const,
+    };
+    const report = validateCustomerProfile(profile, TODAY);
+    expect(report.findings.some((f) => f.path === 'licenseStatus')).toBe(true);
+  });
+  it('blocks when issue date is after expiry date', () => {
+    const profile = {
+      ...makeValidProfile(),
+      licenseIssueDate: '01/01/2028',
+      licenseExpiryDate: '01/01/2027',
+    };
+    const report = validateCustomerProfile(profile, TODAY);
+    expect(report.findings.some((f) => f.path === 'licenseExpiryDate')).toBe(true);
+  });
+});
+
+describe('validateCustomerProfile — shareholders', () => {
+  it('blocks when total ownership exceeds 100%', () => {
+    const profile = makeValidProfile();
+    const shareholders: ShareholderRecord[] = [
+      {
+        id: 'a',
+        type: 'natural',
+        fullName: 'A',
+        ownershipPercent: 60,
+        nationality: 'AE',
+        dateOfBirth: '01/01/1980',
+        emiratesIdNumber: '784-1980-1111111-1',
+        emiratesIdExpiry: '01/01/2030',
+        uboVerifiedAt: '01/01/2026',
+        pepCheckStatus: 'clear',
+        sanctionsCheckStatus: 'clear',
+        adverseMediaCheckStatus: 'clear',
+      },
+      {
+        id: 'b',
+        type: 'natural',
+        fullName: 'B',
+        ownershipPercent: 50,
+        nationality: 'AE',
+        dateOfBirth: '01/01/1985',
+        emiratesIdNumber: '784-1985-2222222-2',
+        emiratesIdExpiry: '01/01/2030',
+        uboVerifiedAt: '01/01/2026',
+        pepCheckStatus: 'clear',
+        sanctionsCheckStatus: 'clear',
+        adverseMediaCheckStatus: 'clear',
+      },
+    ];
+    const p = { ...profile, shareholders };
+    const report = validateCustomerProfile(p, TODAY);
+    expect(report.findings.some((f) => f.path === 'shareholders' && f.severity === 'blocker')).toBe(
+      true
+    );
+  });
+  it('blocks when a UBO has no verification date', () => {
+    const profile = makeValidProfile();
+    const bad: ShareholderRecord = {
+      ...profile.shareholders[0]!,
+      uboVerifiedAt: undefined,
+    };
+    const p = { ...profile, shareholders: [bad] };
+    const report = validateCustomerProfile(p, TODAY);
+    expect(report.findings.some((f) => f.path.includes('uboVerifiedAt'))).toBe(true);
+  });
+  it('blocks when a UAE-national shareholder has invalid EID', () => {
+    const profile = makeValidProfile();
+    const bad: ShareholderRecord = {
+      ...profile.shareholders[0]!,
+      emiratesIdNumber: 'not-an-eid',
+    };
+    const p = { ...profile, shareholders: [bad] };
+    const report = validateCustomerProfile(p, TODAY);
+    expect(report.findings.some((f) => f.path.includes('emiratesIdNumber'))).toBe(true);
+  });
+});
+
+describe('validateCustomerProfile — managers', () => {
+  it('warns when no MLRO is present', () => {
+    const profile = makeValidProfile();
+    // Keep only the CO — remove MLRO
+    const managersWithoutMlro = profile.managers.filter((m) => m.role !== 'mlro');
+    const p = { ...profile, managers: managersWithoutMlro };
+    const report = validateCustomerProfile(p, TODAY);
+    expect(
+      report.findings.some((f) => f.path === 'managers' && f.message.toLowerCase().includes('mlro'))
+    ).toBe(true);
+  });
+  it('blocks when a manager passport is expired', () => {
+    const profile = makeValidProfile();
+    const expiredManager: ManagerRecord = {
+      ...profile.managers[0]!,
+      passportExpiry: '01/01/2025',
+    };
+    const p = { ...profile, managers: [expiredManager, profile.managers[1]!] };
+    const report = validateCustomerProfile(p, TODAY);
+    expect(
+      report.findings.some((f) => f.path.includes('passportExpiry') && f.severity === 'blocker')
+    ).toBe(true);
+  });
+});
+
+describe('validateCustomerProfile — source of funds / wealth', () => {
+  it('blocks when SoF status is verified but no evidence attached', () => {
+    const profile = { ...makeValidProfile(), sourceOfFundsEvidence: [] };
+    const report = validateCustomerProfile(profile, TODAY);
+    expect(report.findings.some((f) => f.path === 'sourceOfFundsEvidence')).toBe(true);
+  });
+  it('warns when high-risk customer has SoW pending', () => {
+    const profile = {
+      ...makeValidProfile(),
+      riskRating: 'high' as const,
+      sourceOfWealthStatus: 'pending' as const,
+    };
+    const report = validateCustomerProfile(profile, TODAY);
+    expect(report.findings.some((f) => f.path === 'sourceOfWealthStatus')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Ships the **Customer Profile v2 foundation** — the complete KYC/CDD data model you specified (customer country/licence/expiry/business model/name + shareholders and managers with DOB/nationality/Emirates ID/expiry) as pure types, a structural+regulatory validator, and an expiry alerter. **87 new unit tests, all passing. Full suite 3,850 tests green.**

This PR is the foundation layer. The UI, Netlify CRUD endpoint, and Asana auto-alerter come in follow-up PRs on top of this — each standalone and mergeable.

## What's in the box

### `src/domain/customerProfile.ts` (~440 lines)

**Canonical type model** covering every field UAE DPMS MoE inspection requires:

- `CustomerProfileV2` — id, legalName, customerType, **country/jurisdiction**, **licenseNumber/licenseIssuer/licenseIssueDate/licenseExpiryDate/licenseStatus**, **businessModel**, activity, sector, expectedMonthlyVolumeAed, expectedTransactionCountPerMonth, riskRating, pepStatus, sanctionsStatus, sourceOfFunds/sourceOfWealth status + evidence, shareholders, managers, entityType, audit fields (createdAt, lastReviewedAt, nextReviewDueAt, recordRetentionUntil)
- `ShareholderRecord` — natural + legal type, **ownershipPercent (UBO at ≥25% per Cabinet Decision 109/2023)**, **dateOfBirth**, **nationality**, **emiratesIdNumber + emiratesIdExpiry**, passport + expiry, screening status, UBO-specific (uboVerifiedAt, uboReverificationDueAt), evidence attachments
- `ManagerRecord` — role-tagged (director / general-manager / authorised-signatory / mlro / co / board-member), **dateOfBirth**, **nationality**, **emiratesIdNumber + expiry**, **passportNumber/passportCountry/passportExpiry**, appointmentDate, authorityLimitAed, isSanctionsAuthority, isStrFilingAuthority, screening, evidence
- `AttachmentRef` — Netlify Blob key + SHA-256 for tamper detection, 10-year retention ready

**Regulatory constants (single source of truth):**
- `UBO_OWNERSHIP_THRESHOLD_PERCENT = 25` — Cabinet Decision 109/2023
- `UBO_REVERIFICATION_WORKING_DAYS = 15` — Cabinet Decision 109/2023
- `PERIODIC_REVIEW_MONTHS` — low: 12, medium: 6, high: 3 — Cabinet Res 134/2025 Art.19
- `RECORD_RETENTION_YEARS = 10` — FDL Art.24
- `EXPIRY_ALERT_WINDOWS_DAYS = [90, 60, 30, 7]`

**Pure helpers:**
- `parseDdMmYyyy` — strict (rejects `31/02/2026`, `29/02/2026`, ISO format; accepts leap-year `29/02/2024`)
- `formatDdMmYyyy`, `daysBetween`, `addYears`, `addMonths` (with month-end clamping)
- `isShareholderUbo`, `extractUbos`, `computeNextReviewDue`, `computeRetentionUntil`

### `src/services/customerProfileValidator.ts` (~460 lines)

Pure structural + regulatory validator. Returns a `ValidationReport` with `blocker` / `warning` / `info` findings per field, each anchored to a regulation. Rules:

- **Identity** — id/legalName required, customerType must be natural or legal
- **Registration** — ISO-3166 alpha-2 country, licence number + issuer required, strict dd/mm/yyyy dates, issueDate strictly before expiryDate, **licenseStatus "active" but expiry in the past → blocker**
- **Business** — businessModel min 10 chars, non-negative volume + count
- **Risk posture** — valid tier, strict dates
- **Source of funds / wealth** — verified status requires evidence, high-risk customer must have SoW verified
- **Shareholders** — total ownership ≤100% (blocker if exceeded), every natural person needs DOB/nationality, **UAE nationals need valid 784-YYYY-NNNNNNN-N Emirates ID**, non-UAE nationals need passport, UBO (≥25%) must have verification date + evidence, warning when no UBO is present
- **Managers** — required fields, **expired manager passport is a hard blocker**, warning when no MLRO or CO is designated per FDL Art.20-22

Helper exports: `isValidEmiratesId`, `isValidCountryCode`, `isExpired`, `isInFuture`.

### `src/services/customerExpiryAlerter.ts` (~310 lines)

Pure expiry scanner. `scanExpiries(profiles, asOf)` walks every customer and emits `ExpiryAlert`s bucketed by:

- **Severity:** `expired` (negative days) / `urgent` (≤7d) / `soon` (≤30d) / `upcoming` (≤90d)
- **Window:** tightest of [7, 30, 60, 90] days
- **Kind:** licence / customer-emirates-id / customer-passport / shareholder-emirates-id / shareholder-passport / manager-emirates-id / manager-passport / ubo-reverification / periodic-review / risk-rating-expiry / record-retention

Every alert carries a stable id, customerId, subjectId, subjectName, daysUntilExpiry (negative for expired), regulatory anchor, and a plain-English message ready for an Asana task body. Sorted ascending by `daysUntilExpiry` so the most urgent alerts appear first.

### `tests/customerProfile.test.ts` — 34 tests
Regulatory constants match their laws; `parseDdMmYyyy` strict cases (rejects 31/02, 29/02 non-leap, ISO, 2-digit year, text); `formatDdMmYyyy` round-trip; `daysBetween`; `addYears`/`addMonths` month-end clamp (31 Jan + 1mo = 28 Feb); `isShareholderUbo` 25% boundary (24.99 → no, 25 → yes, 50 → yes); `extractUbos`; `computeNextReviewDue` per tier; `computeRetentionUntil` 10yr arithmetic.

### `tests/customerProfileValidator.test.ts` — 29 tests
`isValidEmiratesId` accepts `784-1980-1234567-1`, rejects wrong prefix / missing hyphens / wrong segment lengths; `isValidCountryCode` accepts `AE` but rejects `ae`/`ARE`/full names; valid profile produces 0 blockers; identity / registration / licence-status ↔ expiry cross-check / issue < expiry cross-check; shareholders (>100% ownership, missing UBO verification, invalid EID on UAE national); managers (no MLRO warning, expired passport blocker); source of funds (verified without evidence blocker, high-risk SoW pending warning).

### `tests/customerExpiryAlerter.test.ts` — 24 tests
`classifyWindow` + `classifySeverity` bucket boundaries; no alerts when everything future; licence expiring in 60 days → `upcoming` severity / 60-day window; already-expired `severity=expired`; parameterised bucketing test (5/15/45/85 days); shareholder EID + passport + UBO re-verification alerts; manager passport alert; ascending sort order; per-severity counts; clean summary message.

## Quality gate (full pipeline, run locally on Node 22)

| Check | Result |
|---|---|
| `prettier --check 'src/**/*.{ts,tsx}'` | ✅ clean |
| `tsc --noEmit` | ✅ clean |
| `eslint src/ --ext .ts,.tsx` | ✅ clean |
| `vitest run` (full suite) | ✅ **241 files / 3,850 tests** |
| `vitest run tests/customerProfile*` | ✅ **87 new tests** |
| `validate:goaml -- --all` | ✅ all 4 fixtures valid |

## What this does NOT do (on purpose)

- No Netlify function yet — `/api/customer-profile` CRUD is Phase A.2
- No React UI yet — `CustomerProfileEditor`, `ShareholderList`, `ManagerList`, `AttachmentUpload` are Phase A.2
- No Asana auto-task emitter yet — consuming `scanExpiries()` output and writing tasks to the KYC/CDD Tracker sections (provisioned in PR #127) is Phase C
- Does **not** replace the existing `CustomerProfile` in `src/domain/customers.ts` — v1 stays in place as the minimal seed; v2 is the richer store that the orchestrator will upgrade to

## Regulatory citation (CLAUDE.md §8)

This change touches `src/domain/` and `src/services/`. Every type, constant, validator rule, and alerter heuristic cites its regulatory anchor:

- **FDL No.10/2025** Art.12-14 (CDD), Art.20-22 (CO + MLRO mandatory), Art.24 (10yr retention), Art.26-27 (STR filing per subject), Art.35 (TFS screening)
- **Cabinet Res 134/2025** Art.7-10 (CDD data per tier), Art.14 (EDD + PEP Board approval), Art.19 (internal review cadence)
- **Cabinet Decision 109/2023** (UBO 25% threshold, 15 working-day re-verification)
- **MoE Circular 08/AML/2021** (DPMS licence validity)
- **FATF** Rec 10 (CDD), Rec 11 (record-keeping), Rec 12 (PEP)

**No threshold, deadline, or decision pathway was changed.** `src/domain/constants.ts` untouched.

## Test plan

- [ ] CI runs `lint-and-test (20)` on this PR → green
- [ ] Merge
- [ ] Follow-up PR Phase A.2 wires the UI + endpoint
- [ ] Follow-up PR Phase C wires the Asana auto-task emitter

## Rollback

Fully reversible with `git revert`. All new code is additive — no existing functionality touched. The v1 `CustomerProfile` in `src/domain/customers.ts` is untouched and continues to serve its existing consumers.
