### PR TITLE
Sanctions Watch Daily Report generator + cron

### DIFF
--- a/netlify/functions/sanctions-watch-cron.mts
+++ b/netlify/functions/sanctions-watch-cron.mts
@@ -1,0 +1,176 @@
+/**
+ * Sanctions Watch Daily — cron.
+ *
+ * Schedule: daily 05:00 UTC = 09:00 Asia/Dubai. Feeds the Claude Code
+ * "Sanctions Watch" routine that runs at the same time slot. The routine
+ * reads the latest blob produced here to brief the MLRO without having
+ * to re-aggregate the raw hits itself.
+ *
+ * This cron does NOT re-run screening. The existing
+ * netlify/functions/sanctions-delta-screen-cron.mts handles that every
+ * 4 hours and persists hits + audit records. This cron only aggregates
+ * an MLRO-facing view over whatever those stores already contain.
+ *
+ * The initial implementation passes empty hit / frozen / false-positive
+ * arrays for customer data we have not yet wired from the blob stores.
+ * The generator tolerates empty collections and will render an "all
+ * clear" report — which is still useful because it exercises the list-
+ * coverage alert path.
+ *
+ * Follow-up (intentional, not a blocker for the routine):
+ *   - Load latest DeltaScreenHit records from the sanctions-delta-
+ *     screen audit store for the past 24h and pass as `hits`.
+ *   - Load confirmed-freeze records from auto-remediation audit and
+ *     pass as `frozenSubjects`.
+ *   - Load dismissed hits from the screening audit store and pass as
+ *     `recentFalsePositives`.
+ *
+ * Regulatory basis:
+ *   - FDL No.10/2025 Art.20-22, Art.24, Art.29, Art.35
+ *   - Cabinet Res 74/2020 Art.4-7
+ *   - FATF Rec 6, Rec 20
+ *   - MoE Circular 08/AML/2021
+ */
+
+import type { Config } from '@netlify/functions';
+import { getStore } from '@netlify/blobs';
+
+const REPORT_STORE = 'sanctions-watch-reports';
+const AUDIT_STORE = 'sanctions-watch-audit';
+const SNAPSHOT_STORE = 'sanctions-snapshots';
+
+interface CronResult {
+  ok: boolean;
+  startedAt: string;
+  reportKey?: string;
+  anyListMissing?: boolean;
+  error?: string;
+}
+
+async function writeAudit(payload: Record<string, unknown>): Promise<void> {
+  try {
+    const store = getStore(AUDIT_STORE);
+    const iso = new Date().toISOString();
+    await store.setJSON(`${iso.slice(0, 10)}/${Date.now()}.json`, {
+      ...payload,
+      recordedAt: iso,
+    });
+  } catch {
+    /* audit write best-effort */
+  }
+}
+
+/**
+ * Best-effort health probe per required source. Reads the most recent
+ * snapshot key under `sanctions-snapshots/<SOURCE>/` and reports 'ok'
+ * if a snapshot exists within the past 24h, 'stale' if older, and
+ * 'missing' if nothing is there. Never throws.
+ */
+async function probeCoverage(
+  now: Date
+): Promise<
+  Record<
+    'UN' | 'OFAC' | 'EU' | 'UK' | 'UAE' | 'EOCN',
+    { status: 'ok' | 'stale' | 'missing'; lastCheckedAt?: string; note?: string }
+  >
+> {
+  const sources = ['UN', 'OFAC', 'EU', 'UK', 'UAE', 'EOCN'] as const;
+  const store = getStore(SNAPSHOT_STORE);
+  const cutoffMs = now.getTime() - 24 * 60 * 60 * 1000;
+
+  const results: Record<
+    string,
+    { status: 'ok' | 'stale' | 'missing'; lastCheckedAt?: string; note?: string }
+  > = {};
+  for (const source of sources) {
+    try {
+      const listing = await store.list({ prefix: `${source}/` });
+      const blobs = (listing.blobs ?? []).slice().sort((a, b) => {
+        return a.key < b.key ? 1 : a.key > b.key ? -1 : 0;
+      });
+      const latest = blobs[0];
+      if (!latest) {
+        results[source] = { status: 'missing', note: 'no snapshot in store' };
+        continue;
+      }
+      // Keys look like "<SOURCE>/<YYYY-MM-DD>/<timestamp>.json" —
+      // the date prefix is enough to detect staleness without loading
+      // the blob body.
+      const dateSegment = latest.key.split('/')[1] ?? '';
+      const dateMs = Date.parse(dateSegment);
+      if (!Number.isFinite(dateMs)) {
+        results[source] = { status: 'stale', note: 'key format unrecognised' };
+        continue;
+      }
+      results[source] = {
+        status: dateMs >= cutoffMs ? 'ok' : 'stale',
+        lastCheckedAt: new Date(dateMs).toISOString(),
+      };
+    } catch (err) {
+      const note = err instanceof Error ? err.message : String(err);
+      results[source] = { status: 'missing', note };
+    }
+  }
+  return results as Record<
+    'UN' | 'OFAC' | 'EU' | 'UK' | 'UAE' | 'EOCN',
+    { status: 'ok' | 'stale' | 'missing'; lastCheckedAt?: string; note?: string }
+  >;
+}
+
+export default async (): Promise<Response> => {
+  const startedAt = new Date().toISOString();
+  const now = new Date(startedAt);
+
+  const { COMPANY_REGISTRY } = await import('../../src/domain/customers');
+  const { buildSanctionsWatchReport, renderSanctionsWatchMarkdown } =
+    await import('../../src/services/sanctionsWatchGenerator');
+
+  try {
+    const coverage = await probeCoverage(now);
+
+    const report = buildSanctionsWatchReport({
+      now,
+      portfolioSize: COMPANY_REGISTRY.length,
+      listCoverage: coverage,
+      hits: [],
+      frozenSubjects: [],
+      recentFalsePositives: [],
+    });
+
+    const markdown = renderSanctionsWatchMarkdown(report);
+    const key = `${startedAt.slice(0, 10)}/report.json`;
+    const store = getStore(REPORT_STORE);
+    await store.setJSON(key, {
+      generatedAt: startedAt,
+      report,
+      markdown,
+    });
+
+    await writeAudit({
+      event: 'sanctions_watch_report_generated',
+      reportKey: key,
+      portfolioSize: report.portfolioSize,
+      anyListMissing: report.anyListMissing,
+      missingSources: report.missingSources,
+      bandCounts: report.bandCounts,
+      freezeCount: report.freezeCountdowns.length,
+    });
+
+    const result: CronResult = {
+      ok: true,
+      startedAt,
+      reportKey: key,
+      anyListMissing: report.anyListMissing,
+    };
+    return Response.json(result);
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    await writeAudit({ event: 'sanctions_watch_report_failed', error });
+    return Response.json({ ok: false, startedAt, error }, { status: 500 });
+  }
+};
+
+export const config: Config = {
+  // Daily 05:00 UTC = 09:00 Asia/Dubai.
+  schedule: '0 5 * * *',
+};

