### PR TITLE
Add Weekly CDD Status Report generator and cron

### DIFF
--- a/netlify/functions/cdd-weekly-status-cron.mts
+++ b/netlify/functions/cdd-weekly-status-cron.mts
@@ -1,0 +1,143 @@
+/**
+ * Weekly CDD Status Report — cron.
+ *
+ * Schedule: Mondays 05:00 UTC = 09:00 Asia/Dubai. Feeds the Claude
+ * Code "Weekly CDD Status Report" routine that runs at the same time
+ * slot. The routine reads the latest blob from this cron to produce
+ * the MLRO briefing without re-computing the report itself.
+ *
+ * The cron is thin by design:
+ *   1. Materialise a CustomerProfile view over COMPANY_REGISTRY
+ *      (the registry omits beneficialOwners + reviewHistory; we
+ *      provide empty arrays because this report does not need them).
+ *   2. Derive PeriodicReviewSchedule entries from each customer's
+ *      lastCDDReviewDate + risk rating via createReviewSchedule.
+ *   3. Pass empty arrays for approvals, filings, and screeningRuns
+ *      for the initial release — those stores will be wired in a
+ *      follow-up once the persistence layer exists. The generator
+ *      already handles empty collections.
+ *   4. Build the report and persist both markdown + JSON to the
+ *      cdd-weekly-status-reports blob store so the routine (and
+ *      auditors) can retrieve it. FDL Art.24 requires 10yr retention,
+ *      which the blob store already satisfies.
+ *
+ * Regulatory basis:
+ *   - FDL No.10/2025 Art.12-14, Art.14, Art.24, Art.26-27, Art.29
+ *   - Cabinet Res 134/2025 Art.7-14, Art.19
+ *   - Cabinet Res 74/2020 Art.6
+ *   - MoE Circular 08/AML/2021
+ */
+
+import type { Config } from '@netlify/functions';
+import { getStore } from '@netlify/blobs';
+
+const REPORT_STORE = 'cdd-weekly-status-reports';
+const AUDIT_STORE = 'cdd-weekly-status-audit';
+
+interface CronResult {
+  ok: boolean;
+  startedAt: string;
+  customers: number;
+  reportKey?: string;
+  error?: string;
+}
+
+async function writeAudit(payload: Record<string, unknown>): Promise<void> {
+  try {
+    const store = getStore(AUDIT_STORE);
+    const iso = new Date().toISOString();
+    await store.setJSON(`${iso.slice(0, 10)}/${Date.now()}.json`, {
+      ...payload,
+      recordedAt: iso,
+    });
+  } catch {
+    /* audit write best-effort */
+  }
+}
+
+export default async (): Promise<Response> => {
+  const startedAt = new Date().toISOString();
+
+  // Dynamic imports keep cold-start small and avoid pulling React
+  // into the function bundle.
+  const { COMPANY_REGISTRY } = await import('../../src/domain/customers');
+  const { createReviewSchedule } = await import(
+    '../../src/domain/periodicReview'
+  );
+  const { buildWeeklyCddReport, renderWeeklyCddReportMarkdown } = await import(
+    '../../src/services/cddReportGenerator'
+  );
+
+  try {
+    const customers = COMPANY_REGISTRY.map((c) => ({
+      ...c,
+      beneficialOwners: [],
+      reviewHistory: [],
+    }));
+
+    const reviewSchedules = customers.map((c) =>
+      createReviewSchedule(
+        c.id,
+        c.legalName,
+        c.riskRating,
+        'cdd-refresh',
+        c.lastCDDReviewDate
+      )
+    );
+
+    const report = buildWeeklyCddReport({
+      now: new Date(),
+      customers,
+      reviewSchedules,
+      approvals: [],
+      filings: [],
+      screeningRuns: [],
+    });
+
+    const markdown = renderWeeklyCddReportMarkdown(report);
+    const key = `${startedAt.slice(0, 10)}/report.json`;
+
+    const store = getStore(REPORT_STORE);
+    await store.setJSON(key, {
+      generatedAt: startedAt,
+      report,
+      markdown,
+    });
+
+    await writeAudit({
+      event: 'cdd_weekly_status_report_generated',
+      reportKey: key,
+      tierRollup: report.tierRollup,
+      overdueReviewsCount: report.overdueReviews.length,
+      pendingApprovalsCount: report.pendingApprovals.length,
+      overdueFilingsCount: report.filingSnapshot.overdue.length,
+      sanctionsResolvedCount: report.sanctionsResolvedThisWeek.length,
+    });
+
+    const result: CronResult = {
+      ok: true,
+      startedAt,
+      customers: customers.length,
+      reportKey: key,
+    };
+    return Response.json(result);
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    await writeAudit({
+      event: 'cdd_weekly_status_report_failed',
+      error,
+    });
+    const result: CronResult = {
+      ok: false,
+      startedAt,
+      customers: 0,
+      error,
+    };
+    return Response.json(result, { status: 500 });
+  }
+};
+
+export const config: Config = {
+  // Mondays 05:00 UTC = 09:00 Asia/Dubai.
+  schedule: '0 5 * * 1',
+};

