### PR TITLE
Sanctions feed debug endpoint + EOCN manual upload endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,6 +129,19 @@ ASANA_CENTRAL_MLRO_PROJECT_GID=
 # Art.24 10-year retention guarantee outside localStorage.
 ASANA_AUDIT_LOG_PROJECT_GID=
 
+# ---------------------------------------------------------------------------
+# Sanctions manual-upload token
+# ---------------------------------------------------------------------------
+
+# Shared secret for the two sanctions operator endpoints:
+#   - POST /api/sanctions/eocn-upload      — manual UAE EOCN snapshot upload
+#   - GET  /api/sanctions/feed-debug       — raw upstream feed diagnosis
+# The upload endpoint REQUIRES this env var (writes are never unauth'd).
+# The feed-debug endpoint is unauth'd when this env var is absent —
+# set it in production to gate operator diagnostics behind the token.
+# Generate a strong random value (e.g. `openssl rand -hex 32`).
+SANCTIONS_UPLOAD_TOKEN=
+
 # Inspector evidence project — Tier-4 #14. Receives a sanitised
 # mirror of every compliance-action audit entry (freeze, escalate,
 # STR/SAR filing, four-eyes invocation, dispatch errors). PII,

--- a/netlify/functions/sanctions-eocn-upload.mts
+++ b/netlify/functions/sanctions-eocn-upload.mts
@@ -1,0 +1,206 @@
+/**
+ * EOCN / UAE Sanctions Manual Upload Endpoint.
+ *
+ * UAE EOCN distributes its sanctions list via PDF / XML circulars —
+ * there is no stable public URL that can be polled by the ingest cron.
+ * The MLRO is therefore expected to convert the latest EOCN circular
+ * into a normalised JSON payload and POST it here on the EOCN
+ * publication cadence.
+ *
+ * Once accepted, the snapshot is persisted under
+ * `sanctions-snapshots/UAE_EOCN/<YYYY-MM-DD>/snapshot.json` — exactly
+ * the path the ingest cron would use for an automated source — so
+ * both the sanctions-delta-screen cron and the MLRO briefings pick
+ * the upload up on their next run.
+ *
+ * Usage:
+ *   POST /api/sanctions/eocn-upload
+ *   Authorization: Bearer <SANCTIONS_UPLOAD_TOKEN>
+ *   Content-Type: application/json
+ *
+ *   Body: {
+ *     "circularDate": "2026-04-15",       // optional, defaults to today
+ *     "circularReference": "EOCN/2026/07", // optional, audit only
+ *     "entries": NormalisedSanction[]     // required
+ *   }
+ *
+ *   Each entry must have: source = 'UAE_EOCN', sourceId, primaryName,
+ *   aliases (array), type, programmes (array), hash.
+ *
+ * Regulatory basis:
+ *   - FDL No.10/2025 Art.24 (record retention — audit trail of every
+ *     upload)
+ *   - FDL No.10/2025 Art.35 (TFS sanctions completeness)
+ *   - Cabinet Res 74/2020 Art.4-7 (UAE-specific designations — the
+ *     domestic source this endpoint feeds)
+ */
+
+import type { Config } from '@netlify/functions';
+import { getStore } from '@netlify/blobs';
+
+const SNAPSHOT_STORE = 'sanctions-snapshots';
+const INGEST_AUDIT_STORE = 'sanctions-ingest-audit';
+
+interface NormalisedSanctionLike {
+  source: 'UAE_EOCN';
+  sourceId: string;
+  primaryName: string;
+  aliases?: ReadonlyArray<string>;
+  type?: 'individual' | 'entity' | 'vessel' | 'aircraft' | 'unknown';
+  dateOfBirth?: string;
+  nationality?: string;
+  programmes?: ReadonlyArray<string>;
+  remarks?: string;
+  hash?: string;
+}
+
+interface UploadBody {
+  circularDate?: string;
+  circularReference?: string;
+  entries: ReadonlyArray<NormalisedSanctionLike>;
+}
+
+function isAuthorised(req: Request): boolean {
+  const expected = process.env.SANCTIONS_UPLOAD_TOKEN;
+  if (!expected) return false; // writes always require a token
+  const header = req.headers.get('authorization') ?? '';
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  return match?.[1] === expected;
+}
+
+function validateEntry(
+  entry: unknown,
+  index: number
+): { ok: true; value: NormalisedSanctionLike } | { ok: false; error: string } {
+  if (!entry || typeof entry !== 'object') {
+    return { ok: false, error: `entries[${index}] is not an object` };
+  }
+  const e = entry as Record<string, unknown>;
+  if (e.source !== 'UAE_EOCN') {
+    return {
+      ok: false,
+      error: `entries[${index}].source must be "UAE_EOCN", got ${JSON.stringify(e.source)}`,
+    };
+  }
+  if (typeof e.sourceId !== 'string' || !e.sourceId) {
+    return {
+      ok: false,
+      error: `entries[${index}].sourceId is required and must be a non-empty string`,
+    };
+  }
+  if (typeof e.primaryName !== 'string' || !e.primaryName) {
+    return {
+      ok: false,
+      error: `entries[${index}].primaryName is required and must be a non-empty string`,
+    };
+  }
+  if (e.aliases !== undefined && !Array.isArray(e.aliases)) {
+    return { ok: false, error: `entries[${index}].aliases must be an array of strings` };
+  }
+  if (e.programmes !== undefined && !Array.isArray(e.programmes)) {
+    return { ok: false, error: `entries[${index}].programmes must be an array of strings` };
+  }
+  return { ok: true, value: e as unknown as NormalisedSanctionLike };
+}
+
+async function writeAudit(payload: Record<string, unknown>): Promise<void> {
+  try {
+    const store = getStore(INGEST_AUDIT_STORE);
+    const iso = new Date().toISOString();
+    await store.setJSON(`${iso.slice(0, 10)}/${Date.now()}.json`, {
+      ...payload,
+      recordedAt: iso,
+    });
+  } catch {
+    /* audit best-effort */
+  }
+}
+
+export default async (req: Request): Promise<Response> => {
+  const startedAt = new Date().toISOString();
+
+  if (!isAuthorised(req)) {
+    return Response.json(
+      {
+        ok: false,
+        error:
+          'unauthorised — set Authorization: Bearer <SANCTIONS_UPLOAD_TOKEN> (also requires SANCTIONS_UPLOAD_TOKEN env var set on the server)',
+      },
+      { status: 401 }
+    );
+  }
+
+  let body: UploadBody;
+  try {
+    const raw = await req.json();
+    body = raw as UploadBody;
+  } catch (err) {
+    return Response.json(
+      { ok: false, error: `malformed JSON body: ${(err as Error).message}` },
+      { status: 400 }
+    );
+  }
+
+  if (!Array.isArray(body.entries)) {
+    return Response.json({ ok: false, error: 'entries[] is required' }, { status: 400 });
+  }
+
+  const normalised: NormalisedSanctionLike[] = [];
+  for (let i = 0; i < body.entries.length; i++) {
+    const res = validateEntry(body.entries[i], i);
+    if (!res.ok) {
+      return Response.json({ ok: false, error: res.error }, { status: 400 });
+    }
+    // Provide safe defaults for optional fields so downstream consumers
+    // don't need to handle `undefined` for the array fields.
+    normalised.push({
+      ...res.value,
+      aliases: res.value.aliases ?? [],
+      programmes: res.value.programmes ?? [],
+      type: res.value.type ?? 'unknown',
+    });
+  }
+
+  // Persist to the snapshot store using the same key shape the ingest
+  // cron uses (UAE_EOCN/<day>/snapshot.json) so the coverage probe
+  // transitions from manual-pending → ok on the next briefing run.
+  const day = (body.circularDate ?? startedAt).slice(0, 10);
+  const key = `UAE_EOCN/${day}/snapshot.json`;
+  try {
+    const store = getStore(SNAPSHOT_STORE);
+    await store.setJSON(key, normalised);
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    await writeAudit({
+      event: 'eocn_manual_upload_failed',
+      source: 'UAE_EOCN',
+      error,
+      entryCount: normalised.length,
+    });
+    return Response.json({ ok: false, error }, { status: 500 });
+  }
+
+  await writeAudit({
+    event: 'eocn_manual_upload',
+    source: 'UAE_EOCN',
+    circularDate: day,
+    circularReference: body.circularReference,
+    entryCount: normalised.length,
+    snapshotKey: key,
+  });
+
+  return Response.json({
+    ok: true,
+    startedAt,
+    source: 'UAE_EOCN',
+    snapshotKey: key,
+    entryCount: normalised.length,
+    circularDate: day,
+    circularReference: body.circularReference,
+  });
+};
+
+export const config: Config = {
+  path: '/api/sanctions/eocn-upload',
+  method: ['POST'],
+};