--- a/src/services/sanctionsWatchGenerator.ts
+++ b/src/services/sanctionsWatchGenerator.ts
@@ -1,0 +1,457 @@
+/**
+ * Sanctions Watch Daily Report Generator.
+ *
+ * Produces the 09:00 Asia/Dubai daily snapshot consumed by the MLRO
+ * and by the Claude Code "Sanctions Watch" routine. Pure functions
+ * only: every input is passed explicitly so the report is deterministic
+ * and unit-testable.
+ *
+ * The report answers:
+ *   1. Were all six sanctions lists checked in the past 24 hours?
+ *      (UN, OFAC, EU, UK, UAE, EOCN — FDL Art.35, Cabinet Res 74/2020 Art.4)
+ *   2. What hits surfaced, bucketed by confidence (confirmed / likely /
+ *      potential / low)?
+ *   3. For subjects currently frozen, what is the EOCN 24h notification
+ *      countdown and the CNMR 5-business-day filing countdown?
+ *   4. What false positives were resolved in the past 24h (for audit
+ *      transparency, not as a tipping-off channel)?
+ *
+ * The generator does NOT re-run screening. Screening is already handled
+ * by netlify/functions/sanctions-delta-screen-cron.mts (every 4h). This
+ * module only assembles an MLRO-facing view over the hits that store
+ * has already produced.
+ *
+ * Regulatory basis:
+ *   - FDL No.10/2025 Art.20-22 (CO duty of care, reasoned decision)
+ *   - FDL No.10/2025 Art.24 (10yr retention, audit trail)
+ *   - FDL No.10/2025 Art.29 (no tipping off — report is internal only)
+ *   - FDL No.10/2025 Art.35 (TFS sanctions completeness)
+ *   - Cabinet Res 74/2020 Art.4-7 (freeze without delay, 24h EOCN,
+ *     5 business days CNMR)
+ *   - FATF Rec 6 (UN sanctions screening completeness)
+ *   - FATF Rec 20 (continuous monitoring)
+ *   - MoE Circular 08/AML/2021 (DPMS sector screening cadence)
+ */
+
+import type { DeltaScreenHit, DeltaHitConfidence } from './sanctionsDeltaCohortScreener';
+import { checkEOCNDeadline, checkDeadline } from '../utils/businessDays';
+import { formatDateDDMMYYYY } from '../utils/dates';
+import { CNMR_FILING_DEADLINE_BUSINESS_DAYS } from '../domain/constants';
+
+// ─── Fixed list of lists the UAE TFS framework requires ────────────────────
+
+/**
+ * The six sanctions sources every DPMS must screen against every day.
+ * If any one of these is missing from the coverage map, the report
+ * raises a loud alert. Never skip a list — CLAUDE.md rule.
+ */
+export const REQUIRED_SOURCES = ['UN', 'OFAC', 'EU', 'UK', 'UAE', 'EOCN'] as const;
+export type RequiredSource = (typeof REQUIRED_SOURCES)[number];
+
+export type ListHealthStatus = 'ok' | 'stale' | 'missing';
+
+export interface ListCoverageEntry {
+  source: RequiredSource;
+  status: ListHealthStatus;
+  /** ISO timestamp of the last successful ingest for this source. */
+  lastCheckedAt?: string;
+  /** Optional explanation — e.g. "parser failed", "feed unavailable". */
+  note?: string;
+}
+
+// ─── Frozen-subject countdown input ─────────────────────────────────────────
+
+/**
+ * A subject whose sanctions match has been confirmed and who is therefore
+ * under an active freeze (Cabinet Res 74/2020 Art.4). For each one the
+ * Watch surfaces both countdowns:
+ *   - EOCN 24-hour notification clock (hours remaining)
+ *   - CNMR 5-business-day filing deadline (business days remaining)
+ */
+export interface FrozenSubjectInput {
+  subjectId: string;
+  subjectName: string;
+  /** Which sanctions source the freeze was triggered by. */
+  matchedSource: RequiredSource;
+  /** ISO timestamp when the match was confirmed. Drives both countdowns. */
+  matchConfirmedAt: string;
+  /** True if the EOCN notification has already been filed. */
+  eocnNotified?: boolean;
+  /** True if the CNMR has already been filed to the FIU. */
+  cnmrFiled?: boolean;
+}
+
+// ─── Recent false positives ─────────────────────────────────────────────────
+
+/**
+ * A previously-matched subject whose hit was dismissed as a false
+ * positive within the 24h window. Surfaced for audit transparency; the
+ * report is internal only and never reveals the dismissal to the subject
+ * (FDL Art.29 — no tipping off).
+ */
+export interface ResolvedFalsePositiveInput {
+  subjectId: string;
+  matchedAgainst: string;
+  resolvedAt: string;
+  resolvedBy: string;
+  reason: string;
+}
+
+// ─── Report types ───────────────────────────────────────────────────────────
+
+export interface SanctionsWatchInput {
+  now: Date;
+  portfolioSize: number;
+  /** Health of each of the six required lists. Must include all 6 keys. */
+  listCoverage: Readonly<Record<RequiredSource, Omit<ListCoverageEntry, 'source'>>>;
+  /** Hits emitted by the delta cohort screener in the past 24h. */
+  hits: ReadonlyArray<DeltaScreenHit>;
+  /** Currently frozen subjects awaiting EOCN notification / CNMR filing. */
+  frozenSubjects: ReadonlyArray<FrozenSubjectInput>;
+  /** False positives resolved in the past 24h. */
+  recentFalsePositives: ReadonlyArray<ResolvedFalsePositiveInput>;
+}
+
+export interface BandCounts {
+  confirmed: number;
+  likely: number;
+  potential: number;
+  low: number;
+}
+
+export interface HitView {
+  customerId: string;
+  matchedName: string;
+  source: RequiredSource;
+  matchReasons: ReadonlyArray<string>;
+  matchScore: number;
+  confidence: DeltaHitConfidence;
+  recommendedAction: DeltaScreenHit['recommendedAction'];
+}
+
+export interface FreezeCountdownView {
+  subjectId: string;
+  subjectName: string;
+  matchedSource: RequiredSource;
+  matchConfirmedAt: string;
+  /** Hours remaining on the EOCN 24h notification clock. 0 if breached. */
+  eocnHoursRemaining: number;
+  eocnBreached: boolean;
+  eocnNotified: boolean;
+  /** Business days remaining on the CNMR 5-BD filing clock. 0 if breached. */
+  cnmrBusinessDaysRemaining: number;
+  cnmrBreached: boolean;
+  cnmrFiled: boolean;
+}
+
+export interface FalsePositiveView {
+  subjectId: string;
+  matchedAgainst: string;
+  resolvedAt: string;
+  resolvedBy: string;
+  reason: string;
+}
+
+export interface SanctionsWatchReport {
+  generatedAtIso: string;
+  windowFromIso: string;
+  windowToIso: string;
+  portfolioSize: number;
+  listCoverage: ReadonlyArray<ListCoverageEntry>;
+  anyListMissing: boolean;
+  missingSources: ReadonlyArray<RequiredSource>;
+  bandCounts: BandCounts;
+  confirmedHits: ReadonlyArray<HitView>;
+  likelyHits: ReadonlyArray<HitView>;
+  potentialHits: ReadonlyArray<HitView>;
+  lowHits: ReadonlyArray<HitView>;
+  freezeCountdowns: ReadonlyArray<FreezeCountdownView>;
+  recentFalsePositives: ReadonlyArray<FalsePositiveView>;
+  citations: ReadonlyArray<string>;
+}
+
+// ─── Builder ────────────────────────────────────────────────────────────────
+
+const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+
+function narrowSource(input: string): RequiredSource | null {
+  return (REQUIRED_SOURCES as ReadonlyArray<string>).includes(input)
+    ? (input as RequiredSource)
+    : null;
+}
+
+function toHitView(hit: DeltaScreenHit): HitView {
+  const source = narrowSource(hit.matchedAgainst.source) ?? 'UN';
+  return {
+    customerId: hit.customerId,
+    matchedName: hit.matchedAgainst.name,
+    source,
+    matchReasons: hit.matchReasons,
+    matchScore: hit.matchScore,
+    confidence: hit.confidence,
+    recommendedAction: hit.recommendedAction,
+  };
+}
+
+export function buildSanctionsWatchReport(input: SanctionsWatchInput): SanctionsWatchReport {
+  const { now, portfolioSize, listCoverage, hits, frozenSubjects, recentFalsePositives } = input;
+  const windowFromIso = new Date(now.getTime() - TWENTY_FOUR_HOURS_MS).toISOString();
+  const windowToIso = now.toISOString();
+
+  // 1) List coverage — verify all six required sources are present.
+  const coverage: ListCoverageEntry[] = REQUIRED_SOURCES.map((source) => {
+    const entry = listCoverage[source];
+    return {
+      source,
+      status: entry?.status ?? 'missing',
+      lastCheckedAt: entry?.lastCheckedAt,
+      note: entry?.note,
+    };
+  });
+  const missingSources = coverage.filter((c) => c.status !== 'ok').map((c) => c.source);
+  const anyListMissing = missingSources.length > 0;
+
+  // 2) Hit bucketing by confidence band. Sort each bucket by score desc.
+  const confirmedHits: HitView[] = [];
+  const likelyHits: HitView[] = [];
+  const potentialHits: HitView[] = [];
+  const lowHits: HitView[] = [];
+  for (const h of hits) {
+    const view = toHitView(h);
+    if (h.confidence === 'confirmed') confirmedHits.push(view);
+    else if (h.confidence === 'likely') likelyHits.push(view);
+    else if (h.confidence === 'potential') potentialHits.push(view);
+    else lowHits.push(view);
+  }
+  const scoreDesc = (a: HitView, b: HitView) => b.matchScore - a.matchScore;
+  confirmedHits.sort(scoreDesc);
+  likelyHits.sort(scoreDesc);
+  potentialHits.sort(scoreDesc);
+  lowHits.sort(scoreDesc);
+
+  const bandCounts: BandCounts = {
+    confirmed: confirmedHits.length,
+    likely: likelyHits.length,
+    potential: potentialHits.length,
+    low: lowHits.length,
+  };
+
+  // 3) Freeze countdowns — EOCN 24h + CNMR 5BD per frozen subject.
+  const freezeCountdowns: FreezeCountdownView[] = frozenSubjects.map((s) => {
+    const confirmedAt = new Date(s.matchConfirmedAt);
+    const eocn = checkEOCNDeadline(confirmedAt, now);
+    const cnmr = checkDeadline(confirmedAt, CNMR_FILING_DEADLINE_BUSINESS_DAYS, now);
+    return {
+      subjectId: s.subjectId,
+      subjectName: s.subjectName,
+      matchedSource: s.matchedSource,
+      matchConfirmedAt: s.matchConfirmedAt,
+      eocnHoursRemaining: eocn.hoursRemaining,
+      eocnBreached: eocn.breached,
+      eocnNotified: s.eocnNotified ?? false,
+      cnmrBusinessDaysRemaining: cnmr.businessDaysRemaining,
+      cnmrBreached: cnmr.breached,
+      cnmrFiled: s.cnmrFiled ?? false,
+    };
+  });
+  // Most urgent first: breached → least remaining time.
+  freezeCountdowns.sort((a, b) => {
+    if (a.eocnBreached !== b.eocnBreached) return a.eocnBreached ? -1 : 1;
+    return a.eocnHoursRemaining - b.eocnHoursRemaining;
+  });
+
+  // 4) Recent false positives — pass through with window filter.
+  const windowFromMs = Date.parse(windowFromIso);
+  const falsePositives: FalsePositiveView[] = recentFalsePositives
+    .filter((fp) => {
+      const t = Date.parse(fp.resolvedAt);
+      return Number.isFinite(t) && t >= windowFromMs;
+    })
+    .map((fp) => ({
+      subjectId: fp.subjectId,
+      matchedAgainst: fp.matchedAgainst,
+      resolvedAt: fp.resolvedAt,
+      resolvedBy: fp.resolvedBy,
+      reason: fp.reason,
+    }))
+    .sort((a, b) => b.resolvedAt.localeCompare(a.resolvedAt));
+
+  return {
+    generatedAtIso: windowToIso,
+    windowFromIso,
+    windowToIso,
+    portfolioSize,
+    listCoverage: coverage,
+    anyListMissing,
+    missingSources,
+    bandCounts,
+    confirmedHits,
+    likelyHits,
+    potentialHits,
+    lowHits,
+    freezeCountdowns,
+    recentFalsePositives: falsePositives,
+    citations: [
+      'FDL No.10/2025 Art.20-22 (CO duty of care, reasoned decision)',
+      'FDL No.10/2025 Art.24 (record retention, audit trail)',
+      'FDL No.10/2025 Art.29 (no tipping off — internal report only)',
+      'FDL No.10/2025 Art.35 (TFS sanctions completeness)',
+      'Cabinet Res 74/2020 Art.4-7 (freeze without delay, 24h EOCN, 5BD CNMR)',
+      'FATF Rec 6 (UN sanctions screening completeness)',
+      'FATF Rec 20 (continuous monitoring)',
+      'MoE Circular 08/AML/2021 (DPMS sector screening cadence)',
+    ],
+  };
+}
+
+// ─── Markdown renderer ─────────────────────────────────────────────────────
+
+function renderCoverageTable(entries: ReadonlyArray<ListCoverageEntry>): string[] {
+  const out: string[] = [];
+  out.push('| Source | Status | Last ingest | Note |');
+  out.push('| --- | --- | --- | --- |');
+  for (const e of entries) {
+    const stamp = e.lastCheckedAt ? formatDateDDMMYYYY(e.lastCheckedAt) : '—';
+    out.push(
+      `| ${e.source} | ${e.status === 'ok' ? 'OK' : e.status.toUpperCase()} | ${stamp} | ${e.note ?? ''} |`
+    );
+  }
+  return out;
+}
+
+function renderHitRows(hits: ReadonlyArray<HitView>): string[] {
+  const out: string[] = [];
+  out.push('| Customer | Matched name | List | Reasons | Score | Recommended action |');
+  out.push('| --- | --- | --- | --- | ---: | --- |');
+  for (const h of hits) {
+    out.push(
+      `| ${h.customerId} | ${h.matchedName} | ${h.source} | ${h.matchReasons.join(', ')} | ${h.matchScore.toFixed(2)} | ${h.recommendedAction} |`
+    );
+  }
+  return out;
+}
+
+/**
+ * Render the watch report as markdown. Compliance carve-out applies —
+ * regulatory content stays verbose even when token-efficiency rules
+ * trim prose elsewhere (see CLAUDE.md).
+ */
+export function renderSanctionsWatchMarkdown(report: SanctionsWatchReport): string {
+  const fromDisplay = formatDateDDMMYYYY(report.windowFromIso);
+  const toDisplay = formatDateDDMMYYYY(report.windowToIso);
+  const lines: string[] = [];
+
+  lines.push('# Sanctions Watch — Daily Report');
+  lines.push('');
+  lines.push(`Window: ${fromDisplay} to ${toDisplay}`);
+  lines.push(`Generated: ${formatDateDDMMYYYY(report.generatedAtIso)}`);
+  lines.push(`Portfolio size: ${report.portfolioSize}`);
+  lines.push('');
+
+  // 1) List coverage. Loud alert if any required list is missing.
+  lines.push('## 1. List coverage (FDL Art.35, Cabinet Res 74/2020 Art.4)');
+  lines.push('');
+  if (report.anyListMissing) {
+    lines.push(
+      `**ALERT: ${report.missingSources.length} required source(s) missing or stale: ${report.missingSources.join(', ')}.**`
+    );
+    lines.push(
+      'Cabinet Res 74/2020 Art.4 and FATF Rec 6 require every UAE DPMS to screen against all six sources daily. Investigate the ingest pipeline before closing this report.'
+    );
+    lines.push('');
+  } else {
+    lines.push('All six required sources ingested in the past 24 hours.');
+    lines.push('');
+  }
+  lines.push(...renderCoverageTable(report.listCoverage));
+  lines.push('');
+
+  // 2) Hits by confidence band.
+  lines.push('## 2. Hits by confidence band');
+  lines.push('');
+  lines.push('| Band | Count | Recommended path |');
+  lines.push('| --- | ---: | --- |');
+  lines.push(
+    `| Confirmed | ${report.bandCounts.confirmed} | freeze_immediately (Cabinet Res 74/2020 Art.4) |`
+  );
+  lines.push(`| Likely | ${report.bandCounts.likely} | gate_for_co_review (four-eyes) |`);
+  lines.push(`| Potential | ${report.bandCounts.potential} | escalate_for_review (CO decides) |`);
+  lines.push(`| Low | ${report.bandCounts.low} | log + dismiss with reasoning |`);
+  lines.push('');
+
+  if (report.confirmedHits.length > 0) {
+    lines.push('### Confirmed hits');
+    lines.push('');
+    lines.push(...renderHitRows(report.confirmedHits));
+    lines.push('');
+  }
+  if (report.likelyHits.length > 0) {
+    lines.push('### Likely hits');
+    lines.push('');
+    lines.push(...renderHitRows(report.likelyHits));
+    lines.push('');
+  }
+  if (report.potentialHits.length > 0) {
+    lines.push('### Potential hits');
+    lines.push('');
+    lines.push(...renderHitRows(report.potentialHits));
+    lines.push('');
+  }
+  if (
+    report.confirmedHits.length === 0 &&
+    report.likelyHits.length === 0 &&
+    report.potentialHits.length === 0
+  ) {
+    lines.push('No confirmed, likely, or potential hits in the past 24 hours.');
+    lines.push('');
+  }
+
+  // 3) Freeze countdowns.
+  lines.push('## 3. Active freeze countdowns (Cabinet Res 74/2020 Art.4-7)');
+  lines.push('');
+  if (report.freezeCountdowns.length === 0) {
+    lines.push('No subjects currently under active freeze.');
+  } else {
+    lines.push(
+      '| Subject | List | Confirmed at | EOCN 24h remaining | EOCN notified | CNMR 5BD remaining | CNMR filed |'
+    );
+    lines.push('| --- | --- | --- | ---: | :---: | ---: | :---: |');
+    for (const f of report.freezeCountdowns) {
+      const eocnCell = f.eocnBreached ? 'BREACHED' : `${f.eocnHoursRemaining.toFixed(1)} h`;
+      const cnmrCell = f.cnmrBreached ? 'BREACHED' : `${f.cnmrBusinessDaysRemaining} BD`;
+      lines.push(
+        `| ${f.subjectName} | ${f.matchedSource} | ${formatDateDDMMYYYY(f.matchConfirmedAt)} | ${eocnCell} | ${f.eocnNotified ? 'yes' : 'NO'} | ${cnmrCell} | ${f.cnmrFiled ? 'yes' : 'NO'} |`
+      );
+    }
+  }
+  lines.push('');
+
+  // 4) Recent false positives.
+  lines.push('## 4. False positives resolved in the past 24 hours');
+  lines.push('');
+  if (report.recentFalsePositives.length === 0) {
+    lines.push('No false positives resolved in the past 24 hours.');
+  } else {
+    lines.push('| Subject | Matched against | Resolved at | Resolved by | Reason |');
+    lines.push('| --- | --- | --- | --- | --- |');
+    for (const fp of report.recentFalsePositives) {
+      lines.push(
+        `| ${fp.subjectId} | ${fp.matchedAgainst} | ${formatDateDDMMYYYY(fp.resolvedAt)} | ${fp.resolvedBy} | ${fp.reason} |`
+      );
+    }
+  }
+  lines.push('');
+
+  lines.push('## Regulatory basis');
+  lines.push('');
+  for (const c of report.citations) {
+    lines.push(`- ${c}`);
+  }
+  lines.push('');
+  lines.push(
+    'This report is internal to the Compliance Officer and Senior Management. It must not be shared with any subject of a match, freeze, or dismissal listed above (FDL No.10/2025 Art.29 — no tipping off).'
+  );
+  lines.push('');
+
+  return lines.join('\n');
+}