--- a/src/services/cddReportGenerator.ts
+++ b/src/services/cddReportGenerator.ts
@@ -1,0 +1,513 @@
+/**
+ * Weekly CDD Status Report Generator.
+ *
+ * Produces the Monday-morning report consumed by the MLRO and by the
+ * Claude Code "Weekly CDD Status Report" routine. Pure functions only:
+ * all inputs are passed explicitly so the report is deterministic,
+ * unit-testable, and cheap to re-run.
+ *
+ * Report answers five questions:
+ *   1. How many customers are on SDD / CDD / EDD right now?
+ *   2. Which CDD reviews are overdue or due within the next 30 days?
+ *   3. Which PEP / EDD cases are pending Senior Management approval?
+ *   4. Filing snapshot: STRs / CTRs / DPMSRs / CNMRs filed this week,
+ *      plus any overdue filings flagged by businessDays.checkDeadline.
+ *   5. Sanctions matches resolved within the past 7 days.
+ *
+ * The generator intentionally does NOT perform I/O — the Netlify cron
+ * in netlify/functions/cdd-weekly-status-cron.mts is responsible for
+ * loading data and dispatching the output. This module stays pure so
+ * tests can pin every field without mocking network calls.
+ *
+ * Regulatory basis:
+ *   - FDL No.10/2025 Art.12-14 (CDD tiers, review cadence)
+ *   - FDL No.10/2025 Art.14   (PEP enhanced due diligence)
+ *   - FDL No.10/2025 Art.24   (record retention, audit trail)
+ *   - FDL No.10/2025 Art.26-27 (STR / CTR filing obligations)
+ *   - FDL No.10/2025 Art.29   (no tipping off — report is internal only)
+ *   - Cabinet Res 134/2025 Art.5 (risk appetite)
+ *   - Cabinet Res 134/2025 Art.7-10 (CDD tiers)
+ *   - Cabinet Res 134/2025 Art.14 (Senior Management approval for PEP/EDD)
+ *   - Cabinet Res 134/2025 Art.19 (internal review cadence)
+ *   - Cabinet Res 74/2020 Art.6 (CNMR 5 business days)
+ *   - MoE Circular 08/AML/2021 (DPMSR quarterly / CTR 15 business days)
+ */
+
+import type { CustomerProfile } from '../domain/customers';
+import type { PeriodicReviewSchedule } from '../domain/periodicReview';
+import { checkReviewStatus } from '../domain/periodicReview';
+import type { ApprovalRequest } from '../domain/approvals';
+import type { FilingRecord } from './screeningComplianceReport';
+import type { ScreeningRun } from '../domain/screening';
+import { checkDeadline } from '../utils/businessDays';
+import { formatDateDDMMYYYY } from '../utils/dates';
+import {
+  CDD_REVIEW_HIGH_RISK_MONTHS,
+  CDD_REVIEW_MEDIUM_RISK_MONTHS,
+  CDD_REVIEW_LOW_RISK_MONTHS,
+  STR_FILING_DEADLINE_BUSINESS_DAYS,
+  CTR_FILING_DEADLINE_BUSINESS_DAYS,
+  CNMR_FILING_DEADLINE_BUSINESS_DAYS,
+} from '../domain/constants';
+
+// ─── Tier mapping ───────────────────────────────────────────────────────────
+
+/**
+ * Map `CustomerProfile.riskRating` to the CDD tier the UAE AML regime
+ * assigns to that risk level (FDL Art.12-14, Cabinet Res 134/2025 Art.7-10).
+ */
+export type CddTier = 'SDD' | 'CDD' | 'EDD';
+
+export function tierForRiskRating(
+  rating: CustomerProfile['riskRating']
+): CddTier {
+  if (rating === 'high') return 'EDD';
+  if (rating === 'medium') return 'CDD';
+  return 'SDD';
+}
+
+// ─── Report types ───────────────────────────────────────────────────────────
+
+export interface CddTierRollup {
+  sdd: number;
+  cdd: number;
+  edd: number;
+  total: number;
+}
+
+export interface OverdueReview {
+  customerId: string;
+  customerName: string;
+  tier: CddTier;
+  nextReviewDate: string; // ISO
+  status: 'overdue' | 'due';
+}
+
+export interface PendingApproval {
+  approvalId: string;
+  caseId: string;
+  requiredFor: ApprovalRequest['requiredFor'];
+  requestedAt: string; // ISO
+  requestedBy: string;
+  urgency: ApprovalRequest['urgency'];
+  ageInDays: number;
+}
+
+export interface FilingThisWeek {
+  filingType: FilingRecord['filingType'];
+  referenceNumber: string;
+  filingDate: string; // ISO
+  status: FilingRecord['status'];
+  deadlineMet: boolean;
+}
+
+export interface OverdueFiling {
+  filingType: FilingRecord['filingType'];
+  referenceNumber: string;
+  filingDate: string; // ISO of triggering event
+  businessDaysElapsed: number;
+  deadlineBusinessDays: number;
+}
+
+export interface FilingSnapshot {
+  countsByType: Record<FilingRecord['filingType'], number>;
+  filedThisWeek: FilingThisWeek[];
+  overdue: OverdueFiling[];
+}
+
+export interface SanctionsResolution {
+  runId: string;
+  subjectType: ScreeningRun['subjectType'];
+  subjectId: string;
+  executedAt: string; // ISO
+  resolution: string;
+  analyst: string;
+}
+
+export interface WeeklyCddReportInput {
+  /** Fixed "now" for deterministic output and testing. */
+  now: Date;
+  /** All customers in scope. */
+  customers: ReadonlyArray<CustomerProfile>;
+  /** Review schedules. Keyed off customerId. */
+  reviewSchedules: ReadonlyArray<PeriodicReviewSchedule>;
+  /** Open approval requests (pending, approved, or rejected). */
+  approvals: ReadonlyArray<ApprovalRequest>;
+  /** Filings recorded in the system. Week-in-review + overdue logic applied. */
+  filings: ReadonlyArray<FilingRecord>;
+  /** Screening runs resolved in any outcome. Week-in-review applied. */
+  screeningRuns: ReadonlyArray<ScreeningRun>;
+}
+
+export interface WeeklyCddReport {
+  generatedAtIso: string;
+  windowFromIso: string;
+  windowToIso: string;
+  tierRollup: CddTierRollup;
+  overdueReviews: OverdueReview[];
+  pendingApprovals: PendingApproval[];
+  filingSnapshot: FilingSnapshot;
+  sanctionsResolvedThisWeek: SanctionsResolution[];
+  /** Regulatory citations this report attests to. */
+  citations: ReadonlyArray<string>;
+}
+
+// ─── Builder ────────────────────────────────────────────────────────────────
+
+const SEVEN_DAYS_MS = 7 * 86_400_000;
+const APPROVALS_RELEVANT_FOR: ReadonlyArray<ApprovalRequest['requiredFor']> = [
+  'pep-onboarding',
+  'high-risk-onboarding',
+  'edd-continuation',
+];
+const FILING_TYPES: ReadonlyArray<FilingRecord['filingType']> = [
+  'STR',
+  'SAR',
+  'CTR',
+  'DPMSR',
+  'CNMR',
+  'EOCN_FREEZE',
+];
+
+function deadlineForFilingType(
+  type: FilingRecord['filingType']
+): number | null {
+  switch (type) {
+    case 'STR':
+    case 'SAR':
+      return STR_FILING_DEADLINE_BUSINESS_DAYS;
+    case 'CTR':
+    case 'DPMSR':
+      return CTR_FILING_DEADLINE_BUSINESS_DAYS;
+    case 'CNMR':
+      return CNMR_FILING_DEADLINE_BUSINESS_DAYS;
+    case 'EOCN_FREEZE':
+      // EOCN freeze is a 24h clock, not business days. Not covered by this
+      // snapshot — see checkEOCNDeadline in businessDays.ts.
+      return null;
+  }
+}
+
+export function buildWeeklyCddReport(
+  input: WeeklyCddReportInput
+): WeeklyCddReport {
+  const { now, customers, reviewSchedules, approvals, filings, screeningRuns } =
+    input;
+  const windowFromIso = new Date(now.getTime() - SEVEN_DAYS_MS).toISOString();
+  const windowToIso = now.toISOString();
+
+  // 1) Tier rollup.
+  const tierRollup: CddTierRollup = { sdd: 0, cdd: 0, edd: 0, total: 0 };
+  for (const c of customers) {
+    const tier = tierForRiskRating(c.riskRating);
+    if (tier === 'SDD') tierRollup.sdd++;
+    else if (tier === 'CDD') tierRollup.cdd++;
+    else tierRollup.edd++;
+    tierRollup.total++;
+  }
+
+  // 2) Overdue + due-soon reviews.
+  const overdueReviews: OverdueReview[] = [];
+  for (const schedule of reviewSchedules) {
+    const live = checkReviewStatus(schedule);
+    if (live.status !== 'overdue' && live.status !== 'due') continue;
+    const source = customers.find((c) => c.id === schedule.customerId);
+    const tier = source
+      ? tierForRiskRating(source.riskRating)
+      : tierForRiskRating(schedule.riskRating);
+    overdueReviews.push({
+      customerId: schedule.customerId,
+      customerName: schedule.customerName,
+      tier,
+      nextReviewDate: schedule.nextReviewDate,
+      status: live.status,
+    });
+  }
+  // Overdue first, then due-soon. Within each bucket sort by date.
+  overdueReviews.sort((a, b) => {
+    if (a.status !== b.status) return a.status === 'overdue' ? -1 : 1;
+    return a.nextReviewDate.localeCompare(b.nextReviewDate);
+  });
+
+  // 3) Pending Senior Management approvals (PEP / EDD / high-risk onboarding).
+  const pendingApprovals: PendingApproval[] = [];
+  for (const a of approvals) {
+    if (a.status !== 'pending') continue;
+    if (!APPROVALS_RELEVANT_FOR.includes(a.requiredFor)) continue;
+    const requestedAtMs = Date.parse(a.requestedAt);
+    const ageInDays = Number.isFinite(requestedAtMs)
+      ? Math.max(
+          0,
+          Math.floor((now.getTime() - requestedAtMs) / 86_400_000)
+        )
+      : 0;
+    pendingApprovals.push({
+      approvalId: a.id,
+      caseId: a.caseId,
+      requiredFor: a.requiredFor,
+      requestedAt: a.requestedAt,
+      requestedBy: a.requestedBy,
+      urgency: a.urgency,
+      ageInDays,
+    });
+  }
+  // Oldest first — FIFO exposure is the MLRO's risk surface.
+  pendingApprovals.sort((a, b) => b.ageInDays - a.ageInDays);
+
+  // 4) Filing snapshot.
+  const countsByType: Record<FilingRecord['filingType'], number> = {
+    STR: 0,
+    SAR: 0,
+    CTR: 0,
+    DPMSR: 0,
+    CNMR: 0,
+    EOCN_FREEZE: 0,
+  };
+  const filedThisWeek: FilingThisWeek[] = [];
+  const overdue: OverdueFiling[] = [];
+  const windowFromMs = Date.parse(windowFromIso);
+
+  for (const f of filings) {
+    countsByType[f.filingType]++;
+    const filingMs = Date.parse(f.filingDate);
+    if (Number.isFinite(filingMs) && filingMs >= windowFromMs) {
+      filedThisWeek.push({
+        filingType: f.filingType,
+        referenceNumber: f.referenceNumber,
+        filingDate: f.filingDate,
+        status: f.status,
+        deadlineMet: f.deadlineMet,
+      });
+    }
+
+    // Overdue = the source recorded it as overdue OR deadline was not met.
+    // For pending filings we also defensively recompute via businessDays
+    // in case the source system has not yet re-tagged a stale pending
+    // filing as overdue. Submitted / acknowledged filings are trusted.
+    const deadline = deadlineForFilingType(f.filingType);
+    let breached = f.status === 'overdue' || !f.deadlineMet;
+    if (
+      !breached &&
+      f.status === 'pending' &&
+      deadline !== null &&
+      Number.isFinite(filingMs)
+    ) {
+      const check = checkDeadline(new Date(filingMs), deadline, now);
+      breached = check.breached;
+    }
+    if (breached) {
+      const check =
+        deadline !== null && Number.isFinite(filingMs)
+          ? checkDeadline(new Date(filingMs), deadline, now)
+          : null;
+      overdue.push({
+        filingType: f.filingType,
+        referenceNumber: f.referenceNumber,
+        filingDate: f.filingDate,
+        businessDaysElapsed: check?.businessDaysElapsed ?? 0,
+        deadlineBusinessDays: deadline ?? 0,
+      });
+    }
+  }
+  filedThisWeek.sort((a, b) => b.filingDate.localeCompare(a.filingDate));
+  overdue.sort((a, b) => b.businessDaysElapsed - a.businessDaysElapsed);
+
+  // 5) Sanctions resolutions this week.
+  const sanctionsResolvedThisWeek: SanctionsResolution[] = [];
+  for (const r of screeningRuns) {
+    if (!r.falsePositiveResolution) continue;
+    const execMs = Date.parse(r.executedAt);
+    if (!Number.isFinite(execMs) || execMs < windowFromMs) continue;
+    sanctionsResolvedThisWeek.push({
+      runId: r.id,
+      subjectType: r.subjectType,
+      subjectId: r.subjectId,
+      executedAt: r.executedAt,
+      resolution: r.falsePositiveResolution,
+      analyst: r.analyst,
+    });
+  }
+  sanctionsResolvedThisWeek.sort((a, b) =>
+    b.executedAt.localeCompare(a.executedAt)
+  );
+
+  return {
+    generatedAtIso: windowToIso,
+    windowFromIso,
+    windowToIso,
+    tierRollup,
+    overdueReviews,
+    pendingApprovals,
+    filingSnapshot: { countsByType, filedThisWeek, overdue },
+    sanctionsResolvedThisWeek,
+    citations: [
+      'FDL No.10/2025 Art.12-14 (CDD tiers, review cadence)',
+      'FDL No.10/2025 Art.14 (PEP enhanced due diligence)',
+      'FDL No.10/2025 Art.24 (record retention, audit trail)',
+      'FDL No.10/2025 Art.26-27 (STR / CTR filing obligations)',
+      'FDL No.10/2025 Art.29 (no tipping off — internal report only)',
+      'Cabinet Res 134/2025 Art.7-10 (CDD tiers)',
+      'Cabinet Res 134/2025 Art.14 (Senior Management approval)',
+      'Cabinet Res 134/2025 Art.19 (internal review cadence)',
+      'Cabinet Res 74/2020 Art.6 (CNMR 5 business days)',
+      'MoE Circular 08/AML/2021 (DPMSR / CTR threshold and cadence)',
+    ],
+  };
+}
+
+// ─── Markdown renderer ─────────────────────────────────────────────────────
+
+function filingTypeDeadlineLabel(type: FilingRecord['filingType']): string {
+  const days = deadlineForFilingType(type);
+  if (days === null) return '24-hour clock (Cabinet Res 74/2020 Art.4)';
+  if (days === 0) return 'without delay (FDL Art.26-27)';
+  return `${days} business days`;
+}
+
+/**
+ * Render the weekly CDD report as a markdown document suitable for
+ * posting to Asana, emailing to the MLRO, or archiving to a blob.
+ *
+ * Carve-out: compliance content stays verbose even when the rest of
+ * the project trims output. See CLAUDE.md "Token-Efficient Output
+ * Rules → Compliance Carve-Outs".
+ */
+export function renderWeeklyCddReportMarkdown(report: WeeklyCddReport): string {
+  const fromDisplay = formatDateDDMMYYYY(report.windowFromIso);
+  const toDisplay = formatDateDDMMYYYY(report.windowToIso);
+  const lines: string[] = [];
+
+  lines.push('# Weekly CDD Status Report');
+  lines.push('');
+  lines.push(`Window: ${fromDisplay} to ${toDisplay}`);
+  lines.push(`Generated: ${formatDateDDMMYYYY(report.generatedAtIso)}`);
+  lines.push('');
+
+  // 1) Tier rollup.
+  lines.push('## 1. CDD tier rollup');
+  lines.push('');
+  lines.push('| Tier | Count | Review cadence |');
+  lines.push('| --- | ---: | --- |');
+  lines.push(
+    `| SDD | ${report.tierRollup.sdd} | every ${CDD_REVIEW_LOW_RISK_MONTHS} months |`
+  );
+  lines.push(
+    `| CDD | ${report.tierRollup.cdd} | every ${CDD_REVIEW_MEDIUM_RISK_MONTHS} months |`
+  );
+  lines.push(
+    `| EDD | ${report.tierRollup.edd} | every ${CDD_REVIEW_HIGH_RISK_MONTHS} months |`
+  );
+  lines.push(`| **Total** | **${report.tierRollup.total}** | |`);
+  lines.push('');
+
+  // 2) Overdue reviews.
+  lines.push('## 2. Reviews overdue or due within 30 days');
+  lines.push('');
+  if (report.overdueReviews.length === 0) {
+    lines.push('No overdue or imminent reviews. All customers on cadence.');
+  } else {
+    lines.push('| Status | Customer | Tier | Next review date |');
+    lines.push('| --- | --- | --- | --- |');
+    for (const r of report.overdueReviews) {
+      lines.push(
+        `| ${r.status.toUpperCase()} | ${r.customerName} | ${r.tier} | ${formatDateDDMMYYYY(r.nextReviewDate)} |`
+      );
+    }
+  }
+  lines.push('');
+
+  // 3) Pending approvals.
+  lines.push(
+    '## 3. Pending Senior Management approvals (FDL Art.14, Cabinet Res 134/2025 Art.14)'
+  );
+  lines.push('');
+  if (report.pendingApprovals.length === 0) {
+    lines.push('No pending PEP / EDD / high-risk onboarding approvals.');
+  } else {
+    lines.push(
+      '| Case | Required for | Urgency | Requested by | Age (days) |'
+    );
+    lines.push('| --- | --- | --- | --- | ---: |');
+    for (const a of report.pendingApprovals) {
+      lines.push(
+        `| ${a.caseId} | ${a.requiredFor} | ${a.urgency ?? 'standard'} | ${a.requestedBy} | ${a.ageInDays} |`
+      );
+    }
+  }
+  lines.push('');
+
+  // 4) Filing snapshot.
+  lines.push('## 4. Filing snapshot');
+  lines.push('');
+  lines.push('### Counts by type (lifetime)');
+  lines.push('');
+  lines.push('| Type | Count | Deadline |');
+  lines.push('| --- | ---: | --- |');
+  for (const t of FILING_TYPES) {
+    lines.push(
+      `| ${t} | ${report.filingSnapshot.countsByType[t]} | ${filingTypeDeadlineLabel(t)} |`
+    );
+  }
+  lines.push('');
+
+  lines.push('### Filed this week');
+  lines.push('');
+  if (report.filingSnapshot.filedThisWeek.length === 0) {
+    lines.push('No filings recorded in the past 7 days.');
+  } else {
+    lines.push('| Type | Reference | Filed on | Status | Deadline met |');
+    lines.push('| --- | --- | --- | --- | :---: |');
+    for (const f of report.filingSnapshot.filedThisWeek) {
+      lines.push(
+        `| ${f.filingType} | ${f.referenceNumber} | ${formatDateDDMMYYYY(f.filingDate)} | ${f.status} | ${f.deadlineMet ? 'yes' : 'NO'} |`
+      );
+    }
+  }
+  lines.push('');
+
+  lines.push('### Overdue filings');
+  lines.push('');
+  if (report.filingSnapshot.overdue.length === 0) {
+    lines.push('No overdue filings detected.');
+  } else {
+    lines.push(
+      '| Type | Reference | Event date | Business days elapsed | Deadline |'
+    );
+    lines.push('| --- | --- | --- | ---: | ---: |');
+    for (const f of report.filingSnapshot.overdue) {
+      lines.push(
+        `| ${f.filingType} | ${f.referenceNumber} | ${formatDateDDMMYYYY(f.filingDate)} | ${f.businessDaysElapsed} | ${f.deadlineBusinessDays} |`
+      );
+    }
+  }
+  lines.push('');
+
+  // 5) Sanctions resolutions.
+  lines.push('## 5. Sanctions matches resolved this week');
+  lines.push('');
+  if (report.sanctionsResolvedThisWeek.length === 0) {
+    lines.push('No sanctions matches resolved in the past 7 days.');
+  } else {
+    lines.push('| Run | Subject | Resolved on | Analyst | Resolution |');
+    lines.push('| --- | --- | --- | --- | --- |');
+    for (const r of report.sanctionsResolvedThisWeek) {
+      lines.push(
+        `| ${r.runId} | ${r.subjectType}:${r.subjectId} | ${formatDateDDMMYYYY(r.executedAt)} | ${r.analyst} | ${r.resolution} |`
+      );
+    }
+  }
+  lines.push('');
+
+  lines.push('## Regulatory basis');
+  lines.push('');
+  for (const c of report.citations) {
+    lines.push(`- ${c}`);
+  }
+  lines.push('');
+  lines.push(
+    'This report is internal to the Compliance Officer and Senior Management. It must not be shared with the subject of any customer, UBO, or transaction listed above (FDL No.10/2025 Art.29 — no tipping off).'
+  );
+  lines.push('');
+
+  return lines.join('\n');
+}