--- a/netlify/functions/sanctions-feed-debug.mts
+++ b/netlify/functions/sanctions-feed-debug.mts
@@ -1,0 +1,113 @@
+/**
+ * Sanctions Feed Debug — on-demand diagnostic endpoint.
+ *
+ * Fetches a canonical sanctions-list URL with the same User-Agent the
+ * ingest cron uses and returns the HTTP status, content-type, byte
+ * length, and the first 2000 characters of the response body.
+ *
+ * Purpose: lets the MLRO / operator see the raw upstream payload so
+ * we can diagnose parser drift when the ingest cron reports
+ * `ok: true, fetched: 0` (feed reachable but parser yields no rows).
+ *
+ * Usage:
+ *   GET /.netlify/functions/sanctions-feed-debug?source=OFAC_CONS
+ *   (optionally with header `Authorization: Bearer <SANCTIONS_UPLOAD_TOKEN>`)
+ *
+ * Safety:
+ *   - Read-only. Never writes to any blob store. Never triggers the
+ *     ingest cron.
+ *   - Gated by SANCTIONS_UPLOAD_TOKEN when the env var is set. If the
+ *     env var is unset, the endpoint is available without auth, which
+ *     is appropriate for dev deploys but should be set in production.
+ *
+ * Regulatory basis:
+ *   - FDL No.10/2025 Art.35 (TFS sanctions completeness — the MLRO
+ *     needs a way to verify upstream feed health)
+ */
+
+import type { Config } from '@netlify/functions';
+
+const INGEST_USER_AGENT =
+  'Mozilla/5.0 (compatible; HawkeyeSterlingComplianceBot/1.0; +https://github.com/trex0092/compliance-analyzer)';
+
+const FETCH_TIMEOUT_MS = 30_000;
+
+const SOURCE_URLS: Record<string, string> = {
+  OFAC_SDN: 'https://www.treasury.gov/ofac/downloads/sdn.csv',
+  OFAC_CONS: 'https://www.treasury.gov/ofac/downloads/consolidated/cons_prim.csv',
+  UN: 'https://scsanctions.un.org/resources/xml/en/consolidated.xml',
+  EU: 'https://webgate.ec.europa.eu/fsd/fsf/public/files/xmlFullSanctionsList_1_1/content?token=dG9rZW4tMjAxNw',
+  UK_OFSI: 'https://ofsistorage.blob.core.windows.net/publishlive/2022format/ConList.csv',
+};
+
+function isAuthorised(req: Request): boolean {
+  const expected = process.env.SANCTIONS_UPLOAD_TOKEN;
+  if (!expected) return true; // auth disabled when env var absent
+  const header = req.headers.get('authorization') ?? '';
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  return match?.[1] === expected;
+}
+
+export default async (req: Request): Promise<Response> => {
+  if (!isAuthorised(req)) {
+    return Response.json(
+      { ok: false, error: 'unauthorised — set Authorization: Bearer <SANCTIONS_UPLOAD_TOKEN>' },
+      { status: 401 }
+    );
+  }
+
+  const url = new URL(req.url);
+  const source = url.searchParams.get('source');
+  if (!source || !(source in SOURCE_URLS)) {
+    return Response.json(
+      {
+        ok: false,
+        error: 'query parameter `source` required',
+        validSources: Object.keys(SOURCE_URLS),
+      },
+      { status: 400 }
+    );
+  }
+
+  const targetUrl = SOURCE_URLS[source]!;
+  const startedAt = new Date().toISOString();
+
+  try {
+    const res = await fetch(targetUrl, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: {
+        'User-Agent': INGEST_USER_AGENT,
+        Accept: 'text/csv, application/xml, text/xml, */*',
+      },
+    });
+    const body = await res.text();
+    return Response.json({
+      ok: true,
+      startedAt,
+      source,
+      url: targetUrl,
+      httpStatus: res.status,
+      httpStatusText: res.statusText,
+      contentType: res.headers.get('content-type'),
+      byteLength: body.length,
+      firstLines: body.split(/\r?\n/).slice(0, 20),
+      first2000Chars: body.slice(0, 2000),
+    });
+  } catch (err) {
+    return Response.json(
+      {
+        ok: false,
+        startedAt,
+        source,
+        url: targetUrl,
+        error: err instanceof Error ? err.message : String(err),
+      },
+      { status: 502 }
+    );
+  }
+};
+
+export const config: Config = {
+  path: '/api/sanctions/feed-debug',
+  method: ['GET'],
+};


