### PR TITLE
Briefing routines — audit fixes (redundant condition, silent source fallback, env doc)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,6 +116,11 @@ ASANA_CF_MANUAL_ACTION_DONE=
 
 # Central MLRO triage project — receives a mirrored task for every
 # blocked / freeze / escalated case across all customer projects.
+# Also receives Asana status_updates from the three briefing crons
+# (morning-briefing, sanctions-watch, cdd-weekly-status) via
+# src/services/mlroAsanaDispatch.ts. If unset, the briefing crons
+# skip the Asana post and persist the report to the blob store only
+# — recommended for local dev.
 # Create manually in Asana, then paste the GID here.
 ASANA_CENTRAL_MLRO_PROJECT_GID=
 

--- a/src/services/morningBriefingGenerator.ts
+++ b/src/services/morningBriefingGenerator.ts
@@ -269,7 +269,12 @@ export function buildMorningBriefingReport(input: MorningBriefingInput): Morning
       });
       continue;
     }
-    if (f.status === 'pending' && isSameDate(check.deadlineDate, now) && !f.deadlineMet === false) {
+    // By this point, filings with `!f.deadlineMet` or `status === 'overdue'`
+    // have already been bucketed into `overdueFilings` and the loop
+    // continued. Any pending filing that reaches here has `deadlineMet`
+    // true, so the only remaining check is whether the deadline lands
+    // today.
+    if (f.status === 'pending' && isSameDate(check.deadlineDate, now)) {
       filingsDueToday.push({
         filingType: f.filingType,
         referenceNumber: f.referenceNumber,

--- a/src/services/sanctionsWatchGenerator.ts
+++ b/src/services/sanctionsWatchGenerator.ts
@@ -180,8 +180,17 @@ function narrowSource(input: string): RequiredSource | null {
     : null;
 }
 
-function toHitView(hit: DeltaScreenHit): HitView {
-  const source = narrowSource(hit.matchedAgainst.source) ?? 'UN';
+/**
+ * Convert a `DeltaScreenHit` to the MLRO-facing `HitView`. Returns
+ * `null` when the hit's source cannot be narrowed to one of the six
+ * REQUIRED_SOURCES — rather than silently mislabelling it as 'UN',
+ * drop it so data-quality drift surfaces as a missing row instead of
+ * a wrong one. In practice `SanctionsEntry.source` and `RequiredSource`
+ * share the same six members, so this branch is defensive only.
+ */
+function toHitView(hit: DeltaScreenHit): HitView | null {
+  const source = narrowSource(hit.matchedAgainst.source);
+  if (!source) return null;
   return {
     customerId: hit.customerId,
     matchedName: hit.matchedAgainst.name,
@@ -218,6 +227,7 @@ export function buildSanctionsWatchReport(input: SanctionsWatchInput): Sanctions
   const lowHits: HitView[] = [];
   for (const h of hits) {
     const view = toHitView(h);
+    if (!view) continue;
     if (h.confidence === 'confirmed') confirmedHits.push(view);
     else if (h.confidence === 'likely') likelyHits.push(view);
     else if (h.confidence === 'potential') potentialHits.push(view);


### PR DESCRIPTION
## Summary

Post-merge deep-review audit of the MLRO briefing feature (#140, #142, #143) turned up three cleanup items. This PR addresses them.

1. **`morningBriefingGenerator.ts`** — the filing-due-today check ended with `&& !f.deadlineMet === false`, which is logically `deadlineMet === true`. By the time execution reaches that line, the earlier branch has already bucketed `!f.deadlineMet` into `overdueFilings` and `continue`-d, so the clause was unreachable. Removed. Added a comment so the reasoning stays visible for future readers.
2. **`sanctionsWatchGenerator.ts`** — `toHitView` silently defaulted unrecognised sources to `'UN'` via `?? 'UN'`. `SanctionsEntry.source` and `RequiredSource` already share the same six members so the fallback was unreachable; the concern is that any future source drift would be masked. Changed `toHitView` to return `HitView | null` and the caller filters out nulls. Data-quality drift now surfaces as a missing row instead of a mislabelled one (FDL Art.35, Cabinet Res 74/2020 Art.4).
3. **`.env.example`** — expanded the `ASANA_CENTRAL_MLRO_PROJECT_GID` comment to name the three briefing crons that post status_updates and the graceful-no-op behaviour.

No happy-path behaviour change. 14/14 tests for the two affected generators still pass.

## Deferred (explicitly not in this PR)

**Pre-existing, separate concern**: `sanctions-ingest-cron.mts` does not write `sanctions-deltas/latest.json`. Both the pre-existing `sanctions-delta-screen-cron` and the new `sanctions-watch-cron` read that key and fall back to empty hits when it is absent. The runbook documents the key as if it were written. Fixing it requires a `NormalisedSanction → SanctionsEntry` merge step in the ingest cron — not a MLRO-briefing concern, to be done in a focused follow-up PR.

## Test plan

- [x] `npx vitest run tests/morningBriefingGenerator.test.ts tests/sanctionsWatchGenerator.test.ts` — 14/14 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx prettier --check` — clean on touched files

https://claude.ai/code/session_01K4twBZwq6wDoyF8GptSNQx