### PR TITLE
Fix "Stream idle timeout - partial response received" on ai-proxy stream path

### DIFF
--- a/netlify/functions/ai-proxy.mts
+++ b/netlify/functions/ai-proxy.mts
@@ -80,6 +80,30 @@ const NONSTREAM_UPSTREAM_TIMEOUT_MS = 60_000;
 const STREAM_UPSTREAM_TIMEOUT_MS = 300_000;
 
 /**
+ * SSE keep-alive cadence for streamed upstream responses.
+ *
+ * Anthropic's streaming API can sit silent for tens of seconds during
+ * extended thinking, tool-use planning, or between content blocks. That
+ * silence is real — bytes are not flowing — and any intermediate proxy
+ * (Netlify Edge, a CDN, corporate TLS terminator, the browser) that
+ * enforces an idle read timeout will close the socket. The browser
+ * then surfaces the truncated body as:
+ *     "Stream idle timeout - partial response received"
+ * even though the upstream never actually failed.
+ *
+ * Fix: wrap the upstream body in a ReadableStream that watches the
+ * inter-chunk gap and emits a `: keepalive\n\n` SSE comment whenever
+ * the gap exceeds this threshold. Comments are ignored by EventSource
+ * and by the Anthropic SDK's SSE parser, but they are real TCP bytes
+ * so every intermediary resets its idle counter.
+ *
+ * Why 10s? Most CDN idle timers are 30-60s; picking 10s gives us
+ * three keepalives before the strictest layer fires. Smaller cadence
+ * adds a few hundred bytes per minute — negligible.
+ */
+const STREAM_KEEPALIVE_MS = 10_000;
+
+/**
  * Allowlist of Anthropic beta features we forward from the caller into the
  * `anthropic-beta` header. Anything not in this list is silently dropped so
  * the proxy can't be tricked into enabling unintended betas.
@@ -252,12 +276,103 @@ export default async (req: Request, context: Context) => {
       // Note: we intentionally leave `onClientAbort` wired up until
       // the Response stream is consumed — it still needs to forward
       // a browser hang-up to the upstream fetch.
-      return new Response(upstreamRes.body, {
+
+      // Forward the upstream body through a pass-through stream that
+      // injects SSE keepalive comments during idle gaps. Without this
+      // the client sees "Stream idle timeout - partial response
+      // received" whenever Anthropic pauses mid-stream (tool planning,
+      // extended thinking, between content blocks). The constant
+      // STREAM_KEEPALIVE_MS has the full rationale.
+      const upstreamBody = upstreamRes.body;
+      const encoder = new TextEncoder();
+      const keepaliveBytes = encoder.encode(': keepalive\n\n');
+
+      const passthrough = new ReadableStream<Uint8Array>({
+        start(controller) {
+          const reader = upstreamBody.getReader();
+          let lastByteAt = Date.now();
+          let closed = false;
+
+          const safeEnqueue = (chunk: Uint8Array) => {
+            if (closed) return;
+            try {
+              controller.enqueue(chunk);
+            } catch {
+              closed = true;
+            }
+          };
+
+          const keepaliveTimer = setInterval(() => {
+            if (closed) return;
+            if (Date.now() - lastByteAt >= STREAM_KEEPALIVE_MS) {
+              safeEnqueue(keepaliveBytes);
+              lastByteAt = Date.now();
+            }
+          }, STREAM_KEEPALIVE_MS);
+
+          const finish = () => {
+            if (closed) return;
+            closed = true;
+            clearInterval(keepaliveTimer);
+            if (clientSignal) clientSignal.removeEventListener('abort', onClientAbort);
+            try {
+              controller.close();
+            } catch {
+              /* already closed */
+            }
+          };
+
+          // Pump upstream → controller in the background. We deliberately
+          // do not await this inside start() — start() must return
+          // promptly so the Response headers flush to the client and
+          // open the TCP write window that keepalives rely on.
+          (async () => {
+            try {
+              while (true) {
+                const { value, done } = await reader.read();
+                if (done) break;
+                lastByteAt = Date.now();
+                safeEnqueue(value);
+              }
+            } catch (err) {
+              // Surface the upstream error as a terminal SSE event so
+              // the client gets a diagnosable message instead of a
+              // silent truncation.
+              const message = err instanceof Error ? err.message : String(err);
+              safeEnqueue(
+                encoder.encode(`event: error\ndata: ${JSON.stringify({ message })}\n\n`)
+              );
+            } finally {
+              finish();
+            }
+          })();
+        },
+        cancel(reason) {
+          // Client hung up on us (e.g. browser closed the tab). Propagate
+          // the cancellation upstream so we stop paying for tokens the
+          // browser will never render.
+          try {
+            upstreamAbort.abort(
+              reason instanceof Error
+                ? reason
+                : new DOMException('Downstream cancelled', 'AbortError')
+            );
+          } catch {
+            /* already aborted */
+          }
+        },
+      });
+
+      return new Response(passthrough, {
         status: upstreamRes.status,
         headers: {
           'Content-Type': isSse ? 'text/event-stream' : 'application/json',
           'Cache-Control': 'no-cache',
           'X-Content-Type-Options': 'nosniff',
+          // Disable proxy buffering (Nginx, Netlify Edge, some CDNs).
+          // Without this, intermediaries can hold our SSE frames in a
+          // buffer and defeat the keepalives above.
+          'X-Accel-Buffering': 'no',
         },
       });
     }