### PR DESCRIPTION
## Summary

Two operator endpoints to close the two remaining gaps surfaced by the Morning Briefing diagnostic:

### 1. `GET /api/sanctions/feed-debug?source=<SOURCE>`

Read-only. Fetches the upstream URL with the same User-Agent the ingest cron uses. Returns HTTP status, content-type, byte length, first 20 lines + first 2000 chars of the raw body.

Supports `OFAC_SDN`, `OFAC_CONS`, `UN`, `EU`, `UK_OFSI`.

**Use case:** OFAC_CONS, EU, UK_OFSI all currently report `fetched: 0` despite `ok: true` — feeds reachable but parsers yield no rows. Hit this endpoint to see what the upstream actually sent, then fix the matching parser in a targeted follow-up.

**Auth:** gated by `SANCTIONS_UPLOAD_TOKEN` when set. Unauth'd when absent (acceptable for dev, should be set in prod).

### 2. `POST /api/sanctions/eocn-upload`

Write endpoint for UAE EOCN. Accepts `NormalisedSanction[]` payload, validates each entry, persists to `sanctions-snapshots/UAE_EOCN/<YYYY-MM-DD>/snapshot.json` — exactly the key shape the ingest cron uses.

Once invoked, the coverage probe flips UAE / EOCN from `MANUAL-PENDING` → `OK` on the next briefing run.

