### PR TITLE
Fix SSE stream idle timeout - partial response received

### DIFF
--- a/netlify/functions/ai-proxy.mts
+++ b/netlify/functions/ai-proxy.mts
@@ -60,6 +60,26 @@ const PROVIDERS: Record<string, ProviderConfig> = {
 const MAX_BODY_SIZE = 1024 * 1024; // 1 MB max request body
 
 /**
+ * Upstream request timeouts.
+ *
+ * Non-streaming calls are capped at 60s — if an AI provider hasn't
+ * produced the full response by then, the caller has almost certainly
+ * already given up.
+ *
+ * Streaming calls get a much longer ceiling (5 minutes) because the
+ * signal is attached to the entire `fetch()` — including the time the
+ * body is actively streaming chunks to the client. A short timeout
+ * here aborts the upstream mid-flight and surfaces as
+ * "Stream idle timeout - partial response received" on the browser
+ * even though bytes are still flowing. The stream's real lifetime is
+ * bounded by (a) Anthropic's own stream cap, (b) the client
+ * disconnect signal (propagated below), and (c) Netlify's function
+ * wall-clock — all of which are the right stopping conditions.
+ */
+const NONSTREAM_UPSTREAM_TIMEOUT_MS = 60_000;
+const STREAM_UPSTREAM_TIMEOUT_MS = 300_000;
+
+/**
  * Allowlist of Anthropic beta features we forward from the caller into the
  * `anthropic-beta` header. Anything not in this list is silently dropped so
  * the proxy can't be tricked into enabling unintended betas.
@@ -186,12 +206,37 @@ export default async (req: Request, context: Context) => {
       }
     }
 
-    const upstreamRes = await fetch(targetUrl, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(payload),
-      signal: AbortSignal.timeout(60_000), // 60s timeout for AI requests
-    });
+    // Upstream abort controller. We combine two termination signals:
+    //   1. A wall-clock timeout (longer for streams — see constants above).
+    //   2. The incoming client disconnect signal, so if the browser
+    //      hangs up we stop paying for upstream tokens we'll never
+    //      deliver.
+    // Both use the same AbortController; whichever fires first wins.
+    const upstreamAbort = new AbortController();
+    const timeoutMs = stream ? STREAM_UPSTREAM_TIMEOUT_MS : NONSTREAM_UPSTREAM_TIMEOUT_MS;
+    const upstreamTimeout = setTimeout(() => {
+      upstreamAbort.abort(new DOMException('Upstream timeout', 'TimeoutError'));
+    }, timeoutMs);
+    const clientSignal = (req as unknown as { signal?: AbortSignal }).signal;
+    const onClientAbort = () => upstreamAbort.abort(new DOMException('Client disconnected', 'AbortError'));
+    if (clientSignal) {
+      if (clientSignal.aborted) onClientAbort();
+      else clientSignal.addEventListener('abort', onClientAbort, { once: true });
+    }
+
+    let upstreamRes: Response;
+    try {
+      upstreamRes = await fetch(targetUrl, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(payload),
+        signal: upstreamAbort.signal,
+      });
+    } catch (e) {
+      clearTimeout(upstreamTimeout);
+      if (clientSignal) clientSignal.removeEventListener('abort', onClientAbort);
+      throw e;
+    }
 
     // Never reflect the upstream Content-Type verbatim — the proxy
     // accepts only JSON payloads and SSE streams. Force a known value
@@ -200,6 +245,13 @@ export default async (req: Request, context: Context) => {
     const isSse = upstreamCT.startsWith('text/event-stream');
 
     if (stream && upstreamRes.body) {
+      // Headers received — we no longer need the short-circuit timer.
+      // The stream's lifetime is bounded by Anthropic's own cap, the
+      // client disconnect listener above, and Netlify's wall-clock.
+      clearTimeout(upstreamTimeout);
+      // Note: we intentionally leave `onClientAbort` wired up until
+      // the Response stream is consumed — it still needs to forward
+      // a browser hang-up to the upstream fetch.
       return new Response(upstreamRes.body, {
         status: upstreamRes.status,
         headers: {
@@ -209,6 +261,10 @@ export default async (req: Request, context: Context) => {
         },
       });
     }
+
+    // Non-streaming path: response is buffered below, timer can fire.
+    clearTimeout(upstreamTimeout);
+    if (clientSignal) clientSignal.removeEventListener('abort', onClientAbort);
 
     const responseBody = await upstreamRes.text();
     return new Response(responseBody, {

--- a/netlify/functions/decision-stream.mts
+++ b/netlify/functions/decision-stream.mts
@@ -36,8 +36,30 @@ import {
 
 const MAX_BODY_BYTES = 512 * 1024;
 
+/**
+ * Heartbeat cadence. SSE comment frames (lines starting with `:`) are
+ * ignored by `EventSource` but keep the TCP connection alive and reset
+ * idle timers in any intermediate proxy / CDN / Netlify edge layer.
+ * Without these, long `runComplianceDecision()` awaits produce
+ * "Stream idle timeout - partial response received" on the client.
+ */
+const HEARTBEAT_MS = 5_000;
+
+/**
+ * Hard cap on total stream duration. Netlify standard functions abort
+ * after ~26s wall time; we close cleanly at 24s so the client receives
+ * a terminal `timeout` event rather than a truncated TCP stream.
+ * Consumers should retry on this event.
+ */
+const MAX_STREAM_MS = 24_000;
+
 function sseFrame(event: string, data: unknown): string {
   return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+/** SSE comment frame — keep-alive ping that EventSource silently ignores. */
+function sseHeartbeat(): string {
+  return `: heartbeat ${Date.now()}\n\n`;
 }
 
 function coerceInput(raw: unknown): ComplianceCaseInput | { error: string } {
@@ -85,12 +107,61 @@ export default async (req: Request, context: Context): Promise<Response> => {
   const input = coerceInput(parsed);
   if ('error' in input) return Response.json({ error: input.error }, { status: 400 });
 
+  const clientSignal = (req as unknown as { signal?: AbortSignal }).signal;
+
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
       const enc = new TextEncoder();
-      const emit = (event: string, data: unknown) => {
-        controller.enqueue(enc.encode(sseFrame(event, data)));
+      let closed = false;
+      let heartbeat: ReturnType<typeof setInterval> | null = null;
+      let deadline: ReturnType<typeof setTimeout> | null = null;
+
+      const safeEnqueue = (chunk: Uint8Array) => {
+        if (closed) return;
+        try {
+          controller.enqueue(chunk);
+        } catch {
+          // Controller already closed (client disconnect). Stop further writes.
+          closed = true;
+        }
       };
+      const emit = (event: string, data: unknown) => {
+        safeEnqueue(enc.encode(sseFrame(event, data)));
+      };
+
+      const cleanup = () => {
+        if (closed) return;
+        closed = true;
+        if (heartbeat) clearInterval(heartbeat);
+        if (deadline) clearTimeout(deadline);
+        if (clientSignal) clientSignal.removeEventListener('abort', onAbort);
+        try {
+          controller.close();
+        } catch {
+          /* already closed */
+        }
+      };
+
+      function onAbort() {
+        cleanup();
+      }
+      if (clientSignal) clientSignal.addEventListener('abort', onAbort);
+
+      // Keep-alive heartbeat during the long-running runComplianceDecision
+      // await. Prevents idle-timeout on any intermediate proxy.
+      heartbeat = setInterval(() => {
+        safeEnqueue(enc.encode(sseHeartbeat()));
+      }, HEARTBEAT_MS);
+
+      // Hard deadline: close with a terminal `timeout` event before the
+      // Netlify wall-clock kills the function. Client should retry.
+      deadline = setTimeout(() => {
+        emit('timeout', {
+          reason: 'max-stream-duration',
+          maxStreamMs: MAX_STREAM_MS,
+        });
+        cleanup();
+      }, MAX_STREAM_MS);
 
       try {
         emit('plan:start', {
@@ -120,7 +191,7 @@ export default async (req: Request, context: Context): Promise<Response> => {
         const message = err instanceof Error ? err.message : String(err);
         emit('error', { message });
       } finally {
-        controller.close();
+        cleanup();
       }
     },
   });


### PR DESCRIPTION
## Summary

Fixes the client-facing `API Error: Stream idle timeout - partial response received` on the SSE plane. Two distinct root causes, both transport-layer, zero regulatory surface.

## Root Causes

### 1. `netlify/functions/decision-stream.mts` — no keep-alive during long awaits
The endpoint emitted `plan:start` + `execute:start`, then blocked on `await runComplianceDecision(input)` with **zero traffic on the wire**. `runComplianceDecision` drives 13+ weaponized-brain subsystems plus advisor-strategy escalations and routinely sits idle >30s — long enough for Netlify edge / CDN / browser to close the connection as idle. The client then received only the two opening frames → "partial response received".

### 2. `netlify/functions/ai-proxy.mts` — `AbortSignal.timeout(60_000)` killed active streams
The proxy wrapped the upstream fetch with a 60s abort signal. For non-streaming calls this is correct. For **streaming** calls the signal applies to the entire fetch — including the body — so after 60s of actively flowing tokens the proxy aborted mid-stream.

## Fixes

**decision-stream.mts**
- Emit `:heartbeat <ts>` SSE comment frames every 5s during the long await (ignored by `EventSource`, but keep TCP + proxy idle timers alive).
- 24s hard deadline that closes cleanly with a terminal `timeout` event before Netlify's ~26s wall-clock kills the function.
- `safeEnqueue` guards against writes after controller close; shared `cleanup()` drops heartbeat + deadline + abort listener exactly once on every exit path.
- Client abort signal wired to `cleanup()` so browser disconnect stops work immediately.

**ai-proxy.mts**
- Split the upstream timeout: 60s for non-streaming, 300s for streams.
- Clear the timer as soon as stream headers arrive so the body can flow up to Netlify's own wall-clock (the right stopping condition).
- Propagate client disconnect into the upstream `AbortController` so we stop paying for tokens the browser will never receive.

## Regulatory Basis

- **FDL No.10/2025 Art.20-21** — Compliance Officer situational awareness. The SSE feed is the channel the CO uses to watch decisions progress in real time.
- **Cabinet Res 134/2025 Art.19** — continuous internal monitoring. A truncated stream broke that loop.

No thresholds, verdict logic, or tipping-off surface changed. Pure transport-layer fix.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run tests/complianceDecisionEngine.test.ts tests/advisorStrategy.test.ts` — 48/48 pass
- [x] Confirmed the eslint parser error on `.mts` files is pre-existing on `main` (not introduced here)
- [ ] Manual: trigger a long-running `runComplianceDecision` via `/api/decision/stream` and confirm the client receives heartbeat comments then the `done` frame
- [ ] Manual: trigger a streaming Anthropic call via `/api/ai-proxy` that takes >60s and confirm the body streams to completion without mid-flight abort

https://claude.ai/code/session_01MYiWnwC1eZ7WKABT4rY2VL