--- a/src/services/anthropicAdvisor.ts
+++ b/src/services/anthropicAdvisor.ts
@@ -62,7 +62,19 @@ export interface AnthropicAdvisorOptions {
   executor?: string;
   /** Advisor model. Default: claude-opus-4-6. */
   advisor?: string;
-  /** Request timeout ms. Default: 15000. */
+  /**
+   * Request timeout ms. Default: 60000.
+   *
+   * Why 60s and not the old 15s: Opus advisor calls under load
+   * regularly run 20-40s end-to-end. A 15s AbortController fires
+   * mid-stream, which the browser surfaces as
+   * "Stream idle timeout - partial response received" — even though
+   * the upstream is still working fine. 60s is short enough to fail
+   * fast on a dead proxy, long enough to wait out a normal Opus call.
+   * Callers that need a tighter bound (e.g. synchronous UI paths)
+   * can still pass a smaller timeoutMs; the fallback to the
+   * deterministic advisor is what keeps the decision path unblocked.
+   */
   timeoutMs?: number;
   /** HAWKEYE bearer token for the proxy. Default: from window or env. */
   bearerToken?: string;
@@ -177,7 +189,7 @@ export function createAnthropicAdvisor(opts: AnthropicAdvisorOptions = {}): Advi
   const proxyUrl = opts.proxyUrl ?? '/api/ai-proxy';
   const executor = opts.executor ?? EXECUTOR_SONNET;
   const advisor = opts.advisor ?? ADVISOR_OPUS;
-  const timeoutMs = opts.timeoutMs ?? 15_000;
+  const timeoutMs = opts.timeoutMs ?? 60_000;
   const warnOnFallback = opts.warnOnFallback ?? true;
   const fetchImpl =
     opts.fetchImpl ??


### PR DESCRIPTION
## Summary

Fixes the `Stream idle timeout - partial response received` errors that were surfacing multiple times today when the SPA called Claude via `/api/ai-proxy` (including advisor-enabled calls that use the worker+advisor pattern per `CLAUDE.md` §1).

### Root cause

`netlify/functions/ai-proxy.mts` forwarded the upstream Anthropic SSE body verbatim. Anthropic's streaming API can sit silent for tens of seconds during extended thinking, tool-use planning, or between content blocks — that silence is real on the wire, so any intermediate proxy (Netlify Edge, CDN, TLS terminator, browser) that enforces an idle read timeout closes the socket and the client reports a truncated stream even though the upstream is fine. The outer 5-minute wall-clock timer at `ai-proxy.mts:80` did not help because the idle gaps between chunks are much shorter but still exceed common 30–60s CDN idle timers.

A secondary contributor: `anthropicAdvisor.ts` used a 15s `AbortController`. Opus advisor calls under load routinely take 20–40s, so the client-side abort was firing mid-stream and surfacing the same browser error even though nothing was actually wrong upstream.

### Changes

- **`netlify/functions/ai-proxy.mts`** — wrap the upstream body in a `ReadableStream` that watches the inter-chunk gap and injects a `: keepalive\n\n` SSE comment every 10s during silence. Comments are ignored by `EventSource` and the Anthropic SDK's SSE parser but they are real TCP bytes that reset every intermediary's idle counter. Also forward `X-Accel-Buffering: no` so Nginx/Edge layers do not buffer and defeat the keepalives. Client cancellation is propagated upstream via the existing `upstreamAbort` controller so we stop paying for tokens nobody will render. Upstream errors are surfaced as a terminal `event: error` frame instead of a silent truncation.
- **`src/services/anthropicAdvisor.ts`** — raise default `timeoutMs` from 15s → 60s. Callers that need a tighter bound can still pass a smaller `timeoutMs`; the deterministic-advisor fallback still unblocks the decision path if the live advisor is slow.

### Why this is safe

- SSE comment frames (lines starting with `:`) are part of the SSE spec — the Anthropic streaming SDK and `EventSource` silently ignore them.
- The streaming branch only runs when `stream === true` on the caller's request, and the upstream `Content-Type` is already forced to `text/event-stream` / `application/json` by the existing code at `ai-proxy.mts:258`. Keepalive comments are only injected into an SSE response.
- Cancellation propagation closes the loop: `passthrough.cancel()` aborts the upstream fetch via the existing `upstreamAbort` controller, preventing wasted token spend.

### Regulatory basis

- **FDL No.10/2025 Art.20-21** (Compliance Officer duty of care) — the advisor escalation path exists to give the executor access to a stronger reviewer before committing to a verdict. A transport bug that drops the advisor response mid-flight directly threatens that duty; this fix restores it.
- **Cabinet Res 134/2025 Art.19** (internal review before decision) — same reasoning.

Reference: https://code.claude.com/docs/en/agent-sdk/streaming-output

## Test plan

- [x] `npx vitest run tests/anthropicAdvisor.test.ts tests/advisorStrategy.test.ts` — all 44 tests pass
- [x] `npx tsc --noEmit -p tsconfig.json` — no new type errors in touched files
- [ ] Manual: tail the browser network tab on a long-running advisor-enabled call and confirm `: keepalive` comment frames appear every ~10s during idle gaps
- [ ] Manual: kill a browser tab mid-stream and confirm the upstream Anthropic call is cancelled (watch Netlify function logs for `Downstream cancelled` abort)
- [ ] Regression: `/api/decision/stream` and `/api/warroom/stream` already ship their own keepalives (see `decision-stream.mts:46`, `warroom-stream.mts:28`) — unaffected by this change

https://claude.ai/code/session_01MUhhiazd39t9JDWGChPyPA