**Auth:** REQUIRED. `SANCTIONS_UPLOAD_TOKEN` must be set on the server AND the request must present `Authorization: Bearer <token>`. Writes are never unauth'd.

**Audit:** every upload writes `event: 'eocn_manual_upload'` to `sanctions-ingest-audit` with circularDate, circularReference, entryCount, snapshotKey. Failures write `event: 'eocn_manual_upload_failed'`.

## Config change

`.env.example` documents `SANCTIONS_UPLOAD_TOKEN` with a generation command (`openssl rand -hex 32`). Set it in Netlify env vars before shipping.

## Test plan

- [x] `npx vitest run` — 4038/4038 pass (no new tests; the endpoints are I/O + validation with no pure units to spec)
- [x] `npx tsc --noEmit` — clean
- [x] `npx prettier --check` — clean
- [ ] After deploy: `curl 'https://hawkeye-sterling-v2.netlify.app/api/sanctions/feed-debug?source=OFAC_CONS'` → inspect the raw bytes to diagnose why the parser returns 0 rows
- [ ] After deploy: test EOCN upload with a minimal valid payload, confirm the briefing flips `UAE` / `EOCN` to `OK`

## Recommended next workstream (not in this PR)

Once the `feed-debug` endpoint reveals the raw OFAC_CONS / EU / UK_OFSI payloads, fix each parser in a focused PR against the actual observed format.

https://claude.ai/code/session_01K4twBZwq6wDoyF8GptSNQx