### PR TITLE
Phase D+E: tsconfig cleanup + entity-lumping dispatcher tripwire

### DIFF
--- a/src/services/asana/productionDispatchAdapter.ts
+++ b/src/services/asana/productionDispatchAdapter.ts
@@ -41,6 +41,7 @@
  */
 
 import { lintForTippingOff } from '../tippingOffLinter';
+import { lintTaskTitle } from './entityLumpingLinter';
 import type { ProjectEnvKey } from './asanaBrainTaskTemplate';
 import type { TemplateDispatchAdapter } from './orchestrator';
 // AsanaBrainTaskTemplate + BrainVerdictLike are referenced transitively
@@ -171,6 +172,22 @@ export function createProductionAsanaDispatchAdapter(
     const lint = lintForTippingOff(template.notes);
     if (!lint.clean && (lint.topSeverity === 'critical' || lint.topSeverity === 'high')) {
       const reason = `tipping_off_blocked:${lint.findings.map((f) => f.patternId).join(',')}`;
+      logDispatch({ projectGid, taskGid: null, skipped: reason });
+      return { skipped: reason };
+    }
+
+    // Entity-lumping tripwire — compliance rule: each legal entity
+    // must have its own dedicated task per FDL Art.12-14 / Art.24 /
+    // Cabinet Res 134/2025 Art.7-10. A task title that mentions 2+
+    // entities from COMPANY_REGISTRY (e.g. "GRAMALTIN AS / NAPLES LLC
+    // / ZOE FZE — review") breaks the per-entity audit trail, the
+    // four-eyes approver chain, and the SLA enforcer. Block at
+    // write time so the violation never reaches Asana.
+    const entityLint = lintTaskTitle(template.name);
+    if (entityLint.isLumped) {
+      const reason = `entity_lumping_blocked:${entityLint.matches
+        .map((m) => m.displayName)
+        .join('+')}`;
       logDispatch({ projectGid, taskGid: null, skipped: reason });
       return { skipped: reason };
     }

--- a/tests/productionDispatchAdapter.test.ts
+++ b/tests/productionDispatchAdapter.test.ts
@@ -11,44 +11,39 @@
  *   - Integrates with AsanaOrchestrator.dispatchWithTemplate
  *   - Idempotency: replays never call createTask twice
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi } from 'vitest';
 import {
   createProductionAsanaDispatchAdapter,
   __test__,
   type CreateTaskFn,
-} from "../src/services/asana/productionDispatchAdapter";
-import type { AsanaBrainTaskTemplate } from "../src/services/asana/asanaBrainTaskTemplate";
-import {
-  AsanaOrchestrator,
-  type BrainVerdictLike,
-} from "../src/services/asana/orchestrator";
+} from '../src/services/asana/productionDispatchAdapter';
+import type { AsanaBrainTaskTemplate } from '../src/services/asana/asanaBrainTaskTemplate';
+import { AsanaOrchestrator, type BrainVerdictLike } from '../src/services/asana/orchestrator';
 
 const { defaultEnvResolver } = __test__;
 
 function verdict(overrides: Partial<BrainVerdictLike> = {}): BrainVerdictLike {
   return {
-    id: "t1:e1:1",
-    tenantId: "t1",
-    verdict: "freeze",
+    id: 't1:e1:1',
+    tenantId: 't1',
+    verdict: 'freeze',
     confidence: 0.95,
-    recommendedAction: "Freeze",
+    recommendedAction: 'Freeze',
     requiresHumanReview: true,
-    at: "2026-04-14T12:00:00.000Z",
-    entityId: "e1",
-    entityName: "Opaque",
+    at: '2026-04-14T12:00:00.000Z',
+    entityId: 'e1',
+    entityName: 'Opaque',
     ...overrides,
   };
 }
 