--- a/src/services/scheduledComplianceReports.ts
+++ b/src/services/scheduledComplianceReports.ts
@@ -60,6 +60,17 @@ export const SCHEDULED_REPORTS: readonly ScheduledReportDefinition[] = [
     dispatchTo: 'compliance_project',
   },
   {
+    id: 'daily_sanctions_watch',
+    name: 'Sanctions Watch Daily Report',
+    cadence: 'daily',
+    purpose:
+      'Daily 09:00 Dubai MLRO snapshot: six-list coverage check, hits by confidence band, active freeze countdowns (EOCN 24h + CNMR 5BD), and false positives resolved in the past 24 hours',
+    citation:
+      'FDL No.10/2025 Art.20-22, Art.24, Art.29, Art.35; Cabinet Res 74/2020 Art.4-7; FATF Rec 6, Rec 20; MoE Circular 08/AML/2021',
+    outputs: ['markdown', 'json'],
+    dispatchTo: 'mlro',
+  },
+  {
     id: 'weekly_sla_rollup',
     name: 'Weekly SLA rollup',
     cadence: 'weekly',

--- a/tests/sanctionsWatchGenerator.test.ts
+++ b/tests/sanctionsWatchGenerator.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Sanctions Watch Daily Report — unit tests.
+ *
+ * Covers:
+ *   - All six required sources must appear in coverage, missing ones
+ *     trigger a loud ALERT (FDL Art.35, Cabinet Res 74/2020 Art.4).
+ *   - Hits are bucketed correctly by DeltaHitConfidence band.
+ *   - Confirmed hits land in the confirmed bucket with freeze recommendation.
+ *   - Freeze countdowns compute EOCN 24h remaining and CNMR 5BD remaining,
+ *     and breached freezes sort ahead of active ones.
+ *   - False positives outside the 24h window are excluded.
+ *   - Markdown cites regulations and includes the no-tipping-off warning.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type {
+  DeltaScreenHit,
+  DeltaHitConfidence,
+} from '../src/services/sanctionsDeltaCohortScreener';
+import type { SanctionsEntry } from '../src/services/sanctionsDelta';
+import {
+  buildSanctionsWatchReport,
+  renderSanctionsWatchMarkdown,
+  REQUIRED_SOURCES,
+  type RequiredSource,
+  type FrozenSubjectInput,
+  type ResolvedFalsePositiveInput,
+  type ListHealthStatus,
+} from '../src/services/sanctionsWatchGenerator';
+
+const NOW = new Date('2026-04-16T05:00:00.000Z'); // 09:00 Dubai
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+function fullyCovered(): Record<
+  RequiredSource,
+  { status: ListHealthStatus; lastCheckedAt?: string; note?: string }
+> {
+  const stampIso = new Date(NOW.getTime() - 2 * HOUR_MS).toISOString();
+  return {
+    UN: { status: 'ok', lastCheckedAt: stampIso },
+    OFAC: { status: 'ok', lastCheckedAt: stampIso },
+    EU: { status: 'ok', lastCheckedAt: stampIso },
+    UK: { status: 'ok', lastCheckedAt: stampIso },
+    UAE: { status: 'ok', lastCheckedAt: stampIso },
+    EOCN: { status: 'ok', lastCheckedAt: stampIso },
+  };
+}
+
+function sanctionsEntry(name: string, source: SanctionsEntry['source']): SanctionsEntry {
+  return { id: `${source}-${name}`, name, source };
+}
+
+function hit(
+  customerId: string,
+  matchedName: string,
+  source: SanctionsEntry['source'],
+  confidence: DeltaHitConfidence,
+  matchScore: number
+): DeltaScreenHit {
+  const action: DeltaScreenHit['recommendedAction'] =
+    matchScore >= 0.9
+      ? 'freeze_immediately'
+      : matchScore >= 0.8
+        ? 'gate_for_co_review'
+        : 'escalate_for_review';
+  return {
+    customerId,
+    tenantId: 'tenant-1',
+    matchedAgainst: sanctionsEntry(matchedName, source),
+    matchReasons: ['name'],
+    matchScore,
+    confidence,
+    recommendedAction: action,
+    regulatory: ['FDL No.10/2025 Art.35'],
+  };
+}
+
+describe('REQUIRED_SOURCES', () => {
+  it('exposes the six UAE TFS sources in the canonical order', () => {
+    expect([...REQUIRED_SOURCES]).toEqual(['UN', 'OFAC', 'EU', 'UK', 'UAE', 'EOCN']);
+  });
+});
+
+describe('buildSanctionsWatchReport — list coverage', () => {
+  it('flags missing lists when any of the six required sources is absent', () => {
+    const coverage = fullyCovered();
+    coverage.EOCN = { status: 'missing' };
+    coverage.UK = { status: 'stale', note: 'feed timeout' };
+
+    const report = buildSanctionsWatchReport({
+      now: NOW,
+      portfolioSize: 42,
+      listCoverage: coverage,
+      hits: [],
+      frozenSubjects: [],
+      recentFalsePositives: [],
+    });
+
+    expect(report.anyListMissing).toBe(true);
+    expect(report.missingSources.sort()).toEqual(['EOCN', 'UK']);
+    expect(report.listCoverage).toHaveLength(6);
+  });
+
+  it('reports clear coverage when all six sources are ok', () => {
+    const report = buildSanctionsWatchReport({
+      now: NOW,
+      portfolioSize: 42,
+      listCoverage: fullyCovered(),
+      hits: [],
+      frozenSubjects: [],
+      recentFalsePositives: [],
+    });
+    expect(report.anyListMissing).toBe(false);
+    expect(report.missingSources).toEqual([]);
+  });
+});
+
+describe('buildSanctionsWatchReport — hit bucketing', () => {
+  it('partitions hits by DeltaHitConfidence band and sorts by score desc', () => {
+    const hits: DeltaScreenHit[] = [
+      hit('c-1', 'John Smith', 'OFAC', 'confirmed', 0.99),
+      hit('c-2', 'John Smyth', 'OFAC', 'likely', 0.85),
+      hit('c-3', 'John S', 'OFAC', 'potential', 0.55),
+      hit('c-4', 'J Smith', 'OFAC', 'confirmed', 0.95),
+      hit('c-5', 'Smithy', 'UN', 'low', 0.45),
+    ];
+
+    const report = buildSanctionsWatchReport({
+      now: NOW,
+      portfolioSize: 100,
+      listCoverage: fullyCovered(),
+      hits,
+      frozenSubjects: [],
+      recentFalsePositives: [],
+    });
+
+    expect(report.bandCounts).toEqual({
+      confirmed: 2,
+      likely: 1,
+      potential: 1,
+      low: 1,
+    });
+    expect(report.confirmedHits.map((h) => h.customerId)).toEqual(['c-1', 'c-4']);
+    expect(report.confirmedHits[0].recommendedAction).toBe('freeze_immediately');
+    expect(report.likelyHits[0].recommendedAction).toBe('gate_for_co_review');
+    expect(report.potentialHits[0].recommendedAction).toBe('escalate_for_review');
+  });
+});
+
+describe('buildSanctionsWatchReport — freeze countdowns', () => {
+  it('computes EOCN 24h remaining and CNMR 5BD remaining for each frozen subject', () => {
+    const twoHoursAgoIso = new Date(NOW.getTime() - 2 * HOUR_MS).toISOString();
+    const thirtyHoursAgoIso = new Date(NOW.getTime() - 30 * HOUR_MS).toISOString();
+
+    const frozen: FrozenSubjectInput[] = [
+      {
+        subjectId: 'freeze-fresh',
+        subjectName: 'Acme BV',
+        matchedSource: 'OFAC',
+        matchConfirmedAt: twoHoursAgoIso,
+      },
+      {
+        subjectId: 'freeze-breached',
+        subjectName: 'Stale Co',
+        matchedSource: 'UN',
+        matchConfirmedAt: thirtyHoursAgoIso,
+        eocnNotified: true,
+      },
+    ];
+
+    const report = buildSanctionsWatchReport({
+      now: NOW,
+      portfolioSize: 2,
+      listCoverage: fullyCovered(),
+      hits: [],
+      frozenSubjects: frozen,
+      recentFalsePositives: [],
+    });
+
+    expect(report.freezeCountdowns).toHaveLength(2);
+    // Breached EOCN sorts first.
+    expect(report.freezeCountdowns[0].subjectId).toBe('freeze-breached');
+    expect(report.freezeCountdowns[0].eocnBreached).toBe(true);
+    expect(report.freezeCountdowns[0].eocnNotified).toBe(true);
+
+    expect(report.freezeCountdowns[1].subjectId).toBe('freeze-fresh');
+    expect(report.freezeCountdowns[1].eocnBreached).toBe(false);
+    // ~22 hours remaining, allow rounding.
+    expect(report.freezeCountdowns[1].eocnHoursRemaining).toBeGreaterThan(21);
+    expect(report.freezeCountdowns[1].eocnHoursRemaining).toBeLessThanOrEqual(22);
+    // CNMR has 5 business days budget.
+    expect(report.freezeCountdowns[1].cnmrBusinessDaysRemaining).toBeGreaterThan(0);
+    expect(report.freezeCountdowns[1].cnmrFiled).toBe(false);
+  });
+});
+
+describe('buildSanctionsWatchReport — recent false positives', () => {
+  it('includes only false positives resolved within the past 24 hours', () => {
+    const eightHoursAgoIso = new Date(NOW.getTime() - 8 * HOUR_MS).toISOString();
+    const threeDaysAgoIso = new Date(NOW.getTime() - 3 * DAY_MS).toISOString();
+
+    const fps: ResolvedFalsePositiveInput[] = [
+      {
+        subjectId: 'c-recent',
+        matchedAgainst: 'Name Collision Ltd',
+        resolvedAt: eightHoursAgoIso,
+        resolvedBy: 'analyst.a',
+        reason: 'different DOB and nationality',
+      },
+      {
+        subjectId: 'c-old',
+        matchedAgainst: 'Other Co',
+        resolvedAt: threeDaysAgoIso,
+        resolvedBy: 'analyst.a',
+        reason: 'out of window',
+      },
+    ];
+
+    const report = buildSanctionsWatchReport({
+      now: NOW,
+      portfolioSize: 10,
+      listCoverage: fullyCovered(),
+      hits: [],
+      frozenSubjects: [],
+      recentFalsePositives: fps,
+    });
+
+    expect(report.recentFalsePositives.map((f) => f.subjectId)).toEqual(['c-recent']);
+  });
+});
+
+describe('renderSanctionsWatchMarkdown', () => {
+  it('renders all sections, cites regulations, and includes no-tipping-off warning', () => {
+    const report = buildSanctionsWatchReport({
+      now: NOW,
+      portfolioSize: 5,
+      listCoverage: fullyCovered(),
+      hits: [],
+      frozenSubjects: [],
+      recentFalsePositives: [],
+    });
+    const md = renderSanctionsWatchMarkdown(report);
+
+    expect(md).toContain('# Sanctions Watch — Daily Report');
+    expect(md).toContain('## 1. List coverage (FDL Art.35, Cabinet Res 74/2020 Art.4)');
+    expect(md).toContain('## 2. Hits by confidence band');
+    expect(md).toContain('## 3. Active freeze countdowns (Cabinet Res 74/2020 Art.4-7)');
+    expect(md).toContain('## 4. False positives resolved in the past 24 hours');
+    expect(md).toContain('## Regulatory basis');
+    expect(md).toContain('All six required sources ingested in the past 24 hours.');
+    expect(md).toContain('FDL No.10/2025 Art.29');
+    expect(md).toContain('It must not be shared with any subject of a match, freeze, or dismissal');
+  });
+
+  it('surfaces the ALERT banner when any required list is missing', () => {
+    const coverage = fullyCovered();
+    coverage.EOCN = { status: 'missing', note: 'feed unavailable' };
+
+    const report = buildSanctionsWatchReport({
+      now: NOW,
+      portfolioSize: 5,
+      listCoverage: coverage,
+      hits: [],
+      frozenSubjects: [],
+      recentFalsePositives: [],
+    });
+    const md = renderSanctionsWatchMarkdown(report);
+
+    expect(md).toContain('ALERT: 1 required source(s) missing or stale: EOCN');
+    expect(md).toContain(
+      'Cabinet Res 74/2020 Art.4 and FATF Rec 6 require every UAE DPMS to screen against all six sources daily.'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Feeds the Claude Code **Sanctions Watch** routine (daily 09:00 Asia/Dubai). This is Routine #2 from the MLRO briefing set — the highest-stakes one, since false negatives are a regulatory breach under Cabinet Res 74/2020 Art.4. Companion to #140 (Weekly CDD Status Report).

The report does NOT re-run screening. The existing `sanctions-delta-screen-cron.mts` handles that every 4 hours. This cron aggregates an MLRO-facing view over the hits those stores already produce.

The report answers:

1. **List coverage (FDL Art.35, Cabinet Res 74/2020 Art.4).** Were all six required sources ingested in the past 24h — UN, OFAC, EU, UK, UAE, EOCN? Missing or stale sources trigger a loud ALERT banner. Never skip a list (CLAUDE.md rule).
2. **Hits by confidence band.** Confirmed / likely / potential / low, each with the recommended `freeze_immediately` / `gate_for_co_review` / `escalate_for_review` action mapped from `DeltaHitConfidence`.
3. **Active freeze countdowns.** For each currently-frozen subject: EOCN 24-hour notification remaining (via `checkEOCNDeadline`) and CNMR 5-business-day filing remaining (via `checkDeadline` + `CNMR_FILING_DEADLINE_BUSINESS_DAYS`). Breached freezes sort first.
4. **Recent false positives.** Dismissals in the past 24h, surfaced for audit transparency only.

**No tipping off** (FDL Art.29) — the report is internal to the MLRO and ends with an explicit warning against sharing any subject, freeze, or dismissal with the customer.

## Changes

- **`src/services/sanctionsWatchGenerator.ts`** — pure builder + markdown renderer. Exports `REQUIRED_SOURCES` so every consumer operates on the same six-source truth. Reuses `DeltaScreenHit` from `sanctionsDeltaCohortScreener`, deadline utilities from `businessDays.ts`, and the CNMR constant from `domain/constants.ts`. No hardcoded thresholds.
- **`src/services/scheduledComplianceReports.ts`** — registers `daily_sanctions_watch` alongside `daily_screening_heartbeat`.
- **`tests/sanctionsWatchGenerator.test.ts`** — 8 specs covering the required-sources set, missing-list alerts, hit bucketing, freeze countdown sorting (breached first), false-positive windowing, and markdown output.
- **`netlify/functions/sanctions-watch-cron.mts`** — daily 05:00 UTC = 09:00 Dubai. Probes the `sanctions-snapshots` blob store for per-source freshness. For v1, `hits` / `frozenSubjects` / `recentFalsePositives` pass empty — the generator tolerates this, the list-coverage alert path still runs. Wiring those from their respective audit stores is an intentional follow-up.

## Regulatory basis

- FDL No.10/2025 Art.20-22 (CO duty of care, reasoned decision)
- FDL No.10/2025 Art.24 (record retention, audit trail)
- FDL No.10/2025 Art.29 (no tipping off)
- FDL No.10/2025 Art.35 (TFS sanctions completeness)
- Cabinet Res 74/2020 Art.4-7 (freeze, 24h EOCN, 5BD CNMR)
- FATF Rec 6 (UN sanctions screening completeness)
- FATF Rec 20 (continuous monitoring)
- MoE Circular 08/AML/2021 (DPMS sector cadence)

## Test plan

- [x] `npx vitest run tests/sanctionsWatchGenerator.test.ts` — 8/8 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npx prettier --check` — all four new/modified files pass
- [ ] Manual: invoke `netlify/functions/sanctions-watch-cron.mts` on a preview deploy, confirm blob writes
- [ ] Follow-up PR: wire real hits / frozen subjects / dismissed false positives from their audit stores

https://claude.ai/code/session_01K4twBZwq6wDoyF8GptSNQx