### PR TITLE
Audit 5-fix bundle: timezone, pagination, citation lock, cross-source correlation, incomplete-briefing banner

### DIFF
--- a/netlify/functions/cdd-weekly-status-cron.mts
+++ b/netlify/functions/cdd-weekly-status-cron.mts
@@ -93,9 +93,13 @@ export default async (): Promise<Response> => {
       now: new Date(),
       customers,
       reviewSchedules,
+      // Persistence for these three does not yet exist. Declare them
+      // as unwired so the generator emits a loud "INCOMPLETE BRIEFING"
+      // banner — silent empty sections would be a regulatory hazard.
       approvals: [],
       filings: [],
       screeningRuns: [],
+      unwiredDataSources: ['approvals', 'filings', 'screeningRuns'],
     });
 
     const markdown = renderWeeklyCddReportMarkdown(report);

--- a/netlify/functions/morning-briefing-cron.mts
+++ b/netlify/functions/morning-briefing-cron.mts
@@ -30,6 +30,28 @@
 import type { Config } from '@netlify/functions';
 import { getStore } from '@netlify/blobs';
 
+/**
+ * Walk every page of a blob-store listing. The Netlify SDK only
+ * returns a single page per `list({ prefix })` call — for stores
+ * with more than ~1000 entries under a prefix we'd silently skip
+ * older blobs. Iterating with `paginate: true` returns all blobs
+ * across all pages.
+ */
+async function listAllBlobs(
+  store: ReturnType<typeof getStore>,
+  prefix: string
+): Promise<Array<{ key: string }>> {
+  const all: Array<{ key: string }> = [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const iter = (store as any).list({ prefix, paginate: true }) as AsyncIterable<{
+    blobs?: Array<{ key: string }>;
+  }>;
+  for await (const page of iter) {
+    if (page.blobs) for (const b of page.blobs) all.push(b);
+  }
+  return all;
+}
+
 const REPORT_STORE = 'morning-briefing-reports';
 const AUDIT_STORE = 'morning-briefing-audit';
 const SNAPSHOT_STORE = 'sanctions-snapshots';
@@ -105,8 +127,8 @@ async function probeCoverage(
     try {
       let latestKey: string | undefined;
       for (const prefix of INGEST_KEY_PREFIXES[source]) {
-        const listing = await store.list({ prefix });
-        for (const blob of listing.blobs ?? []) {
+        const blobs = await listAllBlobs(store, prefix);
+        for (const blob of blobs) {
           if (!latestKey || blob.key > latestKey) latestKey = blob.key;
         }
       }
@@ -160,8 +182,8 @@ async function probeCronHealth(now: Date): Promise<
       let okCount = 0;
       let lastKey: string | undefined;
       for (const prefix of prefixes) {
-        const listing = await store.list({ prefix: `${prefix}/` });
-        for (const blob of listing.blobs ?? []) {
+        const blobs = await listAllBlobs(store, `${prefix}/`);
+        for (const blob of blobs) {
           runCount += 1;
           // For a best-effort health check we only inspect the key; loading
           // every blob body is too expensive for a cold start.
@@ -216,8 +238,8 @@ async function probeOvernightActivity(now: Date): Promise<{
     const today = now.toISOString().slice(0, 10);
     const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
     for (const prefix of [today, yesterday]) {
-      const listing = await store.list({ prefix: `${prefix}/` });
-      for (const blob of listing.blobs ?? []) {
+      const blobs = await listAllBlobs(store, `${prefix}/`);
+      for (const blob of blobs) {
         const body = (await store.get(blob.key, { type: 'json' })) as {
           finishedAtIso?: string;
           totalConfirmed?: number;
@@ -245,8 +267,8 @@ async function probeOvernightActivity(now: Date): Promise<{
     const today = now.toISOString().slice(0, 10);
     const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
     for (const prefix of [today, yesterday]) {
-      const listing = await store.list({ prefix: `${prefix}/` });
-      sanctionsIngestRuns += (listing.blobs ?? []).length;
+      const blobs = await listAllBlobs(store, `${prefix}/`);
+      sanctionsIngestRuns += blobs.length;
     }
   } catch {
     /* best-effort */
@@ -308,12 +330,14 @@ export default async (): Promise<Response> => {
       cronHealth,
       reviewsDueToday,
       overnightActivity,
-      // Persistence for these three does not yet exist. Leaving empty
-      // here is safe — the generator surfaces "no items" rather than
-      // pretending we checked them. See PR description for follow-up.
+      // Persistence for these three does not yet exist. Pass empty
+      // arrays AND declare them as unwired so the generator surfaces
+      // a loud "INCOMPLETE BRIEFING" banner — better than silently
+      // showing "no items" when the data was never loaded.
       frozenSubjects: [],
       pendingApprovals: [],
       filings: [],
+      unwiredDataSources: ['frozenSubjects', 'pendingApprovals', 'filings'],
     });
 
     const markdown = renderMorningBriefingMarkdown(report);

--- a/netlify/functions/sanctions-feed-debug.mts
+++ b/netlify/functions/sanctions-feed-debug.mts
@@ -93,6 +93,29 @@ export default async (req: Request): Promise<Response> => {
       },
     });
     const body = await res.text();
+
+    // Run the actual ingest parser against the live body so we see
+    // exactly how many records the production pipeline would emit —
+    // and the first 3 records so we can eyeball fields.
+    let parserRecordCount: number | undefined;
+    let firstParsedRecords: unknown;
+    let parserError: string | undefined;
+    try {
+      const ing = await import('../../src/services/sanctionsIngest');
+      let parsed: unknown[] | undefined;
+      if (source === 'OFAC_SDN') parsed = ing.parseOfacSdnCsv(body);
+      else if (source === 'OFAC_CONS') parsed = ing.parseOfacConsCsv(body);
+      else if (source === 'UN') parsed = ing.parseUnConsolidatedXml(body);
+      else if (source === 'EU') parsed = ing.parseEuSanctionsXml(body);
+      else if (source === 'UK_OFSI') parsed = ing.parseUkOfsiCsv(body);
+      if (parsed) {
+        parserRecordCount = parsed.length;
+        firstParsedRecords = parsed.slice(0, 3);
+      }
+    } catch (err) {
+      parserError = err instanceof Error ? err.message : String(err);
+    }
+
     return Response.json({
       ok: true,
       startedAt,
@@ -104,6 +127,9 @@ export default async (req: Request): Promise<Response> => {
       byteLength: body.length,
       firstLines: body.split(/\r?\n/).slice(0, 20),
       first2000Chars: body.slice(0, 2000),
+      parserRecordCount,
+      firstParsedRecords,
+      parserError,
     });
   } catch (err) {
     return Response.json(

--- a/netlify/functions/sanctions-ingest-status.mts
+++ b/netlify/functions/sanctions-ingest-status.mts
@@ -32,6 +32,22 @@
 
 import { getStore } from '@netlify/blobs';
 
+/** Walk every page of a blob-store listing — the SDK paginates by default. */
+async function listAllBlobs(
+  store: ReturnType<typeof getStore>,
+  prefix: string
+): Promise<Array<{ key: string }>> {
+  const all: Array<{ key: string }> = [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const iter = (store as any).list({ prefix, paginate: true }) as AsyncIterable<{
+    blobs?: Array<{ key: string }>;
+  }>;
+  for await (const page of iter) {
+    if (page.blobs) for (const b of page.blobs) all.push(b);
+  }
+  return all;
+}
+
 const INGEST_AUDIT_STORE = 'sanctions-ingest-audit';
 
 type SanctionsSource = 'OFAC_SDN' | 'OFAC_CONS' | 'UN' | 'EU' | 'UK_OFSI' | 'UAE_EOCN';
@@ -74,8 +90,8 @@ export default async (): Promise<Response> => {
   try {
     const store = getStore(INGEST_AUDIT_STORE);
     for (const prefix of [today, yesterday]) {
-      const listing = await store.list({ prefix: `${prefix}/` });
-      for (const blob of listing.blobs ?? []) {
+      const blobs = await listAllBlobs(store, `${prefix}/`);
+      for (const blob of blobs) {
         const body = (await store.get(blob.key, { type: 'json' })) as AuditEntry | null;
         if (!body || !Array.isArray(body.results)) continue;
         totalAuditEntries += 1;

--- a/netlify/functions/sanctions-ingest-status.mts
+++ b/netlify/functions/sanctions-ingest-status.mts
@@ -102,13 +102,22 @@ export default async (): Promise<Response> => {
           row.totalRuns += 1;
           if (r.ok) {
             row.successRuns += 1;
-            row.lastSuccessIso = at;
-            if (typeof r.fetched === 'number') row.lastFetchedCount = r.fetched;
+            // Only overwrite "last success" data when this entry is
+            // newer than what we've seen — Netlify blob list order is
+            // not chronological, so without this guard we'd report
+            // whatever audit entry happened to be iterated last
+            // (often a stale pre-fix run that returned `fetched: 0`).
+            if (!row.lastSuccessIso || (at && at > row.lastSuccessIso)) {
+              row.lastSuccessIso = at;
+              if (typeof r.fetched === 'number') row.lastFetchedCount = r.fetched;
+            }
           } else {
             row.failedRuns += 1;
             if (r.error) {
-              row.lastError = r.error;
-              row.lastErrorAtIso = at;
+              if (!row.lastErrorAtIso || (at && at > row.lastErrorAtIso)) {
+                row.lastError = r.error;
+                row.lastErrorAtIso = at;
+              }
             }
           }
         }

--- a/netlify/functions/sanctions-watch-cron.mts
+++ b/netlify/functions/sanctions-watch-cron.mts
@@ -28,6 +28,22 @@
 import type { Config } from '@netlify/functions';
 import { getStore } from '@netlify/blobs';
 
+/** Walk every page of a blob-store listing — the SDK paginates by default. */
+async function listAllBlobs(
+  store: ReturnType<typeof getStore>,
+  prefix: string
+): Promise<Array<{ key: string }>> {
+  const all: Array<{ key: string }> = [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const iter = (store as any).list({ prefix, paginate: true }) as AsyncIterable<{
+    blobs?: Array<{ key: string }>;
+  }>;
+  for await (const page of iter) {
+    if (page.blobs) for (const b of page.blobs) all.push(b);
+  }
+  return all;
+}
+
 const REPORT_STORE = 'sanctions-watch-reports';
 const AUDIT_STORE = 'sanctions-watch-audit';
 const SNAPSHOT_STORE = 'sanctions-snapshots';
@@ -114,8 +130,8 @@ async function probeCoverage(
       // snapshot across them (OFAC has two underlying feeds).
       let latestKey: string | undefined;
       for (const prefix of INGEST_KEY_PREFIXES[source]) {
-        const listing = await store.list({ prefix });
-        for (const blob of listing.blobs ?? []) {
+        const blobs = await listAllBlobs(store, prefix);
+        for (const blob of blobs) {
           if (!latestKey || blob.key > latestKey) latestKey = blob.key;
         }
       }
@@ -167,8 +183,8 @@ async function loadLiveHits(): Promise<
     if (!delta) return [];
 
     const cohortStore = getStore(COHORT_STORE);
-    const cohortListing = await cohortStore.list({ prefix: '' });
-    const tenantCohortKeys = (cohortListing.blobs ?? [])
+    const cohortBlobs = await listAllBlobs(cohortStore, '');
+    const tenantCohortKeys = cohortBlobs
       .map((b) => b.key)
       .filter((k) => k.endsWith('/cohort.json'));
 
@@ -209,10 +225,13 @@ export default async (): Promise<Response> => {
       portfolioSize: COMPANY_REGISTRY.length,
       listCoverage: coverage,
       hits,
-      // Frozen-subject and false-positive persistence does not yet exist.
-      // See PR description for the tracked follow-up.
+      // Frozen-subject and false-positive persistence does not yet
+      // exist. Declare them as unwired so the generator emits a loud
+      // "INCOMPLETE BRIEFING" banner instead of silently rendering
+      // empty sections that look like "all clear".
       frozenSubjects: [],
       recentFalsePositives: [],
+      unwiredDataSources: ['frozenSubjects', 'recentFalsePositives'],
     });
 
     const markdown = renderSanctionsWatchMarkdown(report);

--- a/src/services/cddReportGenerator.ts
+++ b/src/services/cddReportGenerator.ts
@@ -135,6 +135,12 @@ export interface WeeklyCddReportInput {
   filings: ReadonlyArray<FilingRecord>;
   /** Screening runs resolved in any outcome. Week-in-review applied. */
   screeningRuns: ReadonlyArray<ScreeningRun>;
+  /**
+   * Names of data sources NOT yet wired into a persistence layer.
+   * Surfaced as a loud "INCOMPLETE BRIEFING" banner so the MLRO does
+   * not infer "all clear" from a wiring gap (FDL Art.20-22).
+   */
+  unwiredDataSources?: ReadonlyArray<string>;
 }
 
 export interface WeeklyCddReport {
@@ -146,6 +152,7 @@ export interface WeeklyCddReport {
   pendingApprovals: PendingApproval[];
   filingSnapshot: FilingSnapshot;
   sanctionsResolvedThisWeek: SanctionsResolution[];
+  unwiredDataSources: ReadonlyArray<string>;
   /** Regulatory citations this report attests to. */
   citations: ReadonlyArray<string>;
 }
@@ -323,6 +330,7 @@ export function buildWeeklyCddReport(input: WeeklyCddReportInput): WeeklyCddRepo
     pendingApprovals,
     filingSnapshot: { countsByType, filedThisWeek, overdue },
     sanctionsResolvedThisWeek,
+    unwiredDataSources: input.unwiredDataSources ?? [],
     citations: [
       'FDL No.10/2025 Art.12-14 (CDD tiers, review cadence)',
       'FDL No.10/2025 Art.14 (PEP enhanced due diligence)',
@@ -365,6 +373,16 @@ export function renderWeeklyCddReportMarkdown(report: WeeklyCddReport): string {
   lines.push(`Window: ${fromDisplay} to ${toDisplay}`);
   lines.push(`Generated: ${formatDateDDMMYYYY(report.generatedAtIso)}`);
   lines.push('');
+
+  if (report.unwiredDataSources.length > 0) {
+    lines.push(
+      `**⚠ INCOMPLETE BRIEFING — ${report.unwiredDataSources.length} data source(s) not yet wired: ${report.unwiredDataSources.join(', ')}.**`
+    );
+    lines.push(
+      'Empty sections below for these sources do NOT mean "all clear" — verify manually until the persistence layer ships (FDL Art.20-22).'
+    );
+    lines.push('');
+  }
 
   // 1) Tier rollup.
   lines.push('## 1. CDD tier rollup');

--- a/src/services/morningBriefingGenerator.ts
+++ b/src/services/morningBriefingGenerator.ts
@@ -45,7 +45,7 @@ import { REQUIRED_SOURCES } from './sanctionsWatchGenerator';
 import type { ApprovalRequest } from '../domain/approvals';
 import type { FilingRecord } from './screeningComplianceReport';
 import { checkEOCNDeadline, checkDeadline } from '../utils/businessDays';
-import { formatDateDDMMYYYY } from '../utils/dates';
+import { formatDateDDMMYYYY, isSameDubaiDate } from '../utils/dates';
 import { CNMR_FILING_DEADLINE_BUSINESS_DAYS } from '../domain/constants';
 
 // ─── Input types ────────────────────────────────────────────────────────────
@@ -104,6 +104,15 @@ export interface MorningBriefingInput {
   pendingApprovals: ReadonlyArray<ApprovalRequest>;
   /** Filings in the system — used to pick out filings due today. */
   filings: ReadonlyArray<FilingRecord>;
+  /**
+   * Names of data sources that are NOT yet wired into a persistence
+   * layer (so the corresponding input arrays will be empty regardless
+   * of real-world activity). When non-empty, the briefing renders a
+   * loud "INCOMPLETE BRIEFING" banner so the MLRO knows the absence
+   * of items in those sections is a wiring gap, not a clean state.
+   * The cron is responsible for declaring this honestly.
+   */
+  unwiredDataSources?: ReadonlyArray<string>;
 }
 
 // ─── Output types ───────────────────────────────────────────────────────────
@@ -169,6 +178,8 @@ export interface MorningBriefingReport {
     pendingApprovalsOver48h: ReadonlyArray<PendingApprovalOver48h>;
     overdueFilings: ReadonlyArray<OverdueFilingItem>;
   };
+  /** Pass-through: data sources the cron declared as not yet wired. */
+  unwiredDataSources: ReadonlyArray<string>;
   citations: ReadonlyArray<string>;
 }
 
@@ -193,13 +204,12 @@ function deadlineForFilingType(type: FilingRecord['filingType']): number | null 
   }
 }
 
-function isSameDate(a: Date, b: Date): boolean {
-  return (
-    a.getFullYear() === b.getFullYear() &&
-    a.getMonth() === b.getMonth() &&
-    a.getDate() === b.getDate()
-  );
-}
+// Dubai-local same-day comparison. The cron runs in UTC; using
+// `getDate()` directly returns the UTC day-of-month, which is off by
+// one for any instant between 20:00 UTC and 24:00 UTC (= 00:00 to
+// 04:00 Dubai). For a "is the deadline today in Dubai?" check we
+// must compare Dubai-local calendar dates explicitly.
+const isSameDate = isSameDubaiDate;
 
 // ─── Builder ────────────────────────────────────────────────────────────────
 
@@ -310,6 +320,7 @@ export function buildMorningBriefingReport(input: MorningBriefingInput): Morning
     generatedAtIso: windowToIso,
     windowFromIso,
     windowToIso,
+    unwiredDataSources: input.unwiredDataSources ?? [],
     listCoverage: coverage,
     anyListMissing: missingSources.length > 0,
     missingSources,
@@ -350,6 +361,20 @@ export function renderMorningBriefingMarkdown(report: MorningBriefingReport): st
     `Window: ${formatDateDDMMYYYY(report.windowFromIso)} to ${formatDateDDMMYYYY(report.windowToIso)}`
   );
   lines.push('');
+
+  // Honesty banner: if any data source is not yet wired into a
+  // persistence layer, the corresponding sections will be empty no
+  // matter what is happening operationally. The MLRO must verify
+  // those sections manually until the persistence layer ships.
+  if (report.unwiredDataSources.length > 0) {
+    lines.push(
+      `**⚠ INCOMPLETE BRIEFING — ${report.unwiredDataSources.length} data source(s) not yet wired: ${report.unwiredDataSources.join(', ')}.**`
+    );
+    lines.push(
+      'Empty sections below for these sources do NOT mean "all clear" — they mean the persistence layer is not yet feeding the briefing. Verify manually before relying on this report (FDL No.10/2025 Art.20-22 — CO duty of care).'
+    );
+    lines.push('');
+  }
 
   // 1) Critical today.
   lines.push('## 1. Critical today');

--- a/src/services/sanctionsDeltaCohortScreener.ts
+++ b/src/services/sanctionsDeltaCohortScreener.ts
@@ -287,6 +287,44 @@ export function screenCohortAgainstDelta(
     }
   }
 
+  // Cross-source correlation pass. A subject that hits on TWO or
+  // more independent sanctions sources in the same delta is a much
+  // stronger signal than one that hits on a single source — a UN
+  // designation that also appears on OFAC SDN and EU is, in practice,
+  // confirmed. Boost matchScore by +0.2 per additional distinct
+  // source (cap 0.99) and re-derive band + recommended action so
+  // the downstream MLRO view escalates appropriately.
+  //
+  // Regulatory anchor: FATF Rec 6 (timely UN sanctions implementation
+  // — multi-source confirmation removes ambiguity about whether the
+  // listing is current); CLAUDE.md "never skip a list" rule (the
+  // cross-source signal only exists when all six lists are screened).
+  const sourcesByCustomer = new Map<string, Set<string>>();
+  for (const h of hits) {
+    let set = sourcesByCustomer.get(h.customerId);
+    if (!set) {
+      set = new Set();
+      sourcesByCustomer.set(h.customerId, set);
+    }
+    set.add(h.matchedAgainst.source);
+  }
+  for (let i = 0; i < hits.length; i++) {
+    const h = hits[i]!;
+    const sources = sourcesByCustomer.get(h.customerId)!;
+    if (sources.size < 2) continue;
+    const boost = Math.min(0.4, 0.2 * (sources.size - 1));
+    const newScore = Math.min(0.99, h.matchScore + boost);
+    if (newScore !== h.matchScore) {
+      hits[i] = {
+        ...h,
+        matchScore: newScore,
+        confidence: deriveBand(newScore),
+        recommendedAction: deriveAction(newScore),
+        matchReasons: [...h.matchReasons, `cross-source-x${sources.size}`],
+      };
+    }
+  }
+
   hits.sort((a, b) => b.matchScore - a.matchScore);
 
   const summary =

--- a/src/services/sanctionsIngest.ts
+++ b/src/services/sanctionsIngest.ts
@@ -359,8 +359,23 @@ export function parseUkOfsiCsv(csv: string): NormalisedSanction[] {
   const lines = csv.split(/\r?\n/).filter((l) => l.trim().length > 0);
   if (lines.length < 2) return []; // header + at least one data row
 
+  // OFSI prepends an optional metadata line to the CSV:
+  //   Last Updated,27/01/2026
+  //   Name 6,Name 1,Name 2,...
+  // Find the real header by looking for the first line that contains
+  // the "Group ID" marker. This is robust against the preamble being
+  // added/removed or additional metadata rows landing in future.
+  let headerIndex = 0;
+  for (let i = 0; i < Math.min(lines.length, 5); i++) {
+    if (lines[i]!.includes('Group ID') && lines[i]!.includes('Name 1')) {
+      headerIndex = i;
+      break;
+    }
+  }
+  if (lines.length - headerIndex < 2) return []; // header + 1 row minimum
+
   // Parse header to find column indices.
-  const headerFields = parseOfacCsvLine(lines[0]!);
+  const headerFields = parseOfacCsvLine(lines[headerIndex]!);
   const col = (name: string) => {
     const idx = headerFields.findIndex((h) => h.trim().toLowerCase() === name.toLowerCase());
     return idx;
@@ -394,7 +409,7 @@ export function parseUkOfsiCsv(csv: string): NormalisedSanction[] {
     }
   >();
 
-  for (let i = 1; i < lines.length; i++) {
+  for (let i = headerIndex + 1; i < lines.length; i++) {
     const fields = parseOfacCsvLine(lines[i]!);
     const groupId = fields[iGroupId]?.trim();
     if (!groupId) continue;

--- a/src/services/sanctionsWatchGenerator.ts
+++ b/src/services/sanctionsWatchGenerator.ts
@@ -131,6 +131,13 @@ export interface SanctionsWatchInput {
   frozenSubjects: ReadonlyArray<FrozenSubjectInput>;
   /** False positives resolved in the past 24h. */
   recentFalsePositives: ReadonlyArray<ResolvedFalsePositiveInput>;
+  /**
+   * Names of data sources NOT yet wired into a persistence layer (so
+   * the corresponding input arrays will be empty regardless of real
+   * activity). Surfaced as a loud "INCOMPLETE BRIEFING" banner so the
+   * MLRO does not infer "all clear" from a wiring gap.
+   */
+  unwiredDataSources?: ReadonlyArray<string>;
 }
 
 export interface BandCounts {
@@ -188,6 +195,7 @@ export interface SanctionsWatchReport {
   lowHits: ReadonlyArray<HitView>;
   freezeCountdowns: ReadonlyArray<FreezeCountdownView>;
   recentFalsePositives: ReadonlyArray<FalsePositiveView>;
+  unwiredDataSources: ReadonlyArray<string>;
   citations: ReadonlyArray<string>;
 }
 
@@ -333,6 +341,7 @@ export function buildSanctionsWatchReport(input: SanctionsWatchInput): Sanctions
     lowHits,
     freezeCountdowns,
     recentFalsePositives: falsePositives,
+    unwiredDataSources: input.unwiredDataSources ?? [],
     citations: [
       'FDL No.10/2025 Art.20-22 (CO duty of care, reasoned decision)',
       'FDL No.10/2025 Art.24 (record retention, audit trail)',
@@ -393,6 +402,16 @@ export function renderSanctionsWatchMarkdown(report: SanctionsWatchReport): stri
   lines.push(`Generated: ${formatDateDDMMYYYY(report.generatedAtIso)}`);
   lines.push(`Portfolio size: ${report.portfolioSize}`);
   lines.push('');
+
+  if (report.unwiredDataSources.length > 0) {
+    lines.push(
+      `**⚠ INCOMPLETE BRIEFING — ${report.unwiredDataSources.length} data source(s) not yet wired: ${report.unwiredDataSources.join(', ')}.**`
+    );
+    lines.push(
+      'Empty sections below for these sources do NOT mean "all clear" — verify manually until the persistence layer ships (FDL Art.20-22).'
+    );
+    lines.push('');
+  }
 
   // 1) List coverage. Loud alert if any required list is missing.
   lines.push('## 1. List coverage (FDL Art.35, Cabinet Res 74/2020 Art.4)');

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -25,20 +25,52 @@ export function addYears(dateIso: string, years: number): string {
 }
 
 /**
- * Format a date string as dd/mm/yyyy — the mandatory format for UAE
- * compliance documents (FDL, goAML filings, MoE reports).
- * Do NOT use toLocaleDateString() which varies by browser locale.
+ * Format a date string as dd/mm/yyyy in the UAE / Asia/Dubai timezone
+ * (UTC+4, no DST). This is the mandatory format for UAE compliance
+ * documents (FDL, goAML filings, MoE reports). Do NOT rely on the
+ * runtime's local timezone — Netlify functions execute in UTC, so
+ * `d.getDate()` would return the UTC day-of-month, which can be off
+ * by one near midnight Dubai. Use Intl.DateTimeFormat with an
+ * explicit `timeZone` for correctness.
  */
-/** Short format for UI display: dd/mm/yyyy */
+/** Short format for UI display: dd/mm/yyyy (Dubai-local). */
 export function formatDate(dateStr: string): string {
   return formatDateDDMMYYYY(dateStr);
 }
 
+const DUBAI_DDMMYYYY = new Intl.DateTimeFormat('en-GB', {
+  timeZone: 'Asia/Dubai',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
+const DUBAI_YYYYMMDD = new Intl.DateTimeFormat('en-CA', {
+  timeZone: 'Asia/Dubai',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
 export function formatDateDDMMYYYY(dateStr: string): string {
   const d = new Date(dateStr);
   if (isNaN(d.getTime())) return '';
-  const day = String(d.getDate()).padStart(2, '0');
-  const month = String(d.getMonth() + 1).padStart(2, '0');
-  const year = d.getFullYear();
-  return `${day}/${month}/${year}`;
+  return DUBAI_DDMMYYYY.format(d);
+}
+
+/**
+ * Return the calendar date the given instant falls on in the UAE /
+ * Asia/Dubai timezone, formatted as `YYYY-MM-DD`. Use this to compare
+ * "is this Dubai-today?" instead of `getDate()` on a UTC-runtime
+ * Date object.
+ */
+export function dubaiDateYmd(input: Date | string): string {
+  const d = typeof input === 'string' ? new Date(input) : input;
+  if (isNaN(d.getTime())) return '';
+  return DUBAI_YYYYMMDD.format(d);
+}
+
+/** True when the two instants fall on the same Dubai-local calendar date. */
+export function isSameDubaiDate(a: Date, b: Date): boolean {
+  return dubaiDateYmd(a) === dubaiDateYmd(b);
 }

--- a/tests/morningBriefingGenerator.test.ts
+++ b/tests/morningBriefingGenerator.test.ts
@@ -210,6 +210,21 @@ describe('buildMorningBriefingReport — pending approvals', () => {
   });
 });
 
+describe('buildMorningBriefingReport — unwired data sources', () => {
+  it('passes through unwiredDataSources verbatim', () => {
+    const report = buildMorningBriefingReport({
+      ...baseInput(),
+      unwiredDataSources: ['frozenSubjects', 'pendingApprovals', 'filings'],
+    });
+    expect(report.unwiredDataSources).toEqual(['frozenSubjects', 'pendingApprovals', 'filings']);
+  });
+
+  it('defaults unwiredDataSources to empty array when not provided', () => {
+    const report = buildMorningBriefingReport(baseInput());
+    expect(report.unwiredDataSources).toEqual([]);
+  });
+});
+
 describe('renderMorningBriefingMarkdown', () => {
   it('renders all sections and includes regulatory + no-tipping-off text', () => {
     const report = buildMorningBriefingReport(baseInput());
@@ -225,5 +240,17 @@ describe('renderMorningBriefingMarkdown', () => {
     expect(md).toContain('FDL No.10/2025 Art.29');
     expect(md).toContain('must not be shared with any subject');
     expect(md).toContain('No critical items for today.');
+  });
+
+  it('renders the INCOMPLETE BRIEFING banner when sources are unwired', () => {
+    const report = buildMorningBriefingReport({
+      ...baseInput(),
+      unwiredDataSources: ['frozenSubjects', 'pendingApprovals', 'filings'],
+    });
+    const md = renderMorningBriefingMarkdown(report);
+    expect(md).toContain('⚠ INCOMPLETE BRIEFING');
+    expect(md).toContain('frozenSubjects');
+    expect(md).toContain('pendingApprovals');
+    expect(md).toContain('filings');
   });
 });

--- a/tests/regulatoryCitationLock.test.ts
+++ b/tests/regulatoryCitationLock.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Regulatory Citation Lock — second-line guardrail on top of
+ * tests/constants.test.ts.
+ *
+ * tests/constants.test.ts pins each regulatory constant to a value.
+ * This file pins each constant to its REGULATORY CITATION (article,
+ * circular, or guidance section). Together they form an audit trail
+ * a MoE inspector or LBMA auditor can read directly:
+ *
+ *   "Where in your code is FDL Art.26-27 enforced?"
+ *   → grep this file for that citation, follow the constant name.
+ *
+ * If you change a constant value AND its citation, this test will
+ * still pass — but you MUST also bump REGULATORY_CONSTANTS_VERSION
+ * (see assertion at the bottom). That bump is the audit signal.
+ *
+ * Reviewers: a PR that touches this file MUST cite the regulation
+ * change in its description (per CLAUDE.md §8 commit citation rule).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  STR_FILING_DEADLINE_BUSINESS_DAYS,
+  CTR_FILING_DEADLINE_BUSINESS_DAYS,
+  CNMR_FILING_DEADLINE_BUSINESS_DAYS,
+  EOCN_FREEZE_IMMEDIATELY,
+  DPMS_CASH_THRESHOLD_AED,
+  CROSS_BORDER_CASH_THRESHOLD_AED,
+  UBO_OWNERSHIP_THRESHOLD_PCT,
+  UBO_REVERIFICATION_WORKING_DAYS,
+  RECORD_RETENTION_YEARS,
+  CDD_REVIEW_HIGH_RISK_MONTHS,
+  CDD_REVIEW_MEDIUM_RISK_MONTHS,
+  CDD_REVIEW_LOW_RISK_MONTHS,
+  MOE_CIRCULAR_IMPLEMENTATION_DAYS,
+  REGULATORY_CONSTANTS_VERSION,
+} from '@/domain/constants';
+
+interface CitationEntry {
+  name: string;
+  value: number | boolean | string;
+  expected: number | boolean | string;
+  citation: string;
+}
+
+const CITATIONS: ReadonlyArray<CitationEntry> = [
+  {
+    name: 'STR_FILING_DEADLINE_BUSINESS_DAYS',
+    value: STR_FILING_DEADLINE_BUSINESS_DAYS,
+    expected: 0,
+    citation: 'FDL No.10/2025 Art.26-27 — file STR/SAR without delay',
+  },
+  {
+    name: 'CTR_FILING_DEADLINE_BUSINESS_DAYS',
+    value: CTR_FILING_DEADLINE_BUSINESS_DAYS,
+    expected: 15,
+    citation: 'FDL No.10/2025 Art.16 + MoE Circular 08/AML/2021 — DPMS cash 15 BD',
+  },
+  {
+    name: 'CNMR_FILING_DEADLINE_BUSINESS_DAYS',
+    value: CNMR_FILING_DEADLINE_BUSINESS_DAYS,
+    expected: 5,
+    citation: 'Cabinet Res 74/2020 Art.6 — CNMR within 5 business days of confirmed match',
+  },
+  {
+    name: 'EOCN_FREEZE_IMMEDIATELY',
+    value: EOCN_FREEZE_IMMEDIATELY,
+    expected: true,
+    citation: 'Cabinet Res 74/2020 Art.4 + EOCN TFS Guidance July 2025 — freeze without delay',
+  },
+  {
+    name: 'DPMS_CASH_THRESHOLD_AED',
+    value: DPMS_CASH_THRESHOLD_AED,
+    expected: 55_000,
+    citation: 'MoE Circular 08/AML/2021 — DPMS cash transaction reporting threshold',
+  },
+  {
+    name: 'CROSS_BORDER_CASH_THRESHOLD_AED',
+    value: CROSS_BORDER_CASH_THRESHOLD_AED,
+    expected: 60_000,
+    citation: 'Cabinet Res 134/2025 Art.16 — cross-border cash / BNI declaration',
+  },
+  {
+    name: 'UBO_OWNERSHIP_THRESHOLD_PCT',
+    value: UBO_OWNERSHIP_THRESHOLD_PCT,
+    expected: 0.25,
+    citation: 'Cabinet Decision 109/2023 — beneficial ownership 25% threshold (stored as fraction)',
+  },
+  {
+    name: 'UBO_REVERIFICATION_WORKING_DAYS',
+    value: UBO_REVERIFICATION_WORKING_DAYS,
+    expected: 15,
+    citation: 'Cabinet Decision 109/2023 — UBO re-verification deadline',
+  },
+  {
+    name: 'RECORD_RETENTION_YEARS',
+    value: RECORD_RETENTION_YEARS,
+    expected: 10,
+    citation: 'FDL No.10/2025 Art.24 + MoE DPMS Guidance — minimum record retention',
+  },
+  {
+    name: 'CDD_REVIEW_HIGH_RISK_MONTHS',
+    value: CDD_REVIEW_HIGH_RISK_MONTHS,
+    expected: 3,
+    citation: 'Cabinet Res 134/2025 Art.14 + Art.19 — EDD review cadence',
+  },
+  {
+    name: 'CDD_REVIEW_MEDIUM_RISK_MONTHS',
+    value: CDD_REVIEW_MEDIUM_RISK_MONTHS,
+    expected: 6,
+    citation: 'Cabinet Res 134/2025 Art.7-10 + Art.19 — CDD review cadence',
+  },
+  {
+    name: 'CDD_REVIEW_LOW_RISK_MONTHS',
+    value: CDD_REVIEW_LOW_RISK_MONTHS,
+    expected: 12,
+    citation: 'Cabinet Res 134/2025 Art.7-10 + Art.19 — SDD review cadence',
+  },
+  {
+    name: 'MOE_CIRCULAR_IMPLEMENTATION_DAYS',
+    value: MOE_CIRCULAR_IMPLEMENTATION_DAYS,
+    expected: 30,
+    citation: 'MoE Circular policy — implementation deadline after new circular',
+  },
+];
+
+describe('Regulatory citation lock — every filing deadline / threshold maps to a regulation', () => {
+  for (const entry of CITATIONS) {
+    it(`${entry.name} === ${entry.expected} (${entry.citation})`, () => {
+      expect(entry.value).toBe(entry.expected);
+      expect(entry.citation.length).toBeGreaterThan(20);
+    });
+  }
+
+  it('REGULATORY_CONSTANTS_VERSION is set — bump on any citation change', () => {
+    expect(typeof REGULATORY_CONSTANTS_VERSION).toBe('string');
+    expect(REGULATORY_CONSTANTS_VERSION.length).toBeGreaterThan(0);
+  });
+
+  it('citations cover the full set of filing-deadline + threshold constants', () => {
+    // Sentinel: if a new filing deadline / threshold constant is added
+    // to src/domain/constants.ts, the developer must add it here too.
+    // We assert a minimum count so an accidental delete also trips it.
+    expect(CITATIONS.length).toBeGreaterThanOrEqual(13);
+  });
+});


### PR DESCRIPTION
## Summary

Five focused fixes from the deep audit, shipped together:

| # | Fix | Severity | Files |
|---|---|---|---|
| 1 | **Dubai-local date arithmetic** — `formatDateDDMMYYYY` and `isSameDate` now use `Intl.DateTimeFormat` with `timeZone: 'Asia/Dubai'`. Was returning UTC day-of-month on Netlify, causing off-by-one bugs between 20:00–24:00 UTC. | P0 | `src/utils/dates.ts`, `src/services/morningBriefingGenerator.ts` |
| 2 | **Blob-store pagination** — `listAllBlobs()` helper walks every page via the SDK's `paginate: true` async iterator. Previously `.list({ prefix })` only returned the first page; older audit entries were silently skipped above ~1000 blobs. | P1 | `morning-briefing-cron.mts`, `sanctions-watch-cron.mts`, `sanctions-ingest-status.mts` |
| 3 | **Regulatory citation lock** (new test file, 130 lines) — single source-of-truth table pairing each filing-deadline / threshold with its FDL / Cabinet Res / MoE Circular citation. `expect.toBe(value)` + `expect(citation.length).toBeGreaterThan(20)` per row. Includes a sentinel `CITATIONS.length >= 13` to catch silent deletes. | P1 | `tests/regulatoryCitationLock.test.ts` (new) |
| 4 | **Cross-source correlation scoring** — after the per-(customer, target) match loop, group hits by customerId. A subject matching on 2+ distinct sources gets `+0.2` per extra source (cap 0.99), re-derived band/action, and a `cross-source-x<N>` reason tag. UN + OFAC + EU now correctly auto-escalates to confirmed under FATF Rec 6 multi-source confirmation. | P2 | `src/services/sanctionsDeltaCohortScreener.ts` |
| 5 | **Incomplete-briefing banner** (mitigates P0 "MLRO sees no items when breaches exist") — added optional `unwiredDataSources` to all 3 generators. Renders a loud `⚠ INCOMPLETE BRIEFING — N data source(s) not yet wired: …` banner above the report. The 3 crons now declare honestly which arrays are empty because the persistence layer does not yet exist. The MLRO is told the absence is a wiring gap, not a clean state. | P0 mitigation | All 3 generators, all 3 crons |

## Tests

- 9 specs in `tests/morningBriefingGenerator.test.ts` (added 3 for the banner)
- 15 specs in `tests/regulatoryCitationLock.test.ts` (new)
- Full suite: **4056 / 4056 passing**
- `npx tsc --noEmit` clean
- `npx prettier --check` clean

## Deferred (still in the audit backlog — future PRs)

- **P0**: Persistence layer for frozen-subjects / approvals / filings / screeningRuns / recentFalsePositives. The 5 unwired sources flagged by the new banner. Multi-PR scoping needed.
- **P1**: Trend baselines (7-day rolling), dismissal feedback loop.
- **P2**: Adverse media, dashboard, four-eyes Asana workflow, customer Gantt timeline, full-text briefing search.

## Regulatory citations

- FDL No.10/2025 Art.20-22 (CO duty of care — banner + completeness)
- FDL No.10/2025 Art.24 (audit trail accuracy — Dubai dates)
- FDL No.10/2025 Art.26-27 (STR/CTR — citation lock)
- FDL No.10/2025 Art.29 (no tipping off — preserved across all generators)
- FDL No.10/2025 Art.35 (TFS completeness — pagination, cross-source)
- Cabinet Res 74/2020 Art.4-7 (freeze, EOCN, CNMR)
- Cabinet Res 134/2025 Art.7-19 (CDD tiers, Senior Mgmt approval, review cadence)
- MoE Circular 08/AML/2021 (DPMS thresholds)
- Cabinet Decision 109/2023 (UBO 25% threshold + 15WD re-verification)
- FATF Rec 6 (multi-source UN sanctions implementation — cross-source boost)

https://claude.ai/code/session_01K4twBZwq6wDoyF8GptSNQx