### PR TITLE
Phase A.2: Customer Profile CRUD endpoint (POST /api/customer-profile)

### DIFF
--- a/netlify/functions/customer-profile.mts
+++ b/netlify/functions/customer-profile.mts
@@ -1,0 +1,410 @@
+/**
+ * Customer Profile CRUD endpoint — browser-facing + agent-facing
+ * CRUD over CustomerProfileV2 records, backed by Netlify Blobs.
+ *
+ * Routes (all under POST /api/customer-profile with an { action } field):
+ *   - action: 'create'  → create a new profile
+ *   - action: 'get'     → fetch by id
+ *   - action: 'list'    → list all profiles
+ *   - action: 'update'  → partial patch by id
+ *   - action: 'delete'  → hard delete by id (audit-logged)
+ *
+ * Why POST for everything:
+ *   Netlify functions are routed by path, and the existing
+ *   middleware chain (auth + rate limit) is POST-first. Using a
+ *   single POST endpoint with an `action` discriminator keeps the
+ *   auth/rate-limit plumbing consistent with every other brain
+ *   endpoint in this repo.
+ *
+ * Every write path runs the pure `validateCustomerProfile`
+ * validator before touching the blob store. If the validator
+ * reports blockers, the write is rejected with 422 + the full
+ * finding list so the UI can render inline errors.
+ *
+ * Persistence: Netlify Blobs store "customer-profiles", keyed by
+ * `profile/${id}.json`. The store is global per-site (per-tenant
+ * partitioning is enforced at the auth layer — the brain token
+ * carries a tenant id).
+ *
+ * Security:
+ *   POST + OPTIONS only
+ *   Bearer HAWKEYE_BRAIN_TOKEN required (via authenticate())
+ *   Rate limited 30 / 15 min per IP (read-heavy on the list action)
+ *
+ * Regulatory basis:
+ *   FDL No.10/2025 Art.12-14 (CDD per customer)
+ *   FDL No.10/2025 Art.24    (10yr retention — records are never
+ *                              hard-deleted; `delete` moves to a
+ *                              tombstone key with the same TTL)
+ *   FDL No.10/2025 Art.20-22 (CO visibility into the customer register)
+ *   Cabinet Res 134/2025 Art.7-10 (CDD data per tier)
+ *   Cabinet Res 134/2025 Art.19   (internal review)
+ *   Cabinet Decision 109/2023     (UBO register)
+ */
+
+import type { Config, Context } from '@netlify/functions';
+import { getStore } from '@netlify/blobs';
+import { checkRateLimit } from './middleware/rate-limit.mts';
+import { authenticate } from './middleware/auth.mts';
+import type { CustomerProfileV2 } from '../../src/domain/customerProfile';
+import { validateCustomerProfile } from '../../src/services/customerProfileValidator';
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin':
+    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://hawkeye-sterling-v2.netlify.app',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+  'Access-Control-Max-Age': '600',
+  Vary: 'Origin',
+} as const;
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return Response.json(body, {
+    ...init,
+    headers: { ...CORS_HEADERS, ...(init.headers ?? {}) },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Request validation
+// ---------------------------------------------------------------------------
+
+type Action = 'create' | 'get' | 'list' | 'update' | 'delete';
+
+interface BaseRequest {
+  action: Action;
+}
+interface CreateRequest extends BaseRequest {
+  action: 'create';
+  profile: CustomerProfileV2;
+}
+interface GetRequest extends BaseRequest {
+  action: 'get';
+  id: string;
+}
+interface ListRequest extends BaseRequest {
+  action: 'list';
+}
+interface UpdateRequest extends BaseRequest {
+  action: 'update';
+  id: string;
+  patch: Partial<CustomerProfileV2>;
+}
+interface DeleteRequest extends BaseRequest {
+  action: 'delete';
+  id: string;
+  reason: string;
+}
+
+type ProfileRequest = CreateRequest | GetRequest | ListRequest | UpdateRequest | DeleteRequest;
+
+function validateRequest(
+  raw: unknown
+): { ok: true; req: ProfileRequest } | { ok: false; error: string } {
+  if (!raw || typeof raw !== 'object') return { ok: false, error: 'body must be an object' };
+  const r = raw as Record<string, unknown>;
+  const action = r.action;
+  if (typeof action !== 'string') return { ok: false, error: 'action must be a string' };
+  if (!['create', 'get', 'list', 'update', 'delete'].includes(action)) {
+    return { ok: false, error: `unknown action: ${action}` };
+  }
+  if (action === 'create') {
+    if (!r.profile || typeof r.profile !== 'object') {
+      return { ok: false, error: 'create requires a profile object' };
+    }
+    return { ok: true, req: { action: 'create', profile: r.profile as CustomerProfileV2 } };
+  }
+  if (action === 'get') {
+    if (typeof r.id !== 'string' || r.id.length === 0) {
+      return { ok: false, error: 'get requires id string' };
+    }
+    return { ok: true, req: { action: 'get', id: r.id } };
+  }
+  if (action === 'list') {
+    return { ok: true, req: { action: 'list' } };
+  }
+  if (action === 'update') {
+    if (typeof r.id !== 'string' || r.id.length === 0) {
+      return { ok: false, error: 'update requires id string' };
+    }
+    if (!r.patch || typeof r.patch !== 'object') {
+      return { ok: false, error: 'update requires a patch object' };
+    }
+    return {
+      ok: true,
+      req: {
+        action: 'update',
+        id: r.id,
+        patch: r.patch as Partial<CustomerProfileV2>,
+      },
+    };
+  }
+  // delete
+  if (typeof r.id !== 'string' || r.id.length === 0) {
+    return { ok: false, error: 'delete requires id string' };
+  }
+  if (typeof r.reason !== 'string' || r.reason.length < 5) {
+    return { ok: false, error: 'delete requires a reason (≥5 chars) for the audit log' };
+  }
+  return { ok: true, req: { action: 'delete', id: r.id, reason: r.reason } };
+}
+
+// ---------------------------------------------------------------------------
+// Blob-store helpers (injectable for tests via __test__)
+// ---------------------------------------------------------------------------
+
+interface ProfileStore {
+  list(): Promise<readonly string[]>;
+  get(id: string): Promise<CustomerProfileV2 | null>;
+  set(id: string, profile: CustomerProfileV2): Promise<void>;
+  tombstone(id: string, payload: { reason: string; tombstonedAt: string }): Promise<void>;
+}
+
+function makeNetlifyBlobStore(): ProfileStore {
+  const store = getStore('customer-profiles');
+  const tombstones = getStore('customer-profiles-tombstones');
+  return {
+    async list() {
+      // Netlify Blobs exposes a list() method that yields keys under
+      // a prefix. We scope by "profile/".
+      const res = await store.list({ prefix: 'profile/' });
+      return res.blobs.map((b) => b.key);
+    },
+    async get(id: string) {
+      const raw = (await store.get(`profile/${id}.json`, {
+        type: 'json',
+      })) as CustomerProfileV2 | null;
+      return raw ?? null;
+    },
+    async set(id: string, profile: CustomerProfileV2) {
+      await store.setJSON(`profile/${id}.json`, profile);
+    },
+    async tombstone(id, payload) {
+      // Move the profile body out of the live store and into the
+      // tombstone store. FDL Art.24 — 10 year retention means we
+      // do NOT hard delete.
+      const existing = await store.get(`profile/${id}.json`, { type: 'json' });
+      if (existing) {
+        await tombstones.setJSON(`tombstone/${id}/${Date.now()}.json`, {
+          profile: existing,
+          ...payload,
+        });
+      }
+      await store.delete(`profile/${id}.json`);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pure business logic (testable, store is injected)
+// ---------------------------------------------------------------------------
+
+interface HandlerDeps {
+  store: ProfileStore;
+  nowIso: string;
+  userId: string;
+}
+
+export async function handleCreate(
+  req: CreateRequest,
+  deps: HandlerDeps
+): Promise<{ status: number; body: unknown }> {
+  // Force the schema version + createdAt on create — caller cannot
+  // forge these.
+  const profile: CustomerProfileV2 = {
+    ...req.profile,
+    schemaVersion: 2,
+    createdAt: deps.nowIso,
+  };
+  const report = validateCustomerProfile(profile);
+  if (!report.ok) {
+    return {
+      status: 422,
+      body: { ok: false, error: 'validation_failed', report },
+    };
+  }
+  // Reject if id already exists — create is not an upsert.
+  const existing = await deps.store.get(profile.id);
+  if (existing) {
+    return {
+      status: 409,
+      body: {
+        ok: false,
+        error: 'id_already_exists',
+        id: profile.id,
+        hint: 'use action="update" to modify an existing profile',
+      },
+    };
+  }
+  await deps.store.set(profile.id, profile);
+  return { status: 200, body: { ok: true, profile, warnings: report.warningCount } };
+}
+
+export async function handleGet(
+  req: GetRequest,
+  deps: HandlerDeps
+): Promise<{ status: number; body: unknown }> {
+  const profile = await deps.store.get(req.id);
+  if (!profile) return { status: 404, body: { ok: false, error: 'not_found', id: req.id } };
+  return { status: 200, body: { ok: true, profile } };
+}
+
+export async function handleList(
+  _req: ListRequest,
+  deps: HandlerDeps
+): Promise<{ status: number; body: unknown }> {
+  const keys = await deps.store.list();
+  const ids = keys
+    .map((k) => {
+      // profile/<id>.json → <id>
+      const match = /^profile\/(.+)\.json$/.exec(k);
+      return match?.[1] ?? null;
+    })
+    .filter((id): id is string => id !== null);
+  // For list, return only id + legalName + riskRating summary (cheap
+  // payload for the list view; UI fetches full profile on row click).
+  const summaries: Array<{
+    id: string;
+    legalName: string;
+    riskRating: string;
+    licenseExpiryDate: string;
+    country: string;
+  }> = [];
+  for (const id of ids) {
+    const p = await deps.store.get(id);
+    if (p) {
+      summaries.push({
+        id: p.id,
+        legalName: p.legalName,
+        riskRating: p.riskRating,
+        licenseExpiryDate: p.licenseExpiryDate,
+        country: p.country,
+      });
+    }
+  }
+  return { status: 200, body: { ok: true, count: summaries.length, profiles: summaries } };
+}
+
+export async function handleUpdate(
+  req: UpdateRequest,
+  deps: HandlerDeps
+): Promise<{ status: number; body: unknown }> {
+  const existing = await deps.store.get(req.id);
+  if (!existing) return { status: 404, body: { ok: false, error: 'not_found', id: req.id } };
+
+  // Merge the patch, but ALWAYS preserve id + createdAt +
+  // schemaVersion (these are write-once).
+  const merged: CustomerProfileV2 = {
+    ...existing,
+    ...req.patch,
+    id: existing.id,
+    schemaVersion: 2,
+    createdAt: existing.createdAt,
+    lastReviewedAt: deps.nowIso,
+    lastReviewerUserId: deps.userId,
+  };
+  const report = validateCustomerProfile(merged);
+  if (!report.ok) {
+    return {
+      status: 422,
+      body: { ok: false, error: 'validation_failed', report },
+    };
+  }
+  await deps.store.set(merged.id, merged);
+  return { status: 200, body: { ok: true, profile: merged, warnings: report.warningCount } };
+}
+
+export async function handleDelete(
+  req: DeleteRequest,
+  deps: HandlerDeps
+): Promise<{ status: number; body: unknown }> {
+  const existing = await deps.store.get(req.id);
+  if (!existing) return { status: 404, body: { ok: false, error: 'not_found', id: req.id } };
+  await deps.store.tombstone(req.id, {
+    reason: req.reason,
+    tombstonedAt: deps.nowIso,
+  });
+  return { status: 200, body: { ok: true, tombstoned: req.id, reason: req.reason } };
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export default async (req: Request, context: Context): Promise<Response> => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+  }
+  if (req.method !== 'POST') {
+    return jsonResponse({ error: 'Method not allowed' }, { status: 405 });
+  }
+
+  const rl = await checkRateLimit(req, {
+    max: 30,
+    clientIp: context.ip,
+    namespace: 'customer-profile',
+  });
+  if (rl) return rl;
+
+  const auth = authenticate(req);
+  if (!auth.ok) return auth.response!;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return jsonResponse({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const v = validateRequest(body);
+  if (!v.ok) return jsonResponse({ error: v.error }, { status: 400 });
+
+  const deps: HandlerDeps = {
+    store: makeNetlifyBlobStore(),
+    nowIso: new Date().toISOString(),
+    userId: auth.userId ?? 'unknown',
+  };
+
+  let result;
+  try {
+    switch (v.req.action) {
+      case 'create':
+        result = await handleCreate(v.req, deps);
+        break;
+      case 'get':
+        result = await handleGet(v.req, deps);
+        break;
+      case 'list':
+        result = await handleList(v.req, deps);
+        break;
+      case 'update':
+        result = await handleUpdate(v.req, deps);
+        break;
+      case 'delete':
+        result = await handleDelete(v.req, deps);
+        break;
+    }
+  } catch (err) {
+    return jsonResponse(
+      {
+        ok: false,
+        error: 'handler_error',
+        reason: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 }
+    );
+  }
+
+  return jsonResponse(result.body, { status: result.status });
+};
+
+export const config: Config = {
+  path: '/api/customer-profile',
+  method: ['POST', 'OPTIONS'],
+};
+
+// Exports for unit tests.
+export const __test__ = {
+  validateRequest,
+};
+export type { ProfileStore, HandlerDeps };

--- a/tests/customerProfileCrudHandlers.test.ts
+++ b/tests/customerProfileCrudHandlers.test.ts
@@ -1,0 +1,464 @@
+/**
+ * Tests for the pure handler functions in
+ * netlify/functions/customer-profile.mts. The handlers take an
+ * injected ProfileStore so we never hit Netlify Blobs in tests.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { CustomerProfileV2 } from '../src/domain/customerProfile';
+import {
+  __test__,
+  handleCreate,
+  handleDelete,
+  handleGet,
+  handleList,
+  handleUpdate,
+  type HandlerDeps,
+  type ProfileStore,
+} from '../netlify/functions/customer-profile.mts';
+
+// ---------------------------------------------------------------------------
+// In-memory store for tests
+// ---------------------------------------------------------------------------
+
+function makeMemoryStore(): ProfileStore & {
+  readonly state: Map<string, CustomerProfileV2>;
+  readonly tombstones: Array<{ id: string; payload: { reason: string; tombstonedAt: string } }>;
+} {
+  const state = new Map<string, CustomerProfileV2>();
+  const tombstones: Array<{
+    id: string;
+    payload: { reason: string; tombstonedAt: string };
+  }> = [];
+  return {
+    state,
+    tombstones,
+    async list() {
+      return Array.from(state.keys()).map((id) => `profile/${id}.json`);
+    },
+    async get(id: string) {
+      return state.get(id) ?? null;
+    },
+    async set(id: string, profile: CustomerProfileV2) {
+      state.set(id, profile);
+    },
+    async tombstone(id, payload) {
+      state.delete(id);
+      tombstones.push({ id, payload });
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: a fully valid profile
+// ---------------------------------------------------------------------------
+
+function makeValidProfile(id = 'cust-test'): CustomerProfileV2 {
+  return {
+    schemaVersion: 2,
+    id,
+    legalName: 'TEST TRADING L.L.C',
+    customerType: 'legal',
+    country: 'AE',
+    jurisdiction: 'Dubai',
+    licenseNumber: 'DET-TEST',
+    licenseIssuer: 'Dubai DET',
+    licenseIssueDate: '01/01/2024',
+    licenseExpiryDate: '01/01/2030',
+    licenseStatus: 'active',
+    businessModel: 'Jewellery wholesale trading in UAE',
+    activity: 'Jewellery Trading',
+    sector: 'jewellery-retail',
+    expectedMonthlyVolumeAed: 100_000,
+    expectedTransactionCountPerMonth: 10,
+    riskRating: 'medium',
+    riskRatingAssignedAt: '01/01/2026',
+    riskRatingExpiresAt: '01/07/2026',
+    pepStatus: 'clear',
+    sanctionsStatus: 'clear',
+    sourceOfFundsStatus: 'verified',
+    sourceOfFundsEvidence: [
+      {
+        blobKey: 'evidence/sof.pdf',
+        filename: 'sof.pdf',
+        mimeType: 'application/pdf',
+        uploadedAt: '2026-01-01T00:00:00Z',
+        uploadedBy: 'mlro',
+        sha256: 'a'.repeat(64),
+      },
+    ],
+    sourceOfWealthStatus: 'not_applicable',
+    shareholders: [
+      {
+        id: 'sh-1',
+        type: 'natural',
+        fullName: 'Owner One',
+        ownershipPercent: 60,
+        dateOfBirth: '01/01/1980',
+        nationality: 'AE',
+        emiratesIdNumber: '784-1980-1111111-1',
+        emiratesIdExpiry: '01/01/2030',
+        uboVerifiedAt: '01/01/2026',
+        pepCheckStatus: 'clear',
+        sanctionsCheckStatus: 'clear',
+        adverseMediaCheckStatus: 'clear',
+        evidenceAttachments: [
+          {
+            blobKey: 'evidence/sh1.pdf',
+            filename: 'sh1.pdf',
+            mimeType: 'application/pdf',
+            uploadedAt: '2026-01-01T00:00:00Z',
+            uploadedBy: 'mlro',
+            sha256: 'b'.repeat(64),
+          },
+        ],
+      },
+    ],
+    managers: [
+      {
+        id: 'mgr-1',
+        fullName: 'MLRO Guy',
+        role: 'mlro',
+        dateOfBirth: '01/01/1980',
+        nationality: 'AE',
+        emiratesIdNumber: '784-1980-2222222-2',
+        emiratesIdExpiry: '01/01/2030',
+        passportNumber: 'A1',
+        passportCountry: 'AE',
+        passportExpiry: '01/01/2030',
+        appointmentDate: '01/01/2024',
+        isSanctionsAuthority: true,
+        isStrFilingAuthority: true,
+        pepCheckStatus: 'clear',
+        sanctionsCheckStatus: 'clear',
+        adverseMediaCheckStatus: 'clear',
+      },
+      {
+        id: 'mgr-2',
+        fullName: 'CO Guy',
+        role: 'co',
+        dateOfBirth: '01/01/1985',
+        nationality: 'AE',
+        emiratesIdNumber: '784-1985-3333333-3',
+        emiratesIdExpiry: '01/01/2030',
+        passportNumber: 'A2',
+        passportCountry: 'AE',
+        passportExpiry: '01/01/2030',
+        appointmentDate: '01/01/2024',
+        isSanctionsAuthority: true,
+        isStrFilingAuthority: false,
+        pepCheckStatus: 'clear',
+        sanctionsCheckStatus: 'clear',
+        adverseMediaCheckStatus: 'clear',
+      },
+    ],
+    entityType: 'standalone',
+    createdAt: '2026-01-01T00:00:00Z',
+    nextReviewDueAt: '01/07/2026',
+    recordRetentionUntil: '01/01/2036',
+  };
+}
+
+function makeDeps(store: ProfileStore): HandlerDeps {
+  return {
+    store,
+    nowIso: '2026-04-15T10:00:00.000Z',
+    userId: 'test-user',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// validateRequest
+// ---------------------------------------------------------------------------
+
+describe('validateRequest', () => {
+  const { validateRequest } = __test__;
+
+  it('rejects non-object', () => {
+    expect(validateRequest('not-an-object').ok).toBe(false);
+    expect(validateRequest(null).ok).toBe(false);
+  });
+
+  it('rejects unknown action', () => {
+    const res = validateRequest({ action: 'upsert' });
+    expect(res.ok).toBe(false);
+  });
+
+  it('accepts valid create request', () => {
+    const res = validateRequest({ action: 'create', profile: {} });
+    expect(res.ok).toBe(true);
+  });
+
+  it('rejects create without profile', () => {
+    expect(validateRequest({ action: 'create' }).ok).toBe(false);
+  });
+
+  it('rejects get without id', () => {
+    expect(validateRequest({ action: 'get' }).ok).toBe(false);
+    expect(validateRequest({ action: 'get', id: '' }).ok).toBe(false);
+  });
+
+  it('accepts list without args', () => {
+    expect(validateRequest({ action: 'list' }).ok).toBe(true);
+  });
+
+  it('rejects update without patch', () => {
+    expect(validateRequest({ action: 'update', id: 'x' }).ok).toBe(false);
+  });
+
+  it('rejects delete without reason', () => {
+    expect(validateRequest({ action: 'delete', id: 'x' }).ok).toBe(false);
+    expect(validateRequest({ action: 'delete', id: 'x', reason: 'no' }).ok).toBe(false);
+  });
+
+  it('accepts delete with a real reason', () => {
+    const res = validateRequest({
+      action: 'delete',
+      id: 'x',
+      reason: 'Customer exited relationship',
+    });
+    expect(res.ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleCreate
+// ---------------------------------------------------------------------------
+
+describe('handleCreate', () => {
+  let store: ReturnType<typeof makeMemoryStore>;
+  let deps: HandlerDeps;
+
+  beforeEach(() => {
+    store = makeMemoryStore();
+    deps = makeDeps(store);
+  });
+
+  it('creates a valid profile and persists it', async () => {
+    const profile = makeValidProfile();
+    const result = await handleCreate({ action: 'create', profile }, deps);
+    expect(result.status).toBe(200);
+    const body = result.body as { ok: boolean; profile: CustomerProfileV2 };
+    expect(body.ok).toBe(true);
+    expect(body.profile.id).toBe('cust-test');
+    expect(store.state.has('cust-test')).toBe(true);
+  });
+
+  it('rejects an invalid profile with 422 + findings', async () => {
+    const profile = { ...makeValidProfile(), id: '' }; // empty id is a blocker
+    const result = await handleCreate({ action: 'create', profile }, deps);
+    expect(result.status).toBe(422);
+    const body = result.body as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe('validation_failed');
+    expect(store.state.size).toBe(0);
+  });
+
+  it('rejects duplicate id with 409', async () => {
+    const profile = makeValidProfile();
+    await handleCreate({ action: 'create', profile }, deps);
+    const second = await handleCreate({ action: 'create', profile }, deps);
+    expect(second.status).toBe(409);
+  });
+
+  it('forces schemaVersion=2 and overwrites createdAt', async () => {
+    const tampered = {
+      ...makeValidProfile(),
+      schemaVersion: 99 as unknown as 2,
+      createdAt: '1970-01-01T00:00:00Z',
+    };
+    const result = await handleCreate({ action: 'create', profile: tampered }, deps);
+    expect(result.status).toBe(200);
+    const body = result.body as { profile: CustomerProfileV2 };
+    expect(body.profile.schemaVersion).toBe(2);
+    expect(body.profile.createdAt).toBe('2026-04-15T10:00:00.000Z');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleGet
+// ---------------------------------------------------------------------------
+
+describe('handleGet', () => {
+  let store: ReturnType<typeof makeMemoryStore>;
+  let deps: HandlerDeps;
+
+  beforeEach(() => {
+    store = makeMemoryStore();
+    deps = makeDeps(store);
+  });
+
+  it('returns 404 when not found', async () => {
+    const result = await handleGet({ action: 'get', id: 'missing' }, deps);
+    expect(result.status).toBe(404);
+  });
+
+  it('returns the profile when it exists', async () => {
+    store.state.set('cust-1', makeValidProfile('cust-1'));
+    const result = await handleGet({ action: 'get', id: 'cust-1' }, deps);
+    expect(result.status).toBe(200);
+    const body = result.body as { profile: CustomerProfileV2 };
+    expect(body.profile.id).toBe('cust-1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleList
+// ---------------------------------------------------------------------------
+
+describe('handleList', () => {
+  let store: ReturnType<typeof makeMemoryStore>;
+  let deps: HandlerDeps;
+
+  beforeEach(() => {
+    store = makeMemoryStore();
+    deps = makeDeps(store);
+  });
+
+  it('returns empty list when nothing exists', async () => {
+    const result = await handleList({ action: 'list' }, deps);
+    expect(result.status).toBe(200);
+    const body = result.body as { count: number; profiles: unknown[] };
+    expect(body.count).toBe(0);
+    expect(body.profiles).toHaveLength(0);
+  });
+
+  it('returns id+legalName+riskRating+licenseExpiryDate+country summaries', async () => {
+    store.state.set('c1', makeValidProfile('c1'));
+    store.state.set('c2', { ...makeValidProfile('c2'), legalName: 'NAPLES LLC' });
+    const result = await handleList({ action: 'list' }, deps);
+    expect(result.status).toBe(200);
+    const body = result.body as {
+      count: number;
+      profiles: Array<{
+        id: string;
+        legalName: string;
+        riskRating: string;
+        licenseExpiryDate: string;
+        country: string;
+      }>;
+    };
+    expect(body.count).toBe(2);
+    const ids = body.profiles.map((p) => p.id).sort();
+    expect(ids).toEqual(['c1', 'c2']);
+    for (const p of body.profiles) {
+      expect(p).toHaveProperty('legalName');
+      expect(p).toHaveProperty('riskRating');
+      expect(p).toHaveProperty('licenseExpiryDate');
+      expect(p).toHaveProperty('country');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleUpdate
+// ---------------------------------------------------------------------------
+
+describe('handleUpdate', () => {
+  let store: ReturnType<typeof makeMemoryStore>;
+  let deps: HandlerDeps;
+
+  beforeEach(() => {
+    store = makeMemoryStore();
+    deps = makeDeps(store);
+  });
+
+  it('returns 404 when updating missing profile', async () => {
+    const result = await handleUpdate(
+      { action: 'update', id: 'missing', patch: { jurisdiction: 'Sharjah' } },
+      deps
+    );
+    expect(result.status).toBe(404);
+  });
+
+  it('merges the patch and persists', async () => {
+    store.state.set('cust-1', makeValidProfile('cust-1'));
+    const result = await handleUpdate(
+      { action: 'update', id: 'cust-1', patch: { jurisdiction: 'Sharjah', riskRating: 'high' } },
+      deps
+    );
+    expect(result.status).toBe(200);
+    const body = result.body as { profile: CustomerProfileV2 };
+    expect(body.profile.jurisdiction).toBe('Sharjah');
+    expect(body.profile.riskRating).toBe('high');
+    // id + schemaVersion + createdAt are preserved
+    expect(body.profile.id).toBe('cust-1');
+    expect(body.profile.schemaVersion).toBe(2);
+  });
+
+  it('refuses to overwrite id / schemaVersion / createdAt via patch', async () => {
+    store.state.set('cust-1', makeValidProfile('cust-1'));
+    const tampered = {
+      action: 'update' as const,
+      id: 'cust-1',
+      patch: {
+        id: 'pwned',
+        schemaVersion: 99 as unknown as 2,
+        createdAt: '1970-01-01T00:00:00Z',
+      },
+    };
+    const result = await handleUpdate(tampered, deps);
+    expect(result.status).toBe(200);
+    const body = result.body as { profile: CustomerProfileV2 };
+    expect(body.profile.id).toBe('cust-1');
+    expect(body.profile.schemaVersion).toBe(2);
+    expect(body.profile.createdAt).toBe('2026-01-01T00:00:00Z');
+  });
+
+  it('stamps lastReviewedAt + lastReviewerUserId on every update', async () => {
+    store.state.set('cust-1', makeValidProfile('cust-1'));
+    const result = await handleUpdate(
+      { action: 'update', id: 'cust-1', patch: { jurisdiction: 'Sharjah' } },
+      deps
+    );
+    expect(result.status).toBe(200);
+    const body = result.body as { profile: CustomerProfileV2 };
+    expect(body.profile.lastReviewedAt).toBe('2026-04-15T10:00:00.000Z');
+    expect(body.profile.lastReviewerUserId).toBe('test-user');
+  });
+
+  it('rejects a patch that makes the profile invalid', async () => {
+    store.state.set('cust-1', makeValidProfile('cust-1'));
+    const result = await handleUpdate(
+      { action: 'update', id: 'cust-1', patch: { country: 'United Arab Emirates' } },
+      deps
+    );
+    expect(result.status).toBe(422);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleDelete (tombstone)
+// ---------------------------------------------------------------------------
+
+describe('handleDelete', () => {
+  let store: ReturnType<typeof makeMemoryStore>;
+  let deps: HandlerDeps;
+
+  beforeEach(() => {
+    store = makeMemoryStore();
+    deps = makeDeps(store);
+  });
+
+  it('returns 404 when deleting missing profile', async () => {
+    const result = await handleDelete(
+      { action: 'delete', id: 'missing', reason: 'Customer never onboarded' },
+      deps
+    );
+    expect(result.status).toBe(404);
+  });
+
+  it('tombstones (not hard deletes) a live profile', async () => {
+    store.state.set('cust-1', makeValidProfile('cust-1'));
+    const result = await handleDelete(
+      { action: 'delete', id: 'cust-1', reason: 'Customer exited relationship' },
+      deps
+    );
+    expect(result.status).toBe(200);
+    // Profile removed from live store.
+    expect(store.state.has('cust-1')).toBe(false);
+    // Tombstone written.
+    expect(store.tombstones).toHaveLength(1);
+    expect(store.tombstones[0]!.id).toBe('cust-1');
+    expect(store.tombstones[0]!.payload.reason).toBe('Customer exited relationship');
+  });
+});


### PR DESCRIPTION
## Summary

**Phase A.2 — Customer Profile CRUD endpoint.** Full REST-over-POST CRUD over `CustomerProfileV2` records, backed by Netlify Blobs with 10-year tombstone retention per FDL Art.24. Builds directly on the foundation from PR #129.

## Endpoint

`POST /api/customer-profile` with `{ action }` discriminator:

| Action | Behaviour |
|---|---|
| `create` | Validates via `customerProfileValidator`, rejects duplicate id with 409, **forces `schemaVersion=2` and overwrites `createdAt`** so the caller cannot forge the audit trail |
| `get` | 404 when missing |
| `list` | Returns lightweight summaries (id, legalName, riskRating, licenseExpiryDate, country) |
| `update` | Merges patch onto existing, **preserves id + schemaVersion + createdAt (write-once)**, stamps `lastReviewedAt` + `lastReviewerUserId`, re-validates merged profile (422 if invalid) |
| `delete` | **Tombstones — never hard-deletes.** Profile body copied to `customer-profiles-tombstones` store with reason + timestamp (FDL Art.24 10-year retention). Requires reason string ≥5 chars |

## Security
- POST + OPTIONS only
- Bearer `HAWKEYE_BRAIN_TOKEN` via `authenticate()`
- Rate limited 30 / 15 min per IP
- CORS via `HAWKEYE_ALLOWED_ORIGIN`

## Tests (24 unit tests, all passing)

Handlers are pure with an injected `ProfileStore` — tests use an in-memory fake, production uses `makeNetlifyBlobStore()`.

**`validateRequest`** (9 tests) — non-object, unknown action, create/get/list/update/delete shape checks, delete reason length
**`handleCreate`** (4 tests) — creates + persists, rejects invalid (empty id → 422), rejects duplicate id (409), **forces `schemaVersion=2` and overwrites `createdAt` on tamper attempt**
**`handleGet`** (2 tests) — 404 missing, 200 when present
**`handleList`** (2 tests) — empty, summaries contain all 5 fields
**`handleUpdate`** (5 tests) — 404 missing, merges patch, **preserves id/schemaVersion/createdAt on tamper attempt**, stamps `lastReviewedAt` + `lastReviewerUserId`, rejects patch that makes profile invalid (422)
**`handleDelete`** (2 tests) — 404 missing, **tombstones (not hard deletes)**, writes to tombstone store with reason

## Quality gate

| Check | Result |
|---|---|
| `prettier --check` | ✅ clean |
| `tsc --noEmit` | ✅ clean |
| `eslint src/` | ✅ clean |
| `vitest run` (full) | ✅ **243 files / 3,915 tests** |
| `customerProfileCrudHandlers.test.ts` | ✅ **24/24 pass** |

## Regulatory citation

- **FDL No.10/2025** Art.12-14 (CDD per customer), Art.20-22 (CO visibility), **Art.24 (10yr retention — tombstone, never hard delete)**
- **Cabinet Res 134/2025** Art.7-10 (CDD data per tier), Art.19 (internal review — stamped reviewer on every update)
- **Cabinet Decision 109/2023** (UBO register)

No threshold or decision pathway changed. Pure CRUD + validator wiring on top of PR #129.

## Queued for Phase C
- Expiry scan cron that consumes `scanExpiries()` from PR #129 + creates Asana tasks in KYC/CDD Tracker sections from PR #127
- React UI components (`CustomerProfileEditor`, `ShareholderList`, `ManagerList`, `AttachmentUpload`) — deferred to a dedicated turn for React snapshot test infra
