### PR TITLE
Feed-debug: accept token via ?token= query param for browser testing

### DIFF
--- a/netlify/functions/sanctions-feed-debug.mts
+++ b/netlify/functions/sanctions-feed-debug.mts
@@ -43,9 +43,21 @@ const SOURCE_URLS: Record<string, string> = {
 function isAuthorised(req: Request): boolean {
   const expected = process.env.SANCTIONS_UPLOAD_TOKEN;
   if (!expected) return true; // auth disabled when env var absent
+  // Accept the token either as a Bearer header or as a `?token=`
+  // query parameter. The query-param path exists so operators can
+  // hit the endpoint from a browser address bar when terminals /
+  // curl aren't available. Header is preferred; query param is a
+  // pragmatic fallback for on-demand diagnostics only.
   const header = req.headers.get('authorization') ?? '';
   const match = header.match(/^Bearer\s+(.+)$/i);
-  return match?.[1] === expected;
+  if (match?.[1] === expected) return true;
+  try {
+    const url = new URL(req.url);
+    if (url.searchParams.get('token') === expected) return true;
+  } catch {
+    /* fall through */
+  }
+  return false;
 }
 
 export default async (req: Request): Promise<Response> => {


### PR DESCRIPTION
## Summary

Add `?token=<SANCTIONS_UPLOAD_TOKEN>` query-param fallback on `GET /api/sanctions/feed-debug` so operators without terminal / curl access can hit the endpoint from a browser address bar.

Header auth (`Authorization: Bearer <token>`) remains preferred and is the default path. Query-param is a pragmatic fallback for on-demand diagnostics only.

**POST /api/sanctions/eocn-upload unchanged** — writes still require the Bearer header, as a write endpoint should not accept credentials in query strings (they end up in proxy logs, browser history, referer headers).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx prettier --check` — clean
- [ ] After deploy: open `https://hawkeye-sterling-v2.netlify.app/api/sanctions/feed-debug?source=OFAC_CONS&token=<TOKEN>` in a browser — should return JSON with the raw feed bytes

https://claude.ai/code/session_01K4twBZwq6wDoyF8GptSNQx