--- a/src/services/scheduledComplianceReports.ts
+++ b/src/services/scheduledComplianceReports.ts
@@ -69,6 +69,17 @@ export const SCHEDULED_REPORTS: readonly ScheduledReportDefinition[] = [
     dispatchTo: 'mlro',
   },
   {
+    id: 'weekly_cdd_status',
+    name: 'Weekly CDD Status Report',
+    cadence: 'weekly',
+    purpose:
+      'Monday tier rollup (SDD/CDD/EDD), overdue reviews, pending Senior Management approvals, filing snapshot, and sanctions resolutions for the MLRO',
+    citation:
+      'FDL No.10/2025 Art.12-14, Art.14, Art.26-27; Cabinet Res 134/2025 Art.7-14, Art.19',
+    outputs: ['markdown', 'json'],
+    dispatchTo: 'mlro',
+  },
+  {
     id: 'monthly_ubo_reverification',
     name: 'Monthly UBO re-verification',
     cadence: 'monthly',

--- a/tests/cddReportGenerator.test.ts
+++ b/tests/cddReportGenerator.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Weekly CDD Status Report — unit tests.
+ *
+ * Covers:
+ *   - Tier rollup mirrors risk-rating mapping (FDL Art.12-14).
+ *   - Overdue reviews are surfaced; overdue sorts before due-soon.
+ *   - Pending Senior Management approvals filter to PEP / EDD /
+ *     high-risk onboarding only (Cabinet Res 134/2025 Art.14).
+ *   - Filing snapshot counts all filings, marks this-week bucket,
+ *     and detects overdue via businessDays.checkDeadline.
+ *   - Sanctions resolutions within the 7-day window are surfaced.
+ *   - Markdown renderer is deterministic and cites regulations.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { CustomerProfile } from '../src/domain/customers';
+import type { PeriodicReviewSchedule } from '../src/domain/periodicReview';
+import type { ApprovalRequest } from '../src/domain/approvals';
+import type { FilingRecord } from '../src/services/screeningComplianceReport';
+import type { ScreeningRun } from '../src/domain/screening';
+import {
+  buildWeeklyCddReport,
+  renderWeeklyCddReportMarkdown,
+  tierForRiskRating,
+} from '../src/services/cddReportGenerator';
+
+const NOW = new Date('2026-04-13T05:00:00.000Z'); // Mon 09:00 Dubai
+const DAY_MS = 86_400_000;
+
+function customer(
+  id: string,
+  rating: CustomerProfile['riskRating']
+): CustomerProfile {
+  return {
+    id,
+    legalName: `Co ${id}`,
+    type: 'customer',
+    riskRating: rating,
+    pepStatus: 'clear',
+    sanctionsStatus: 'clear',
+    sourceOfFundsStatus: 'verified',
+    sourceOfWealthStatus: 'verified',
+    beneficialOwners: [],
+    reviewHistory: [],
+  };
+}
+
+function schedule(
+  customerId: string,
+  nextReviewDate: string,
+  rating: CustomerProfile['riskRating'] = 'medium'
+): PeriodicReviewSchedule {
+  return {
+    id: `sched-${customerId}`,
+    customerId,
+    customerName: `Co ${customerId}`,
+    riskRating: rating,
+    reviewType: 'cdd-refresh',
+    frequencyMonths: rating === 'high' ? 3 : rating === 'medium' ? 6 : 12,
+    lastReviewDate: new Date(
+      NOW.getTime() - 200 * DAY_MS
+    ).toISOString(),
+    nextReviewDate,
+    status: 'scheduled',
+  };
+}
+
+describe('tierForRiskRating', () => {
+  it('maps risk ratings to UAE CDD tiers', () => {
+    expect(tierForRiskRating('low')).toBe('SDD');
+    expect(tierForRiskRating('medium')).toBe('CDD');
+    expect(tierForRiskRating('high')).toBe('EDD');
+  });
+});
+
+describe('buildWeeklyCddReport — tier rollup', () => {
+  it('counts customers by CDD tier', () => {
+    const report = buildWeeklyCddReport({
+      now: NOW,
+      customers: [
+        customer('a', 'low'),
+        customer('b', 'low'),
+        customer('c', 'medium'),
+        customer('d', 'high'),
+      ],
+      reviewSchedules: [],
+      approvals: [],
+      filings: [],
+      screeningRuns: [],
+    });
+    expect(report.tierRollup).toEqual({
+      sdd: 2,
+      cdd: 1,
+      edd: 1,
+      total: 4,
+    });
+  });
+});
+
+describe('buildWeeklyCddReport — overdue reviews', () => {
+  it('surfaces overdue + due-soon reviews and orders overdue first', () => {
+    const overdueIso = new Date(NOW.getTime() - 10 * DAY_MS).toISOString();
+    const dueSoonIso = new Date(NOW.getTime() + 5 * DAY_MS).toISOString();
+    const farFutureIso = new Date(NOW.getTime() + 90 * DAY_MS).toISOString();
+
+    const report = buildWeeklyCddReport({
+      now: NOW,
+      customers: [
+        customer('late', 'high'),
+        customer('soon', 'medium'),
+        customer('clear', 'low'),
+      ],
+      reviewSchedules: [
+        schedule('soon', dueSoonIso, 'medium'),
+        schedule('late', overdueIso, 'high'),
+        schedule('clear', farFutureIso, 'low'),
+      ],
+      approvals: [],
+      filings: [],
+      screeningRuns: [],
+    });
+
+    expect(report.overdueReviews).toHaveLength(2);
+    expect(report.overdueReviews[0]).toMatchObject({
+      customerId: 'late',
+      status: 'overdue',
+      tier: 'EDD',
+    });
+    expect(report.overdueReviews[1]).toMatchObject({
+      customerId: 'soon',
+      status: 'due',
+      tier: 'CDD',
+    });
+  });
+});
+
+describe('buildWeeklyCddReport — pending approvals', () => {
+  it('includes only PEP / EDD / high-risk onboarding pending approvals', () => {
+    const fivedaysAgo = new Date(NOW.getTime() - 5 * DAY_MS).toISOString();
+    const approvals: ApprovalRequest[] = [
+      {
+        id: 'ap1',
+        caseId: 'case-pep',
+        requiredFor: 'pep-onboarding',
+        status: 'pending',
+        requestedBy: 'analyst.a',
+        requestedAt: fivedaysAgo,
+        urgency: 'urgent',
+      },
+      {
+        id: 'ap2',
+        caseId: 'case-str',
+        requiredFor: 'str-approval',
+        status: 'pending',
+        requestedBy: 'analyst.a',
+        requestedAt: fivedaysAgo,
+      },
+      {
+        id: 'ap3',
+        caseId: 'case-edd',
+        requiredFor: 'edd-continuation',
+        status: 'pending',
+        requestedBy: 'analyst.b',
+        requestedAt: new Date(NOW.getTime() - 12 * DAY_MS).toISOString(),
+      },
+      {
+        id: 'ap4',
+        caseId: 'case-closed',
+        requiredFor: 'pep-onboarding',
+        status: 'approved',
+        requestedBy: 'analyst.a',
+        requestedAt: fivedaysAgo,
+      },
+    ];
+
+    const report = buildWeeklyCddReport({
+      now: NOW,
+      customers: [],
+      reviewSchedules: [],
+      approvals,
+      filings: [],
+      screeningRuns: [],
+    });
+
+    // str-approval filtered; approved filtered. Oldest-first ordering.
+    expect(report.pendingApprovals.map((p) => p.caseId)).toEqual([
+      'case-edd',
+      'case-pep',
+    ]);
+    expect(report.pendingApprovals[0].ageInDays).toBe(12);
+  });
+});
+
+describe('buildWeeklyCddReport — filing snapshot', () => {
+  it('buckets this week, counts by type, and flags overdue via businessDays', () => {
+    const threeDaysAgo = new Date(NOW.getTime() - 3 * DAY_MS).toISOString();
+    const tenDaysAgo = new Date(NOW.getTime() - 10 * DAY_MS).toISOString();
+    const thirtyDaysAgo = new Date(NOW.getTime() - 30 * DAY_MS).toISOString();
+
+    const filings: FilingRecord[] = [
+      {
+        filingType: 'STR',
+        filingDate: threeDaysAgo,
+        referenceNumber: 'STR-001',
+        status: 'submitted',
+        deadlineMet: true,
+      },
+      {
+        filingType: 'CTR',
+        filingDate: tenDaysAgo,
+        referenceNumber: 'CTR-001',
+        status: 'submitted',
+        deadlineMet: true,
+      },
+      {
+        // CNMR event 30 days ago, deadline 5 business days, so breached.
+        filingType: 'CNMR',
+        filingDate: thirtyDaysAgo,
+        referenceNumber: 'CNMR-001',
+        status: 'pending',
+        deadlineMet: true,
+      },
+      {
+        // Explicitly marked overdue by the source system.
+        filingType: 'DPMSR',
+        filingDate: tenDaysAgo,
+        referenceNumber: 'DPMSR-001',
+        status: 'overdue',
+        deadlineMet: false,
+      },
+    ];
+
+    const report = buildWeeklyCddReport({
+      now: NOW,
+      customers: [],
+      reviewSchedules: [],
+      approvals: [],
+      filings,
+      screeningRuns: [],
+    });
+
+    expect(report.filingSnapshot.countsByType.STR).toBe(1);
+    expect(report.filingSnapshot.countsByType.CTR).toBe(1);
+    expect(report.filingSnapshot.countsByType.CNMR).toBe(1);
+    expect(report.filingSnapshot.countsByType.DPMSR).toBe(1);
+    expect(report.filingSnapshot.countsByType.SAR).toBe(0);
+
+    // Only filings within 7 days appear in filedThisWeek.
+    expect(report.filingSnapshot.filedThisWeek.map((f) => f.referenceNumber)).toEqual([
+      'STR-001',
+    ]);
+
+    // CNMR breach + DPMSR explicit overdue.
+    const overdueRefs = report.filingSnapshot.overdue.map((o) => o.referenceNumber);
+    expect(overdueRefs).toContain('CNMR-001');
+    expect(overdueRefs).toContain('DPMSR-001');
+    expect(overdueRefs).not.toContain('STR-001');
+    expect(overdueRefs).not.toContain('CTR-001');
+  });
+});
+
+describe('buildWeeklyCddReport — sanctions resolutions', () => {
+  it('includes only resolved screening runs within the 7-day window', () => {
+    const runs: ScreeningRun[] = [
+      {
+        id: 'run-1',
+        subjectType: 'entity',
+        subjectId: 'ent-1',
+        executedAt: new Date(NOW.getTime() - 2 * DAY_MS).toISOString(),
+        systemUsed: 'refinitiv',
+        listsChecked: ['UN', 'OFAC'],
+        result: 'potential-match',
+        falsePositiveResolution: 'false positive, name collision',
+        analyst: 'analyst.a',
+      },
+      {
+        id: 'run-2',
+        subjectType: 'ubo',
+        subjectId: 'ubo-1',
+        executedAt: new Date(NOW.getTime() - 30 * DAY_MS).toISOString(),
+        systemUsed: 'refinitiv',
+        listsChecked: ['UN', 'OFAC'],
+        result: 'potential-match',
+        falsePositiveResolution: 'false positive',
+        analyst: 'analyst.a',
+      },
+      {
+        id: 'run-3',
+        subjectType: 'entity',
+        subjectId: 'ent-2',
+        executedAt: new Date(NOW.getTime() - 1 * DAY_MS).toISOString(),
+        systemUsed: 'refinitiv',
+        listsChecked: ['UN', 'OFAC'],
+        result: 'clear',
+        analyst: 'analyst.b',
+      },
+    ];
+
+    const report = buildWeeklyCddReport({
+      now: NOW,
+      customers: [],
+      reviewSchedules: [],
+      approvals: [],
+      filings: [],
+      screeningRuns: runs,
+    });
+
+    expect(report.sanctionsResolvedThisWeek.map((r) => r.runId)).toEqual([
+      'run-1',
+    ]);
+  });
+});
+
+describe('renderWeeklyCddReportMarkdown', () => {
+  it('renders headings, rollup, and regulatory citations', () => {
+    const report = buildWeeklyCddReport({
+      now: NOW,
+      customers: [customer('a', 'low'), customer('b', 'high')],
+      reviewSchedules: [],
+      approvals: [],
+      filings: [],
+      screeningRuns: [],
+    });
+    const md = renderWeeklyCddReportMarkdown(report);
+
+    expect(md).toContain('# Weekly CDD Status Report');
+    expect(md).toContain('## 1. CDD tier rollup');
+    expect(md).toContain('## 2. Reviews overdue or due within 30 days');
+    expect(md).toContain(
+      '## 3. Pending Senior Management approvals (FDL Art.14, Cabinet Res 134/2025 Art.14)'
+    );
+    expect(md).toContain('## 4. Filing snapshot');
+    expect(md).toContain('## 5. Sanctions matches resolved this week');
+    expect(md).toContain('## Regulatory basis');
+    expect(md).toContain('FDL No.10/2025 Art.29');
+    // Verbose carve-out: the no-tipping-off warning must be present.
+    expect(md).toContain('must not be shared with the subject');
+  });
+});


### PR DESCRIPTION
## Summary

Implements the Weekly CDD Status Report — a Monday-morning compliance briefing for the MLRO that aggregates customer due diligence tier distribution, overdue reviews, pending Senior Management approvals, filing deadlines, and sanctions resolutions. The report is generated by a pure function (deterministic, testable, I/O-free) and dispatched via a Netlify cron that runs Mondays at 09:00 Dubai time.

## Key Changes

- **`src/services/cddReportGenerator.ts`** (513 lines)
  - `tierForRiskRating()`: Maps customer risk ratings (low/medium/high) to UAE CDD tiers (SDD/CDD/EDD) per FDL Art.12-14
  - `buildWeeklyCddReport()`: Pure function that aggregates five report sections:
    1. Tier rollup (count of customers by CDD tier)
    2. Overdue and due-soon reviews (sorted by status then date)
    3. Pending Senior Management approvals (PEP/EDD/high-risk onboarding only, sorted by age)
    4. Filing snapshot (lifetime counts, this-week bucket, overdue detection via `businessDays.checkDeadline`)
    5. Sanctions resolutions within the 7-day window
  - `renderWeeklyCddReportMarkdown()`: Renders report as markdown with regulatory citations; includes verbose compliance carve-out (no-tipping-off warning per FDL Art.29)
  - All inputs passed explicitly; no I/O or side effects

- **`tests/cddReportGenerator.test.ts`** (339 lines)
  - Unit tests covering tier mapping, tier rollup, overdue review detection and ordering, approval filtering and age calculation, filing snapshot bucketing and overdue detection, sanctions resolution windowing, and markdown rendering

- **`netlify/functions/cdd-weekly-status-cron.mts`** (143 lines)
  - Scheduled cron (Mondays 05:00 UTC = 09:00 Dubai)
  - Materializes `CustomerProfile` view from `COMPANY_REGISTRY`
  - Derives `PeriodicReviewSchedule` entries via `createReviewSchedule()`
  - Calls `buildWeeklyCddReport()` and `renderWeeklyCddReportMarkdown()`
  - Persists JSON + markdown to `cdd-weekly-status-reports` blob store (FDL Art.24 10-year retention)
  - Writes audit trail to `cdd-weekly-status-audit` blob store
  - Thin by design: approvals, filings, and screeningRuns passed as empty arrays pending persistence layer wiring

- **`src/services/scheduledComplianceReports.ts`** (modified)
  - Added `weekly_cdd_status` report definition to `SCHEDULED_REPORTS` array

## Implementation Details

- **Regulatory alignment**: Report cites FDL No.10/2025 (Art.12-14, 14, 24, 26-27, 29), Cabinet Res 134/2025 (Art.7-10, 14, 19), Cabinet Res 74/2020 (Art.6), and MoE Circular 08/AML/2021
- **Pure functions**: All inputs explicit; deterministic output; cheap to re-run; unit-testable without mocking network calls
- **Overdue filing detection**: Defensive recomputation via `businessDays.checkDeadline()` for pending filings in case source system has not yet re-tagged stale records
- **Approval filtering**: Only surfaces PEP onboarding, high-risk onboarding, and EDD continuation approvals (per Cabinet Res 134/2025 Art.14); sorts by age (FIFO exposure)
- **Compliance carve-out**: Markdown output remains verbose even under token-efficiency rules (per CLAUDE.md); includes mandatory no-tipping-off warning

https://claude.ai/code/session_01K4twBZwq6wDoyF8GptSNQx