### PR TITLE
Fix sanctions-snapshot key-prefix mismatch (OFAC/UK false MISSING)

### DIFF
--- a/netlify/functions/morning-briefing-cron.mts
+++ b/netlify/functions/morning-briefing-cron.mts
@@ -74,6 +74,25 @@ type ProbeEntry = { status: ProbeStatus; lastCheckedAt?: string; note?: string }
 // briefing does not flag them as a daily regulatory failure.
 const MANUAL_ONLY_SOURCES = new Set<'UAE' | 'EOCN'>(['UAE', 'EOCN']);
 
+/**
+ * Map the six REQUIRED_SOURCES onto the ingest cron's key prefixes.
+ * OFAC covers both SDN and Consolidated feeds; UAE and EOCN both read
+ * from the single `UAE_EOCN` manual-upload slot. Keeping this in sync
+ * with sanctions-watch-cron.mts is required — the two crons must
+ * agree on what "OK" means per source.
+ */
+const INGEST_KEY_PREFIXES: Record<
+  'UN' | 'OFAC' | 'EU' | 'UK' | 'UAE' | 'EOCN',
+  ReadonlyArray<string>
+> = {
+  UN: ['UN/'],
+  OFAC: ['OFAC_SDN/', 'OFAC_CONS/'],
+  EU: ['EU/'],
+  UK: ['UK_OFSI/'],
+  UAE: ['UAE_EOCN/'],
+  EOCN: ['UAE_EOCN/'],
+};
+
 async function probeCoverage(
   now: Date
 ): Promise<Record<'UN' | 'OFAC' | 'EU' | 'UK' | 'UAE' | 'EOCN', ProbeEntry>> {
@@ -84,18 +103,20 @@ async function probeCoverage(
   for (const source of sources) {
     const manualOnly = MANUAL_ONLY_SOURCES.has(source as 'UAE' | 'EOCN');
     try {
-      const listing = await store.list({ prefix: `${source}/` });
-      const blobs = (listing.blobs ?? [])
-        .slice()
-        .sort((a, b) => (a.key < b.key ? 1 : a.key > b.key ? -1 : 0));
-      const latest = blobs[0];
-      if (!latest) {
+      let latestKey: string | undefined;
+      for (const prefix of INGEST_KEY_PREFIXES[source]) {
+        const listing = await store.list({ prefix });
+        for (const blob of listing.blobs ?? []) {
+          if (!latestKey || blob.key > latestKey) latestKey = blob.key;
+        }
+      }
+      if (!latestKey) {
         out[source] = manualOnly
           ? { status: 'manual-pending', note: 'awaiting manual upload' }
           : { status: 'missing', note: 'no snapshot in store' };
         continue;
       }
-      const dateSegment = latest.key.split('/')[1] ?? '';
+      const dateSegment = latestKey.split('/')[1] ?? '';
       const dateMs = Date.parse(dateSegment);
       if (!Number.isFinite(dateMs)) {
         out[source] = { status: 'stale', note: 'key format unrecognised' };

--- a/netlify/functions/sanctions-watch-cron.mts
+++ b/netlify/functions/sanctions-watch-cron.mts
@@ -80,6 +80,25 @@ type ProbeEntry = { status: ProbeStatus; lastCheckedAt?: string; note?: string }
 // If no snapshot exists they surface as `manual-pending`, not `missing`.
 const MANUAL_ONLY_SOURCES = new Set<'UAE' | 'EOCN'>(['UAE', 'EOCN']);
 
+/**
+ * Map the six REQUIRED_SOURCES (short names used in the MLRO briefing)
+ * onto the ingest cron's key prefixes (long names used in the
+ * `sanctions-snapshots` blob store). OFAC covers both SDN and
+ * Consolidated feeds; UAE and EOCN both read from the single
+ * `UAE_EOCN` manual-upload slot.
+ */
+const INGEST_KEY_PREFIXES: Record<
+  'UN' | 'OFAC' | 'EU' | 'UK' | 'UAE' | 'EOCN',
+  ReadonlyArray<string>
+> = {
+  UN: ['UN/'],
+  OFAC: ['OFAC_SDN/', 'OFAC_CONS/'],
+  EU: ['EU/'],
+  UK: ['UK_OFSI/'],
+  UAE: ['UAE_EOCN/'],
+  EOCN: ['UAE_EOCN/'],
+};
+
 async function probeCoverage(
   now: Date
 ): Promise<Record<'UN' | 'OFAC' | 'EU' | 'UK' | 'UAE' | 'EOCN', ProbeEntry>> {
@@ -91,21 +110,25 @@ async function probeCoverage(
   for (const source of sources) {
     const manualOnly = MANUAL_ONLY_SOURCES.has(source as 'UAE' | 'EOCN');
     try {
-      const listing = await store.list({ prefix: `${source}/` });
-      const blobs = (listing.blobs ?? []).slice().sort((a, b) => {
-        return a.key < b.key ? 1 : a.key > b.key ? -1 : 0;
-      });
-      const latest = blobs[0];
-      if (!latest) {
+      // Walk every ingest prefix for this source and keep the newest
+      // snapshot across them (OFAC has two underlying feeds).
+      let latestKey: string | undefined;
+      for (const prefix of INGEST_KEY_PREFIXES[source]) {
+        const listing = await store.list({ prefix });
+        for (const blob of listing.blobs ?? []) {
+          if (!latestKey || blob.key > latestKey) latestKey = blob.key;
+        }
+      }
+      if (!latestKey) {
         results[source] = manualOnly
           ? { status: 'manual-pending', note: 'awaiting manual upload' }
           : { status: 'missing', note: 'no snapshot in store' };
         continue;
       }
-      // Keys look like "<SOURCE>/<YYYY-MM-DD>/<timestamp>.json" —
-      // the date prefix is enough to detect staleness without loading
-      // the blob body.
-      const dateSegment = latest.key.split('/')[1] ?? '';
+      // Keys look like "<SOURCE>/<YYYY-MM-DD>/<filename>.json" — the
+      // date segment is enough to detect staleness without loading the
+      // blob body.
+      const dateSegment = latestKey.split('/')[1] ?? '';
       const dateMs = Date.parse(dateSegment);
       if (!Number.isFinite(dateMs)) {
         results[source] = { status: 'stale', note: 'key format unrecognised' };


### PR DESCRIPTION
## Root cause

The `/sanctions-ingest-status` diagnostic proved the ingest IS working: 103 runs, 103 successes, 0 failures across all six sources, with OFAC_SDN holding **18,732 records**. The Morning Briefing was still showing OFAC + UK as MISSING because the coverage probe looks for keys under the wrong prefixes.

| Briefing short name | Ingest actual key prefix | Matches? |
|---|---|---|
| `UN/` | `UN/...` | ✅ |
| `OFAC/` | `OFAC_SDN/...`, `OFAC_CONS/...` | ❌ |
| `EU/` | `EU/...` | ✅ |
| `UK/` | `UK_OFSI/...` | ❌ |
| `UAE/` | `UAE_EOCN/...` | ❌ |
| `EOCN/` | `UAE_EOCN/...` | ❌ |

`OFAC/` is NOT a prefix of `OFAC_SDN/...` — they diverge at character 5 (`/` vs `_`). So the probe always returned `missing`.

## Fix

Introduce `INGEST_KEY_PREFIXES` mapping in both crons:
- `OFAC` → checks both `OFAC_SDN/` and `OFAC_CONS/`, takes the newest
- `UK` → `UK_OFSI/`
- `UAE` → `UAE_EOCN/`
- `EOCN` → `UAE_EOCN/` (same manual-upload slot)

Pure generator unchanged.

## Separate concern — surfaced by the diagnostic

OFAC_CONS, EU, UK_OFSI, UAE_EOCN all report `fetched: 0` per run despite `ok: true`. Feeds fetch successfully but parsers return empty arrays. Likely upstream format drift in each feed — separate PR required, one parser at a time, against a live sample.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx prettier --check` — clean
- [ ] After deploy: `/morning-briefing-cron` should show OFAC as OK (because OFAC_SDN has 18k records) and UK as OK (UK_OFSI snapshot exists, just empty). UAE + EOCN remain MANUAL-PENDING.

https://claude.ai/code/session_01K4twBZwq6wDoyF8GptSNQx