### PR TITLE
Apply Prettier formatting to Weekly CDD Status Report files

### DIFF
--- a/netlify/functions/cdd-weekly-status-cron.mts
+++ b/netlify/functions/cdd-weekly-status-cron.mts
@@ -61,12 +61,9 @@ export default async (): Promise<Response> => {
   // Dynamic imports keep cold-start small and avoid pulling React
   // into the function bundle.
   const { COMPANY_REGISTRY } = await import('../../src/domain/customers');
-  const { createReviewSchedule } = await import(
-    '../../src/domain/periodicReview'
-  );
-  const { buildWeeklyCddReport, renderWeeklyCddReportMarkdown } = await import(
-    '../../src/services/cddReportGenerator'
-  );
+  const { createReviewSchedule } = await import('../../src/domain/periodicReview');
+  const { buildWeeklyCddReport, renderWeeklyCddReportMarkdown } =
+    await import('../../src/services/cddReportGenerator');
 
   try {
     const customers = COMPANY_REGISTRY.map((c) => ({
@@ -76,13 +73,7 @@ export default async (): Promise<Response> => {
     }));
 
     const reviewSchedules = customers.map((c) =>
-      createReviewSchedule(
-        c.id,
-        c.legalName,
-        c.riskRating,
-        'cdd-refresh',
-        c.lastCDDReviewDate
-      )
+      createReviewSchedule(c.id, c.legalName, c.riskRating, 'cdd-refresh', c.lastCDDReviewDate)
     );
 
     const report = buildWeeklyCddReport({

--- a/src/services/cddReportGenerator.ts
+++ b/src/services/cddReportGenerator.ts
@@ -58,9 +58,7 @@ import {
  */
 export type CddTier = 'SDD' | 'CDD' | 'EDD';
 
-export function tierForRiskRating(
-  rating: CustomerProfile['riskRating']
-): CddTier {
+export function tierForRiskRating(rating: CustomerProfile['riskRating']): CddTier {
   if (rating === 'high') return 'EDD';
   if (rating === 'medium') return 'CDD';
   return 'SDD';
@@ -169,9 +167,7 @@ const FILING_TYPES: ReadonlyArray<FilingRecord['filingType']> = [
   'EOCN_FREEZE',
 ];
 
-function deadlineForFilingType(
-  type: FilingRecord['filingType']
-): number | null {
+function deadlineForFilingType(type: FilingRecord['filingType']): number | null {
   switch (type) {
     case 'STR':
     case 'SAR':
@@ -188,11 +184,8 @@ function deadlineForFilingType(
   }
 }
 
-export function buildWeeklyCddReport(
-  input: WeeklyCddReportInput
-): WeeklyCddReport {
-  const { now, customers, reviewSchedules, approvals, filings, screeningRuns } =
-    input;
+export function buildWeeklyCddReport(input: WeeklyCddReportInput): WeeklyCddReport {
+  const { now, customers, reviewSchedules, approvals, filings, screeningRuns } = input;
   const windowFromIso = new Date(now.getTime() - SEVEN_DAYS_MS).toISOString();
   const windowToIso = now.toISOString();
 
@@ -236,10 +229,7 @@ export function buildWeeklyCddReport(
     if (!APPROVALS_RELEVANT_FOR.includes(a.requiredFor)) continue;
     const requestedAtMs = Date.parse(a.requestedAt);
     const ageInDays = Number.isFinite(requestedAtMs)
-      ? Math.max(
-          0,
-          Math.floor((now.getTime() - requestedAtMs) / 86_400_000)
-        )
+      ? Math.max(0, Math.floor((now.getTime() - requestedAtMs) / 86_400_000))
       : 0;
     pendingApprovals.push({
       approvalId: a.id,
@@ -286,12 +276,7 @@ export function buildWeeklyCddReport(
     // filing as overdue. Submitted / acknowledged filings are trusted.
     const deadline = deadlineForFilingType(f.filingType);
     let breached = f.status === 'overdue' || !f.deadlineMet;
-    if (
-      !breached &&
-      f.status === 'pending' &&
-      deadline !== null &&
-      Number.isFinite(filingMs)
-    ) {
+    if (!breached && f.status === 'pending' && deadline !== null && Number.isFinite(filingMs)) {
       const check = checkDeadline(new Date(filingMs), deadline, now);
       breached = check.breached;
     }
@@ -327,9 +312,7 @@ export function buildWeeklyCddReport(
       analyst: r.analyst,
     });
   }
-  sanctionsResolvedThisWeek.sort((a, b) =>
-    b.executedAt.localeCompare(a.executedAt)
-  );
+  sanctionsResolvedThisWeek.sort((a, b) => b.executedAt.localeCompare(a.executedAt));
 
   return {
     generatedAtIso: windowToIso,
@@ -388,15 +371,9 @@ export function renderWeeklyCddReportMarkdown(report: WeeklyCddReport): string {
   lines.push('');
   lines.push('| Tier | Count | Review cadence |');
   lines.push('| --- | ---: | --- |');
-  lines.push(
-    `| SDD | ${report.tierRollup.sdd} | every ${CDD_REVIEW_LOW_RISK_MONTHS} months |`
-  );
-  lines.push(
-    `| CDD | ${report.tierRollup.cdd} | every ${CDD_REVIEW_MEDIUM_RISK_MONTHS} months |`
-  );
-  lines.push(
-    `| EDD | ${report.tierRollup.edd} | every ${CDD_REVIEW_HIGH_RISK_MONTHS} months |`
-  );
+  lines.push(`| SDD | ${report.tierRollup.sdd} | every ${CDD_REVIEW_LOW_RISK_MONTHS} months |`);
+  lines.push(`| CDD | ${report.tierRollup.cdd} | every ${CDD_REVIEW_MEDIUM_RISK_MONTHS} months |`);
+  lines.push(`| EDD | ${report.tierRollup.edd} | every ${CDD_REVIEW_HIGH_RISK_MONTHS} months |`);
   lines.push(`| **Total** | **${report.tierRollup.total}** | |`);
   lines.push('');
 
@@ -417,16 +394,12 @@ export function renderWeeklyCddReportMarkdown(report: WeeklyCddReport): string {
   lines.push('');
 
   // 3) Pending approvals.
-  lines.push(
-    '## 3. Pending Senior Management approvals (FDL Art.14, Cabinet Res 134/2025 Art.14)'
-  );
+  lines.push('## 3. Pending Senior Management approvals (FDL Art.14, Cabinet Res 134/2025 Art.14)');
   lines.push('');
   if (report.pendingApprovals.length === 0) {
     lines.push('No pending PEP / EDD / high-risk onboarding approvals.');
   } else {
-    lines.push(
-      '| Case | Required for | Urgency | Requested by | Age (days) |'
-    );
+    lines.push('| Case | Required for | Urgency | Requested by | Age (days) |');
     lines.push('| --- | --- | --- | --- | ---: |');
     for (const a of report.pendingApprovals) {
       lines.push(
@@ -470,9 +443,7 @@ export function renderWeeklyCddReportMarkdown(report: WeeklyCddReport): string {
   if (report.filingSnapshot.overdue.length === 0) {
     lines.push('No overdue filings detected.');
   } else {
-    lines.push(
-      '| Type | Reference | Event date | Business days elapsed | Deadline |'
-    );
+    lines.push('| Type | Reference | Event date | Business days elapsed | Deadline |');
     lines.push('| --- | --- | --- | ---: | ---: |');
     for (const f of report.filingSnapshot.overdue) {
       lines.push(

--- a/src/services/scheduledComplianceReports.ts
+++ b/src/services/scheduledComplianceReports.ts
@@ -74,8 +74,7 @@ export const SCHEDULED_REPORTS: readonly ScheduledReportDefinition[] = [
     cadence: 'weekly',
     purpose:
       'Monday tier rollup (SDD/CDD/EDD), overdue reviews, pending Senior Management approvals, filing snapshot, and sanctions resolutions for the MLRO',
-    citation:
-      'FDL No.10/2025 Art.12-14, Art.14, Art.26-27; Cabinet Res 134/2025 Art.7-14, Art.19',
+    citation: 'FDL No.10/2025 Art.12-14, Art.14, Art.26-27; Cabinet Res 134/2025 Art.7-14, Art.19',
     outputs: ['markdown', 'json'],
     dispatchTo: 'mlro',
   },

--- a/tests/cddReportGenerator.test.ts
+++ b/tests/cddReportGenerator.test.ts
@@ -27,10 +27,7 @@ import {
 const NOW = new Date('2026-04-13T05:00:00.000Z'); // Mon 09:00 Dubai
 const DAY_MS = 86_400_000;
 
-function customer(
-  id: string,
-  rating: CustomerProfile['riskRating']
-): CustomerProfile {
+function customer(id: string, rating: CustomerProfile['riskRating']): CustomerProfile {
   return {
     id,
     legalName: `Co ${id}`,
@@ -57,9 +54,7 @@ function schedule(
     riskRating: rating,
     reviewType: 'cdd-refresh',
     frequencyMonths: rating === 'high' ? 3 : rating === 'medium' ? 6 : 12,
-    lastReviewDate: new Date(
-      NOW.getTime() - 200 * DAY_MS
-    ).toISOString(),
+    lastReviewDate: new Date(NOW.getTime() - 200 * DAY_MS).toISOString(),
     nextReviewDate,
     status: 'scheduled',
   };
@@ -105,11 +100,7 @@ describe('buildWeeklyCddReport — overdue reviews', () => {
 
     const report = buildWeeklyCddReport({
       now: NOW,
-      customers: [
-        customer('late', 'high'),
-        customer('soon', 'medium'),
-        customer('clear', 'low'),
-      ],
+      customers: [customer('late', 'high'), customer('soon', 'medium'), customer('clear', 'low')],
       reviewSchedules: [
         schedule('soon', dueSoonIso, 'medium'),
         schedule('late', overdueIso, 'high'),
@@ -183,10 +174,7 @@ describe('buildWeeklyCddReport — pending approvals', () => {
     });
 
     // str-approval filtered; approved filtered. Oldest-first ordering.
-    expect(report.pendingApprovals.map((p) => p.caseId)).toEqual([
-      'case-edd',
-      'case-pep',
-    ]);
+    expect(report.pendingApprovals.map((p) => p.caseId)).toEqual(['case-edd', 'case-pep']);
     expect(report.pendingApprovals[0].ageInDays).toBe(12);
   });
 });
@@ -246,9 +234,7 @@ describe('buildWeeklyCddReport — filing snapshot', () => {
     expect(report.filingSnapshot.countsByType.SAR).toBe(0);
 
     // Only filings within 7 days appear in filedThisWeek.
-    expect(report.filingSnapshot.filedThisWeek.map((f) => f.referenceNumber)).toEqual([
-      'STR-001',
-    ]);
+    expect(report.filingSnapshot.filedThisWeek.map((f) => f.referenceNumber)).toEqual(['STR-001']);
 
     // CNMR breach + DPMSR explicit overdue.
     const overdueRefs = report.filingSnapshot.overdue.map((o) => o.referenceNumber);
@@ -305,9 +291,7 @@ describe('buildWeeklyCddReport — sanctions resolutions', () => {
       screeningRuns: runs,
     });
 
-    expect(report.sanctionsResolvedThisWeek.map((r) => r.runId)).toEqual([
-      'run-1',
-    ]);
+    expect(report.sanctionsResolvedThisWeek.map((r) => r.runId)).toEqual(['run-1']);
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #140. The four files introduced in that PR were not run through Prettier before the auto-merge completed. This commit is Prettier-only — no behaviour changes.

Files reformatted:
- `src/services/cddReportGenerator.ts`
- `tests/cddReportGenerator.test.ts`
- `netlify/functions/cdd-weekly-status-cron.mts`
- `src/services/scheduledComplianceReports.ts` (the new `weekly_cdd_status` entry)

## Test plan

- [x] `npx prettier --check <files>` — all four pass
- [x] `npx vitest run tests/cddReportGenerator.test.ts` — 7/7 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` (full suite) — 4018/4018 passing before formatting change

https://claude.ai/code/session_01K4twBZwq6wDoyF8GptSNQx