-function template(
-  overrides: Partial<AsanaBrainTaskTemplate> = {}
-): AsanaBrainTaskTemplate {
+function template(overrides: Partial<AsanaBrainTaskTemplate> = {}): AsanaBrainTaskTemplate {
   return {
-    name: "🚨 FREEZE · e1 · Freeze",
-    notes: "# Brain Decision\n\n- Verdict: freeze\n- Clean regulatory body.\n",
-    projectEnvKey: "ASANA_PROJECT_MLRO_CENTRAL",
-    tags: ["brain/verdict/freeze"],
-    routingReason: "verdict=freeze → MLRO Central",
+    name: '🚨 FREEZE · e1 · Freeze',
+    notes: '# Brain Decision\n\n- Verdict: freeze\n- Clean regulatory body.\n',
+    projectEnvKey: 'ASANA_PROJECT_MLRO_CENTRAL',
+    tags: ['brain/verdict/freeze'],
+    routingReason: 'verdict=freeze → MLRO Central',
     ...overrides,
   };
 }
@@ -57,21 +52,21 @@ function template(
 // defaultEnvResolver
 // ---------------------------------------------------------------------------
 
-describe("defaultEnvResolver", () => {
-  it("returns undefined for unset env var", () => {
+describe('defaultEnvResolver', () => {
+  it('returns undefined for unset env var', () => {
     delete process.env.ASANA_PROJECT_MLRO_CENTRAL;
-    expect(defaultEnvResolver("ASANA_PROJECT_MLRO_CENTRAL")).toBeUndefined();
+    expect(defaultEnvResolver('ASANA_PROJECT_MLRO_CENTRAL')).toBeUndefined();
   });
 
-  it("returns the trimmed value for a set env var", () => {
-    process.env.ASANA_PROJECT_MLRO_CENTRAL = "  1234567890  ";
-    expect(defaultEnvResolver("ASANA_PROJECT_MLRO_CENTRAL")).toBe("1234567890");
+  it('returns the trimmed value for a set env var', () => {
+    process.env.ASANA_PROJECT_MLRO_CENTRAL = '  1234567890  ';
+    expect(defaultEnvResolver('ASANA_PROJECT_MLRO_CENTRAL')).toBe('1234567890');
     delete process.env.ASANA_PROJECT_MLRO_CENTRAL;
   });
 
-  it("returns undefined for empty-string env var", () => {
-    process.env.ASANA_PROJECT_MLRO_CENTRAL = "   ";
-    expect(defaultEnvResolver("ASANA_PROJECT_MLRO_CENTRAL")).toBeUndefined();
+  it('returns undefined for empty-string env var', () => {
+    process.env.ASANA_PROJECT_MLRO_CENTRAL = '   ';
+    expect(defaultEnvResolver('ASANA_PROJECT_MLRO_CENTRAL')).toBeUndefined();
     delete process.env.ASANA_PROJECT_MLRO_CENTRAL;
   });
 });
@@ -80,39 +75,39 @@ describe("defaultEnvResolver", () => {
 // Happy path
 // ---------------------------------------------------------------------------
 
-describe("createProductionAsanaDispatchAdapter — happy path", () => {
-  it("creates a task and returns the gid", async () => {
-    const createTask = vi.fn(async () => ({ gid: "task-abc123" }));
+describe('createProductionAsanaDispatchAdapter — happy path', () => {
+  it('creates a task and returns the gid', async () => {
+    const createTask = vi.fn(async () => ({ gid: 'task-abc123' }));
     const adapter = createProductionAsanaDispatchAdapter({
       createTask,
-      projectEnvResolver: () => "proj-mlro-central-gid",
+      projectEnvResolver: () => 'proj-mlro-central-gid',
     });
     const result = await adapter({ verdict: verdict(), template: template() });
-    expect(result.taskGid).toBe("task-abc123");
+    expect(result.taskGid).toBe('task-abc123');
     expect(result.skipped).toBeUndefined();
     expect(createTask).toHaveBeenCalledTimes(1);
     const call = createTask.mock.calls[0][0];
     expect(call.name).toMatch(/FREEZE/);
     expect(call.notes).toMatch(/Brain Decision/);
-    expect(call.projects).toEqual(["proj-mlro-central-gid"]);
-    expect(call.tags).toEqual(["brain/verdict/freeze"]);
+    expect(call.projects).toEqual(['proj-mlro-central-gid']);
+    expect(call.tags).toEqual(['brain/verdict/freeze']);
   });
 
-  it("fires onDispatch with the full outcome", async () => {
+  it('fires onDispatch with the full outcome', async () => {
     const onDispatch = vi.fn();
     const adapter = createProductionAsanaDispatchAdapter({
-      createTask: async () => ({ gid: "task-xyz" }),
-      projectEnvResolver: () => "proj-gid",
+      createTask: async () => ({ gid: 'task-xyz' }),
+      projectEnvResolver: () => 'proj-gid',
       onDispatch,
     });
     await adapter({ verdict: verdict(), template: template() });
     expect(onDispatch).toHaveBeenCalledTimes(1);
     const log = onDispatch.mock.calls[0][0];
-    expect(log.verdictId).toBe("t1:e1:1");
-    expect(log.tenantId).toBe("t1");
-    expect(log.projectEnvKey).toBe("ASANA_PROJECT_MLRO_CENTRAL");
-    expect(log.projectGid).toBe("proj-gid");
-    expect(log.taskGid).toBe("task-xyz");
+    expect(log.verdictId).toBe('t1:e1:1');
+    expect(log.tenantId).toBe('t1');
+    expect(log.projectEnvKey).toBe('ASANA_PROJECT_MLRO_CENTRAL');
+    expect(log.projectGid).toBe('proj-gid');
+    expect(log.taskGid).toBe('task-xyz');
     expect(log.skipped).toBeNull();
   });
 });
@@ -121,41 +116,83 @@ describe("createProductionAsanaDispatchAdapter — happy path", () => {
 // Skip paths
 // ---------------------------------------------------------------------------
 
-describe("createProductionAsanaDispatchAdapter — skip paths", () => {
-  it("skips with project_env_unset when resolver returns undefined", async () => {
+describe('createProductionAsanaDispatchAdapter — skip paths', () => {
+  it('skips with project_env_unset when resolver returns undefined', async () => {
     const createTask = vi.fn();
     const adapter = createProductionAsanaDispatchAdapter({
       createTask: createTask as unknown as CreateTaskFn,
       projectEnvResolver: () => undefined,
     });
     const result = await adapter({ verdict: verdict(), template: template() });
-    expect(result.skipped).toBe("project_env_unset:ASANA_PROJECT_MLRO_CENTRAL");
+    expect(result.skipped).toBe('project_env_unset:ASANA_PROJECT_MLRO_CENTRAL');
     expect(result.taskGid).toBeUndefined();
     // Critical invariant: createTask was NEVER called on a missing env var.
     expect(createTask).not.toHaveBeenCalled();
   });
 
-  it("skips with tipping_off_blocked when notes trip the linter", async () => {
+  it('skips with tipping_off_blocked when notes trip the linter', async () => {
     const createTask = vi.fn();
     const adapter = createProductionAsanaDispatchAdapter({
       createTask: createTask as unknown as CreateTaskFn,
-      projectEnvResolver: () => "proj-gid",
+      projectEnvResolver: () => 'proj-gid',
     });
     const badTemplate = template({
-      notes: "We filed an STR about you last week.",
+      notes: 'We filed an STR about you last week.',
     });
     const result = await adapter({ verdict: verdict(), template: badTemplate });
     expect(result.skipped).toMatch(/tipping_off_blocked/);
     expect(createTask).not.toHaveBeenCalled();
   });
 
-  it("skips with createTask_error when createTask throws", async () => {
+  it('skips with entity_lumping_blocked when the title lumps 2+ entities', async () => {
+    // Compliance tripwire: per-entity rule from FDL Art.12-14 /
+    // Cabinet Res 134/2025 Art.7-10. A task title that names multiple
+    // entities from COMPANY_REGISTRY must be rejected at dispatch
+    // time so the per-entity audit trail is preserved.
+    const createTask = vi.fn();
+    const adapter = createProductionAsanaDispatchAdapter({
+      createTask: createTask as unknown as CreateTaskFn,
+      projectEnvResolver: () => 'proj-gid',
+    });
+    const lumpedTemplate = template({
+      name: 'GRAMALTIN AS / NAPLES LLC / ZOE FZE — CDD Outstanding Files Review',
+    });
+    const result = await adapter({
+      verdict: verdict(),
+      template: lumpedTemplate,
+    });
+    expect(result.skipped).toMatch(/entity_lumping_blocked/);
+    expect(result.skipped).toMatch(/GRAMALTIN AS/);
+    expect(result.skipped).toMatch(/NAPLES LLC/);
+    expect(result.skipped).toMatch(/ZOE FZE/);
+    expect(createTask).not.toHaveBeenCalled();
+  });
+
+  it('permits a clean single-entity task title through the tripwire', async () => {
+    const createTask = vi.fn(async () => ({ gid: 'task-clean' }));
+    const adapter = createProductionAsanaDispatchAdapter({
+      createTask,
+      projectEnvResolver: () => 'proj-gid',
+    });
+    const cleanTemplate = template({
+      name: 'NAPLES LLC — CDD Outstanding Files Review',
+    });
+    const result = await adapter({
+      verdict: verdict(),
+      template: cleanTemplate,
+    });
+    expect(result.taskGid).toBe('task-clean');
+    expect(result.skipped).toBeUndefined();
+    expect(createTask).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips with createTask_error when createTask throws', async () => {
     const createTask = vi.fn(async () => {
-      throw new Error("asana 429");
+      throw new Error('asana 429');
     });
     const adapter = createProductionAsanaDispatchAdapter({
       createTask,
-      projectEnvResolver: () => "proj-gid",
+      projectEnvResolver: () => 'proj-gid',
     });
     const result = await adapter({ verdict: verdict(), template: template() });
     expect(result.skipped).toMatch(/createTask_error:asana 429/);
@@ -163,16 +200,14 @@ describe("createProductionAsanaDispatchAdapter — skip paths", () => {
     expect(createTask).toHaveBeenCalledTimes(1);
   });
 
-  it("never throws — all errors become skipped results", async () => {
+  it('never throws — all errors become skipped results', async () => {
     const adapter = createProductionAsanaDispatchAdapter({
       createTask: async () => {
         throw { boom: true } as unknown as Error;
       },
-      projectEnvResolver: () => "proj-gid",
+      projectEnvResolver: () => 'proj-gid',
     });
-    await expect(
-      adapter({ verdict: verdict(), template: template() })
-    ).resolves.toBeDefined();
+    await expect(adapter({ verdict: verdict(), template: template() })).resolves.toBeDefined();
   });
 });
 
@@ -180,12 +215,12 @@ describe("createProductionAsanaDispatchAdapter — skip paths", () => {
 // Integration with AsanaOrchestrator.dispatchWithTemplate
 // ---------------------------------------------------------------------------
 
-describe("AsanaOrchestrator.dispatchWithTemplate + production adapter", () => {
-  it("creates exactly one task, idempotent on replay", async () => {
-    const createTask = vi.fn(async () => ({ gid: "task-one" }));
+describe('AsanaOrchestrator.dispatchWithTemplate + production adapter', () => {
+  it('creates exactly one task, idempotent on replay', async () => {
+    const createTask = vi.fn(async () => ({ gid: 'task-one' }));
     const adapter = createProductionAsanaDispatchAdapter({
       createTask,
-      projectEnvResolver: () => "proj-gid",
+      projectEnvResolver: () => 'proj-gid',
     });
     const orchestrator = new AsanaOrchestrator({
       templateDispatchAdapter: adapter,
@@ -193,50 +228,44 @@ describe("AsanaOrchestrator.dispatchWithTemplate + production adapter", () => {
 
     const first = await orchestrator.dispatchWithTemplate(verdict(), template());
     expect(first.created).toBe(true);
-    expect(first.taskGid).toBe("task-one");
+    expect(first.taskGid).toBe('task-one');
     expect(createTask).toHaveBeenCalledTimes(1);
 
     const second = await orchestrator.dispatchWithTemplate(verdict(), template());
     expect(second.created).toBe(false);
-    expect(second.taskGid).toBe("task-one");
+    expect(second.taskGid).toBe('task-one');
     // Critical: createTask was NOT called a second time.
     expect(createTask).toHaveBeenCalledTimes(1);
   });
 
-  it("different verdicts create different tasks", async () => {
+  it('different verdicts create different tasks', async () => {
     let counter = 0;
     const createTask = vi.fn(async () => ({ gid: `task-${++counter}` }));
     const adapter = createProductionAsanaDispatchAdapter({
       createTask,
-      projectEnvResolver: () => "proj-gid",
+      projectEnvResolver: () => 'proj-gid',
     });
     const orchestrator = new AsanaOrchestrator({
       templateDispatchAdapter: adapter,
     });
 
-    const a = await orchestrator.dispatchWithTemplate(
-      verdict({ id: "t1:e1:1" }),
-      template()
-    );
-    const b = await orchestrator.dispatchWithTemplate(
-      verdict({ id: "t1:e2:2" }),
-      template()
-    );
-    expect(a.taskGid).toBe("task-1");
-    expect(b.taskGid).toBe("task-2");
+    const a = await orchestrator.dispatchWithTemplate(verdict({ id: 't1:e1:1' }), template());
+    const b = await orchestrator.dispatchWithTemplate(verdict({ id: 't1:e2:2' }), template());
+    expect(a.taskGid).toBe('task-1');
+    expect(b.taskGid).toBe('task-2');
     expect(createTask).toHaveBeenCalledTimes(2);
   });
 
-  it("orchestrator caches skip-free results but NOT skip results", async () => {
+  it('orchestrator caches skip-free results but NOT skip results', async () => {
     let call = 0;
     const createTask = vi.fn(async () => {
       call += 1;
-      if (call === 1) throw new Error("transient");
-      return { gid: "task-recovered" };
+      if (call === 1) throw new Error('transient');
+      return { gid: 'task-recovered' };
     });
     const adapter = createProductionAsanaDispatchAdapter({
       createTask,
-      projectEnvResolver: () => "proj-gid",
+      projectEnvResolver: () => 'proj-gid',
     });
     const orchestrator = new AsanaOrchestrator({
       templateDispatchAdapter: adapter,
@@ -249,28 +278,22 @@ describe("AsanaOrchestrator.dispatchWithTemplate + production adapter", () => {
     // Second call can still succeed because skip results are NOT cached.
     const second = await orchestrator.dispatchWithTemplate(verdict(), template());
     expect(second.created).toBe(true);
-    expect(second.taskGid).toBe("task-recovered");
+    expect(second.taskGid).toBe('task-recovered');
   });
 
-  it("setTemplateDispatchAdapter swaps behaviour at runtime", async () => {
+  it('setTemplateDispatchAdapter swaps behaviour at runtime', async () => {
     const orchestrator = new AsanaOrchestrator();
     // Default adapter should skip with no_template_adapter_configured.
-    const first = await orchestrator.dispatchWithTemplate(
-      verdict(),
-      template()
-    );
-    expect(first.skippedReason).toBe("no_template_adapter_configured");
+    const first = await orchestrator.dispatchWithTemplate(verdict(), template());
+    expect(first.skippedReason).toBe('no_template_adapter_configured');
 
     let called = false;
     orchestrator.setTemplateDispatchAdapter(async () => {
       called = true;
-      return { taskGid: "runtime-gid" };
+      return { taskGid: 'runtime-gid' };
     });
-    const second = await orchestrator.dispatchWithTemplate(
-      verdict({ id: "t1:e1:2" }),
-      template()
-    );
+    const second = await orchestrator.dispatchWithTemplate(verdict({ id: 't1:e1:2' }), template());
     expect(called).toBe(true);
-    expect(second.taskGid).toBe("runtime-gid");
+    expect(second.taskGid).toBe('runtime-gid');
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,9 +13,8 @@
     "isolatedModules": true,
     "noEmit": true,
     "allowImportingTsExtensions": true,
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],


### PR DESCRIPTION
## Summary

Phase D + E combined — small cleanup (tsconfig baseUrl deprecation) + important compliance wiring (entity-lumping tripwire into the dispatcher write path).

## What changed

### Phase D — `tsconfig.json`
- Removed deprecated `baseUrl`, updated `paths` to `"./src/*"` so TS 5+ resolves them relative to the tsconfig location
- `tsc --noEmit` now runs with **zero warnings**

### Phase E — entity-lumping tripwire in `productionDispatchAdapter.ts`
- `createProductionAsanaDispatchAdapter` now calls `lintTaskTitle(template.name)` after the tipping-off linter and before `createTask()`
- If lumped → skipped with `entity_lumping_blocked:<entity>+<entity>+...` and `createTask` is **never** called
- Closes the gap from PR #128: the linter existed (pure + scanner endpoint) but wasn't wired into the write path

### Tests (tests/productionDispatchAdapter.test.ts — 15 total, +2 new)
1. `skips with entity_lumping_blocked when the title lumps 2+ entities` — uses the exact 3-entity failure from the operator screenshot
2. `permits a clean single-entity task title through the tripwire`

## Quality gate
- prettier ✅ clean
- tsc ✅ **clean (no more deprecation warning)**
- eslint ✅ clean
- vitest run ✅ **241 files / 3,852 tests**

## Regulatory citation
FDL Art.12-14 / Art.24, Cabinet Res 134/2025 Art.7-10, Cabinet Decision 109/2023. No threshold or decision pathway changed — pure enforcement wiring.
