### PR TITLE
Add deepResearchEngine + wire as weaponizedBrain subsystem #98

### DIFF
--- a/src/services/deepResearchEngine.ts
+++ b/src/services/deepResearchEngine.ts
@@ -1,0 +1,535 @@
+/**
+ * Deep Research Engine — iterative search → reason → cite loop for compliance.
+ *
+ * Adapts the Jina node-DeepResearch pattern (vendor/node-DeepResearch) into a
+ * browser-safe, dependency-injected engine that powers compliance use cases
+ * the existing single-shot adverseMediaSearch + adverseMediaRanker pair cannot:
+ *
+ *   - Multi-step adverse media research (cross-corroboration across sources)
+ *   - EDD on opaque counterparties (iterative UBO trace, shell-company hunt)
+ *   - Pre-filing STR narrative drafting (gather facts → cite → draft)
+ *
+ * KEY DESIGN CONSTRAINTS
+ *
+ *  1. Browser-safe. No `fetch` import; all I/O is delegated to injected
+ *     functions so the engine itself is pure orchestration logic and unit
+ *     testable without network access.
+ *
+ *  2. Compliance carve-outs. The compliance work this engine does is what
+ *     the auditor will look at first, so the engine MUST:
+ *
+ *       - Redact PII (national IDs, account numbers, passport numbers, IBANs)
+ *         from every query before sending it to an external search backend.
+ *         FDL No.10/2025 Art.29 — never tip off the subject.
+ *       - Log every external call with timestamp, original query, redacted
+ *         query, backend name, and result count. FDL No.10/2025 Art.24 —
+ *         record retention.
+ *       - Maintain citation discipline. Every claim in the final answer must
+ *         carry at least one source URL. Claims with zero sources are
+ *         dropped, not silently retained.
+ *       - Apply a corroboration floor. The engine never reports
+ *         confidence >= HIGH unless at least two independent sources (by
+ *         hostname) corroborate the claim.
+ *
+ *  3. Bounded. max_iterations and max_queries_per_iteration are hard caps
+ *     enforced by the loop, not advisory parameters. Runaway research is a
+ *     real risk with iterative agents and a real cost in real money.
+ *
+ *  4. Auditor-friendly output. Every iteration's plan / search / extract /
+ *     reflect step is captured in the reasoningChain so an MLRO or external
+ *     auditor can replay the full investigation path.
+ *
+ * REGULATORY BASIS
+ *
+ *   - FDL No.10/2025 Art.19    — risk-based internal review
+ *   - FDL No.10/2025 Art.24    — record retention (audit log of every step)
+ *   - FDL No.10/2025 Art.29    — no tipping off (PII redaction)
+ *   - Cabinet Res 134/2025 Art.14 — PEP / EDD enhanced research
+ *   - FATF Rec 10              — ongoing monitoring, adverse media input
+ */
+
+// ---------------------------------------------------------------------------
+// Public input / output types
+// ---------------------------------------------------------------------------
+
+export type ResearchPurpose =
+  | 'adverse_media'
+  | 'edd_counterparty'
+  | 'str_narrative'
+  | 'general_compliance';
+
+export interface EntityContext {
+  /** Display name used to seed queries. Should already be a reasonable public name. */
+  displayName: string;
+  /** Optional aliases (legal name, trading name, transliterations). */
+  aliases?: readonly string[];
+  /** ISO-3166-1 alpha-2 country code where the entity is based. */
+  jurisdiction?: string;
+  /** True if the entity is a natural person (drives PII redaction strictness). */
+  isNaturalPerson?: boolean;
+}
+
+export interface DeepResearchInput {
+  question: string;
+  entity: EntityContext;
+  purpose: ResearchPurpose;
+  /** Hard cap on iterations of plan→search→extract→reflect. Default 3. */
+  maxIterations?: number;
+  /** Hard cap on queries dispatched per iteration. Default 4. */
+  maxQueriesPerIteration?: number;
+  /**
+   * Wall-clock deadline. Engine returns whatever it has at the deadline
+   * with `truncated: true`. Default: no deadline.
+   */
+  deadlineMs?: number;
+}
+
+export type ResearchVerdictHint = 'no_signal' | 'soft_signal' | 'material_signal' | 'critical';
+
+export type ResearchConfidence = 'low' | 'medium' | 'high';
+
+export interface SearchHit {
+  url: string;
+  title: string;
+  snippet: string;
+}
+
+export interface ResearchClaim {
+  /** The factual statement, in the engine's own words. */
+  text: string;
+  /** Source URLs that support this claim. Always >= 1. */
+  sources: readonly string[];
+  /** Distinct hostnames among the sources (for corroboration scoring). */
+  distinctHostnames: number;
+  /** 'low' | 'medium' | 'high' — derived from distinctHostnames + relevance. */
+  confidence: ResearchConfidence;
+  /** Severity tag the engine assigned during reflection. */
+  severity: 'critical' | 'material' | 'ambient' | 'low_signal';
+}
+
+export interface ReasoningStep {
+  iteration: number;
+  phase: 'plan' | 'search' | 'extract' | 'reflect' | 'synthesize';
+  detail: string;
+  durationMs?: number;
+  tookActions?: number;
+}
+
+export interface ResearchAuditLogEntry {
+  timestampIso: string;
+  iteration: number;
+  backend: 'search' | 'extract' | 'reason';
+  originalQuery: string;
+  /** Query as actually sent — PII redacted. */
+  sentQuery: string;
+  resultCount: number;
+  /** True if the redactor found and stripped PII patterns. */
+  redactedFields: readonly string[];
+}
+
+export interface DeepResearchResult {
+  question: string;
+  entity: EntityContext;
+  purpose: ResearchPurpose;
+  /** Plain-text synthesis of the strongest claims. Always includes inline [n] citations. */
+  answer: string;
+  /** Structured claims with sources. The MLRO pivots off these, not `answer`. */
+  claims: readonly ResearchClaim[];
+  /** Verdict hint the brain's clamp logic uses to decide whether to escalate. */
+  verdictHint: ResearchVerdictHint;
+  /** Aggregate confidence: lowest claim confidence among the strongest claims. */
+  confidence: ResearchConfidence;
+  /** Each iteration's plan/search/extract/reflect/synth steps in order. */
+  reasoningChain: readonly ReasoningStep[];
+  /** Every external call made, in order. Required by FDL Art.24. */
+  auditLog: readonly ResearchAuditLogEntry[];
+  /** All queries dispatched (post-redaction). */
+  queriesUsed: readonly string[];
+  /** True if any query needed PII redaction before being sent. */
+  piiRedactionApplied: boolean;
+  /** True if the engine bailed early on deadline / max iterations. */
+  truncated: boolean;
+  /** The reason the loop terminated. */
+  terminationReason: 'answer_found' | 'max_iterations' | 'deadline' | 'no_signal';
+}
+
+// ---------------------------------------------------------------------------
+// Dependency injection — pluggable backends
+// ---------------------------------------------------------------------------
+
+export type SearchFn = (query: string) => Promise<readonly SearchHit[]>;
+
+export type ExtractFn = (url: string) => Promise<string | null>;
+
+export interface ReasonInput {
+  iteration: number;
+  question: string;
+  entity: EntityContext;
+  purpose: ResearchPurpose;
+  knowledgeSoFar: readonly ResearchClaim[];
+  latestSnippets: readonly SearchHit[];
+}
+
+export interface ReasonOutput {
+  /** Newly observed claims for this iteration (will be merged into knowledge). */
+  newClaims: readonly Omit<ResearchClaim, 'distinctHostnames' | 'confidence'>[];
+  /** New sub-queries to dispatch in the NEXT iteration. Empty = stop. */
+  nextQueries: readonly string[];
+  /** True if the reasoner believes the question is sufficiently answered. */
+  done: boolean;
+  /** Free-text rationale the engine records in the reasoningChain. */
+  rationale: string;
+}
+
+export type ReasonFn = (input: ReasonInput) => Promise<ReasonOutput>;
+
+export interface DeepResearchDeps {
+  search: SearchFn;
+  extract: ExtractFn;
+  reason: ReasonFn;
+  /** Override clock for deterministic tests. Default Date.now. */
+  now?: () => number;
+}
+
+// ---------------------------------------------------------------------------
+// PII redactor — never tip off (FDL Art.29)
+// ---------------------------------------------------------------------------
+
+// Order matters: more-specific patterns must run first so the generic
+// digit-run rule does not consume substrings that would have matched
+// e.g. phone numbers or Emirates IDs.
+const PII_PATTERNS: readonly { name: string; re: RegExp }[] = [
+  // Emirates ID: 784-YYYY-NNNNNNN-N (15 digits with optional dashes)
+  { name: 'emirates_id', re: /\b784[-\s]?\d{4}[-\s]?\d{7}[-\s]?\d\b/g },
+  // IBAN (UAE: AE + 21 digits, generic: 2 letters + 13–32 alphanum)
+  { name: 'iban', re: /\b[A-Z]{2}\d{2}[A-Z0-9]{11,30}\b/g },
+  // Email (PII when bound to a subject; redact for tip-off safety)
+  { name: 'email', re: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g },
+  // Phone with international prefix (+9715xxxxxxxx etc.). Must precede
+  // account_number so the leading + isn't stranded after a generic digit
+  // run consumes the trailing digits.
+  { name: 'phone', re: /\+\d{8,15}\b/g },
+  // Generic passport-ish: 1 letter + 7-9 digits, or 9 alphanumerics
+  { name: 'passport', re: /\b[A-Z]\d{7,9}\b/g },
+  // Long account-number-ish digit runs (>=10 digits) — runs LAST so
+  // it doesn't pre-consume Emirates IDs, IBANs, or phone digits.
+  { name: 'account_number', re: /\b\d{10,}\b/g },
+];
+
+export interface RedactionResult {
+  cleaned: string;
+  fieldsFound: readonly string[];
+}
+
+export function redactPiiForExternalQuery(input: string): RedactionResult {
+  let cleaned = input;
+  const fields = new Set<string>();
+  for (const { name, re } of PII_PATTERNS) {
+    if (re.test(cleaned)) {
+      fields.add(name);
+      cleaned = cleaned.replace(re, `[REDACTED:${name}]`);
+    }
+    re.lastIndex = 0;
+  }
+  return { cleaned, fieldsFound: [...fields] };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function hostnameOf(url: string): string {
+  try {
+    return new URL(url).hostname.toLowerCase().replace(/^www\./, '');
+  } catch {
+    return url; // best effort for non-URL refs
+  }
+}
+
+function distinctHostnames(sources: readonly string[]): number {
+  return new Set(sources.map(hostnameOf)).size;
+}
+
+function confidenceFor(distinctHosts: number, severity: ResearchClaim['severity']): ResearchConfidence {
+  if (severity === 'critical' && distinctHosts >= 2) return 'high';
+  if (distinctHosts >= 3) return 'high';
+  if (distinctHosts >= 2) return 'medium';
+  return 'low';
+}
+
+function aggregateVerdictHint(claims: readonly ResearchClaim[]): ResearchVerdictHint {
+  if (claims.length === 0) return 'no_signal';
+  const hasCriticalCorroborated = claims.some(
+    (c) => c.severity === 'critical' && c.distinctHostnames >= 2
+  );
+  if (hasCriticalCorroborated) return 'critical';
+  if (claims.some((c) => c.severity === 'critical' || c.severity === 'material')) {
+    return 'material_signal';
+  }
+  if (claims.some((c) => c.severity === 'ambient')) return 'soft_signal';
+  return 'no_signal';
+}
+
+function aggregateConfidence(claims: readonly ResearchClaim[]): ResearchConfidence {
+  if (claims.length === 0) return 'low';
+  // Lowest confidence among the strongest claims = honest reporting.
+  const ranking: Record<ResearchConfidence, number> = { low: 0, medium: 1, high: 2 };
+  const strongest = [...claims].sort(
+    (a, b) => (ranking[b.confidence] - ranking[a.confidence])
+  );
+  // Take the top 3 and report the WEAKEST among them
+  const topK = strongest.slice(0, Math.min(3, strongest.length));
+  return topK.reduce<ResearchConfidence>(
+    (acc, c) => (ranking[c.confidence] < ranking[acc] ? c.confidence : acc),
+    'high'
+  );
+}
+
+function buildAnswer(claims: readonly ResearchClaim[]): string {
+  if (claims.length === 0) {
+    return 'No corroborated signal was found within the research budget.';
+  }
+  const sorted = [...claims].sort((a, b) => b.distinctHostnames - a.distinctHostnames);
+  const lines: string[] = [];
+  let citationIndex = 1;
+  const seenSources = new Map<string, number>();
+  const footnotes: string[] = [];
+  for (const claim of sorted) {
+    const refIds: number[] = [];
+    for (const src of claim.sources) {
+      let id = seenSources.get(src);
+      if (id === undefined) {
+        id = citationIndex++;
+        seenSources.set(src, id);
+        footnotes.push(`[${id}] ${src}`);
+      }
+      refIds.push(id);
+    }
+    const refStr = refIds.map((n) => `[${n}]`).join('');
+    lines.push(`- (${claim.severity}, ${claim.confidence}) ${claim.text} ${refStr}`);
+  }
+  lines.push('');
+  lines.push('Sources:');
+  lines.push(...footnotes);
+  return lines.join('\n');
+}
+
+function mergeClaims(
+  existing: readonly ResearchClaim[],
+  incoming: readonly Omit<ResearchClaim, 'distinctHostnames' | 'confidence'>[]
+): ResearchClaim[] {
+  const byText = new Map<string, ResearchClaim>();
+  for (const c of existing) byText.set(c.text.toLowerCase(), c);
+  for (const c of incoming) {
+    const key = c.text.toLowerCase();
+    const prior = byText.get(key);
+    const allSources = prior
+      ? Array.from(new Set([...prior.sources, ...c.sources]))
+      : Array.from(new Set(c.sources));
+    if (allSources.length === 0) continue; // citation discipline
+    const distinctHosts = distinctHostnames(allSources);
+    const merged: ResearchClaim = {
+      text: c.text,
+      sources: allSources,
+      distinctHostnames: distinctHosts,
+      severity: c.severity,
+      confidence: confidenceFor(distinctHosts, c.severity),
+    };
+    byText.set(key, merged);
+  }
+  return [...byText.values()];
+}
+
+// ---------------------------------------------------------------------------
+// The engine
+// ---------------------------------------------------------------------------
+
+export async function runDeepResearch(
+  input: DeepResearchInput,
+  deps: DeepResearchDeps
+): Promise<DeepResearchResult> {
+  const now = deps.now ?? (() => Date.now());
+  const startedAt = now();
+  const deadline = input.deadlineMs ? startedAt + input.deadlineMs : Number.POSITIVE_INFINITY;
+  const maxIterations = Math.max(1, input.maxIterations ?? 3);
+  const maxQueriesPerIteration = Math.max(1, input.maxQueriesPerIteration ?? 4);
+
+  const reasoningChain: ReasoningStep[] = [];
+  const auditLog: ResearchAuditLogEntry[] = [];
+  const queriesUsed: string[] = [];
+  let piiRedactionApplied = false;
+  let claims: ResearchClaim[] = [];
+
+  // Seed query: the question itself, scoped by the entity name.
+  const seed = `${input.question} "${input.entity.displayName}"`;
+  let pendingQueries: string[] = [seed];
+
+  let terminationReason: DeepResearchResult['terminationReason'] = 'max_iterations';
+  let truncated = false;
+
+  for (let iter = 1; iter <= maxIterations; iter++) {
+    if (now() >= deadline) {
+      terminationReason = 'deadline';
+      truncated = true;
+      break;
+    }
+
+    // 1. PLAN — record the queries we're about to dispatch.
+    const planStart = now();
+    const queriesThisIter = pendingQueries.slice(0, maxQueriesPerIteration);
+    pendingQueries = pendingQueries.slice(maxQueriesPerIteration); // carry overflow
+    reasoningChain.push({
+      iteration: iter,
+      phase: 'plan',
+      detail: `Planned ${queriesThisIter.length} queries: ${queriesThisIter.join(' | ')}`,
+      durationMs: now() - planStart,
+      tookActions: queriesThisIter.length,
+    });
+
+    // 2. SEARCH — redact PII, dispatch, log every call.
+    const searchStart = now();
+    const allHits: SearchHit[] = [];
+    for (const rawQ of queriesThisIter) {
+      if (now() >= deadline) {
+        terminationReason = 'deadline';
+        truncated = true;
+        break;
+      }
+      const redacted = redactPiiForExternalQuery(rawQ);
+      if (redacted.fieldsFound.length > 0) piiRedactionApplied = true;
+      const sentQuery = redacted.cleaned;
+      queriesUsed.push(sentQuery);
+      const hits = await deps.search(sentQuery);
+      auditLog.push({
+        timestampIso: new Date(now()).toISOString(),
+        iteration: iter,
+        backend: 'search',
+        originalQuery: rawQ,
+        sentQuery,
+        resultCount: hits.length,
+        redactedFields: redacted.fieldsFound,
+      });
+      allHits.push(...hits);
+    }
+    reasoningChain.push({
+      iteration: iter,
+      phase: 'search',
+      detail: `Got ${allHits.length} hits across ${queriesThisIter.length} queries`,
+      durationMs: now() - searchStart,
+      tookActions: allHits.length,
+    });
+
+    // 3. EXTRACT — pull text from the top-K URLs (deduped by hostname,
+    //    cap at 6 to keep token budget bounded). We don't propagate the
+    //    extracted text in the engine output — the reasoner consumes it
+    //    in-memory, and the audit log captures the URL fetch.
+    const extractStart = now();
+    const dedupHits: SearchHit[] = [];
+    const seenHosts = new Set<string>();
+    for (const hit of allHits) {
+      const host = hostnameOf(hit.url);
+      if (seenHosts.has(host)) continue;
+      seenHosts.add(host);
+      dedupHits.push(hit);
+      if (dedupHits.length >= 6) break;
+    }
+    let extractedCount = 0;
+    for (const hit of dedupHits) {
+      if (now() >= deadline) {
+        terminationReason = 'deadline';
+        truncated = true;
+        break;
+      }
+      const text = await deps.extract(hit.url);
+      auditLog.push({
+        timestampIso: new Date(now()).toISOString(),
+        iteration: iter,
+        backend: 'extract',
+        originalQuery: hit.url,
+        sentQuery: hit.url,
+        resultCount: text ? 1 : 0,
+        redactedFields: [],
+      });
+      if (text) extractedCount++;
+    }
+    reasoningChain.push({
+      iteration: iter,
+      phase: 'extract',
+      detail: `Extracted ${extractedCount}/${dedupHits.length} URLs (deduped by hostname)`,
+      durationMs: now() - extractStart,
+      tookActions: extractedCount,
+    });
+
+    // 4. REFLECT — let the reasoner inspect the snippets and emit new claims
+    //    + next queries. The reasoner is the only LLM-bearing dep; everything
+    //    else is mechanical so it can be tested without network.
+    const reflectStart = now();
+    const reasonOut = await deps.reason({
+      iteration: iter,
+      question: input.question,
+      entity: input.entity,
+      purpose: input.purpose,
+      knowledgeSoFar: claims,
+      latestSnippets: dedupHits,
+    });
+    auditLog.push({
+      timestampIso: new Date(now()).toISOString(),
+      iteration: iter,
+      backend: 'reason',
+      originalQuery: input.question,
+      sentQuery: input.question,
+      resultCount: reasonOut.newClaims.length,
+      redactedFields: [],
+    });
+
+    claims = mergeClaims(claims, reasonOut.newClaims);
+    reasoningChain.push({
+      iteration: iter,
+      phase: 'reflect',
+      detail:
+        `${reasonOut.newClaims.length} new claims, ${reasonOut.nextQueries.length} ` +
+        `follow-up queries. Rationale: ${reasonOut.rationale}`,
+      durationMs: now() - reflectStart,
+      tookActions: reasonOut.newClaims.length,
+    });
+
+    if (reasonOut.done) {
+      terminationReason = claims.length > 0 ? 'answer_found' : 'no_signal';
+      break;
+    }
+
+    // Carry the reasoner's follow-ups into the next iteration's queue.
+    pendingQueries = [...pendingQueries, ...reasonOut.nextQueries];
+    if (pendingQueries.length === 0) {
+      terminationReason = claims.length > 0 ? 'answer_found' : 'no_signal';
+      break;
+    }
+  }
+
+  // 5. SYNTHESIZE — build the final answer with citations.
+  const synthStart = now();
+  const answer = buildAnswer(claims);
+  reasoningChain.push({
+    iteration: 0,
+    phase: 'synthesize',
+    detail: `Built final answer from ${claims.length} corroborated claims`,
+    durationMs: now() - synthStart,
+    tookActions: claims.length,
+  });
+
+  return {
+    question: input.question,
+    entity: input.entity,
+    purpose: input.purpose,
+    answer,
+    claims,
+    verdictHint: aggregateVerdictHint(claims),
+    confidence: aggregateConfidence(claims),
+    reasoningChain,
+    auditLog,
+    queriesUsed,
+    piiRedactionApplied,
+    truncated,
+    terminationReason,
+  };
+}

--- a/src/services/deepResearchEngine.ts
+++ b/src/services/deepResearchEngine.ts
@@ -250,7 +250,10 @@ function distinctHostnames(sources: readonly string[]): number {
   return new Set(sources.map(hostnameOf)).size;
 }
 
-function confidenceFor(distinctHosts: number, severity: ResearchClaim['severity']): ResearchConfidence {
+function confidenceFor(
+  distinctHosts: number,
+  severity: ResearchClaim['severity']
+): ResearchConfidence {
   if (severity === 'critical' && distinctHosts >= 2) return 'high';
   if (distinctHosts >= 3) return 'high';
   if (distinctHosts >= 2) return 'medium';
@@ -274,9 +277,7 @@ function aggregateConfidence(claims: readonly ResearchClaim[]): ResearchConfiden
   if (claims.length === 0) return 'low';
   // Lowest confidence among the strongest claims = honest reporting.
   const ranking: Record<ResearchConfidence, number> = { low: 0, medium: 1, high: 2 };
-  const strongest = [...claims].sort(
-    (a, b) => (ranking[b.confidence] - ranking[a.confidence])
-  );
+  const strongest = [...claims].sort((a, b) => ranking[b.confidence] - ranking[a.confidence]);
   // Take the top 3 and report the WEAKEST among them
   const topK = strongest.slice(0, Math.min(3, strongest.length));
   return topK.reduce<ResearchConfidence>(

--- a/src/services/weaponizedBrain.ts
+++ b/src/services/weaponizedBrain.ts
@@ -152,6 +152,13 @@ import {
   type CorrelationReport,
 } from './crossCustomerCorrelator';
 import { reviewExtensions, type TeacherExtensionReport } from './teacherExtensionReviewer';
+import {
+  runDeepResearch,
+  type DeepResearchDeps,
+  type DeepResearchResult,
+  type EntityContext,
+  type ResearchPurpose,
+} from './deepResearchEngine';
 
 // --- Phase 3 imports (#31-#40) ---
 import { analyseBenford, type BenfordReport } from './benfordAnalyzer';
@@ -1017,6 +1024,29 @@ export interface WeaponizedBrainRequest {
    */
   inductionSamples?: readonly LabeledSample[];
   inductionConfig?: InductionConfig;
+
+  /**
+   * #98 Deep research request. When present, the brain runs the iterative
+   * deepResearchEngine using the injected backends. Caller owns the
+   * search/extract/reason functions — this keeps the brain browser-safe and
+   * lets tests stub external I/O. Returns nothing if `deps` is omitted.
+   *
+   * Regulatory basis:
+   *   - FDL No.10/2025 Art.19  (risk-based internal review)
+   *   - FDL No.10/2025 Art.24  (audit trail of every external call)
+   *   - FDL No.10/2025 Art.29  (no tipping off — PII redactor in the engine)
+   *   - Cabinet Res 134/2025 Art.14 (PEP / EDD enhanced research)
+   *   - FATF Rec 10            (ongoing monitoring; adverse media input)
+   */
+  deepResearch?: {
+    question: string;
+    entity: EntityContext;
+    purpose: ResearchPurpose;
+    deps: DeepResearchDeps;
+    maxIterations?: number;
+    maxQueriesPerIteration?: number;
+    deadlineMs?: number;
+  };
 }
 
 export interface WeaponizedExtensions {
@@ -1212,6 +1242,15 @@ export interface WeaponizedExtensions {
   euAiActReadiness?: ReadinessScaffoldResult;
   /** #97 Rule induction — human-readable decision rules extracted from session data. */
   inducedRules?: LearnedRule[];
+
+  /**
+   * #98 Deep research engine — iterative search/reason/cite loop.
+   * Adverse media, EDD on opaque counterparties, STR narrative drafting.
+   * Adapts vendor/node-DeepResearch into a browser-safe, dep-injected engine.
+   * Regulatory basis: FDL Art.19 (risk-based review), Art.24 (audit trail),
+   * Art.29 (no tipping off — engine redacts PII before external queries).
+   */
+  deepResearch?: DeepResearchResult;
 }
 
 export interface WeaponizedBrainResponse {
@@ -2788,6 +2827,32 @@ export async function runWeaponizedBrain(
     if (rulesResult) extensions.inducedRules = rulesResult;
   }
 
+  // #98 Deep research engine — iterative search/reason/cite loop.
+  // Async because the engine awaits injected search/extract/reason backends.
+  // Failures escalate to manual review per FDL Art.24 — never silently swallowed.
+  if (req.deepResearch) {
+    const dr = req.deepResearch;
+    try {
+      extensions.deepResearch = await runDeepResearch(
+        {
+          question: dr.question,
+          entity: dr.entity,
+          purpose: dr.purpose,
+          maxIterations: dr.maxIterations,
+          maxQueriesPerIteration: dr.maxQueriesPerIteration,
+          deadlineMs: dr.deadlineMs,
+        },
+        dr.deps
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      subsystemFailures.push('deepResearchEngine');
+      clampReasons.push(
+        `CLAMP: subsystem deepResearchEngine failed (${message}) — manual review required (FDL Art.24)`
+      );
+    }
+  }
+
   // #88 Quantum-resistant seal — always runs last (seals everything above)
   {
     const sealRecords: QuantumSealRecord[] = [
@@ -2803,6 +2868,22 @@ export async function runWeaponizedBrain(
   // ---------------------------------------------------------------------------
   // Phase 4-10 safety clamps — monotone escalation only.
   // ---------------------------------------------------------------------------
+
+  // #98 Deep research critical signal → escalate. Critical verdictHint
+  // requires >=2 distinct hostnames corroborating a critical-severity claim
+  // (corroboration floor in deepResearchEngine), so this clamp only fires
+  // on real corroborated adverse signal — no single-source false positives.
+  // FATF Rec 10 + Cabinet Res 134/2025 Art.14 (EDD on adverse media).
+  if (extensions.deepResearch?.verdictHint === 'critical') {
+    finalVerdict = escalateTo(finalVerdict, 'escalate');
+    const claimCount = extensions.deepResearch.claims.filter(
+      (c) => c.severity === 'critical' && c.distinctHostnames >= 2
+    ).length;
+    clampReasons.push(
+      `CLAMP: deep research surfaced ${claimCount} corroborated critical claim(s) — ` +
+        `escalate (FATF Rec 10 + Cabinet Res 134/2025 Art.14 + FDL Art.19)`
+    );
+  }
 
   // #41 ESG critical risk → escalate (LBMA RGG v9 §6 / ISSB S1 materiality).
   if (extensions.esgScore?.riskLevel === 'critical') {
@@ -3949,6 +4030,15 @@ function buildAuditNarrative(
   if (extensions.inducedRules && extensions.inducedRules.length > 0) {
     lines.push(
       `  - Rule induction (#97): ${extensions.inducedRules.length} human-readable rule(s) extracted`
+    );
+  }
+  if (extensions.deepResearch) {
+    const dr = extensions.deepResearch;
+    lines.push(
+      `  - Deep research (#98): ${dr.claims.length} claim(s), verdictHint=${dr.verdictHint}, ` +
+        `confidence=${dr.confidence}, queries=${dr.queriesUsed.length}` +
+        (dr.piiRedactionApplied ? ', PII-redacted' : '') +
+        (dr.truncated ? ` (truncated: ${dr.terminationReason})` : '')
     );
   }
 

--- a/tests/deepResearchEngine.test.ts
+++ b/tests/deepResearchEngine.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Tests for deepResearchEngine — the iterative search/reason/cite loop.
+ *
+ * The engine is fully dependency-injected so every test stubs search,
+ * extract, and reason. No network, deterministic clock.
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  runDeepResearch,
+  redactPiiForExternalQuery,
+  type DeepResearchDeps,
+  type DeepResearchInput,
+  type SearchHit,
+} from '@/services/deepResearchEngine';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeClock(): { now: () => number; advance: (ms: number) => void } {
+  let t = 1_000_000;
+  return {
+    now: () => t,
+    advance: (ms: number) => {
+      t += ms;
+    },
+  };
+}
+
+function baseInput(overrides: Partial<DeepResearchInput> = {}): DeepResearchInput {
+  return {
+    question: 'Has this entity been involved in money laundering?',
+    entity: { displayName: 'Acme Trading LLC', jurisdiction: 'AE' },
+    purpose: 'adverse_media',
+    maxIterations: 2,
+    maxQueriesPerIteration: 2,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// PII redactor
+// ---------------------------------------------------------------------------
+
+describe('redactPiiForExternalQuery', () => {
+  it('redacts Emirates ID in any of the common formats', () => {
+    const r1 = redactPiiForExternalQuery('lookup 784-1990-1234567-1');
+    expect(r1.cleaned).toContain('[REDACTED:emirates_id]');
+    expect(r1.fieldsFound).toContain('emirates_id');
+    const r2 = redactPiiForExternalQuery('id 784199012345671');
+    expect(r2.cleaned).toContain('[REDACTED:emirates_id]');
+  });
+
+  it('redacts IBAN, passport, account numbers, email, and phone', () => {
+    const r = redactPiiForExternalQuery(
+      'subject A1234567 IBAN AE070331234567890123456 acct 12345678901 ' +
+        'email test@example.com phone +971501234567'
+    );
+    expect(r.fieldsFound).toEqual(
+      expect.arrayContaining(['passport', 'iban', 'account_number', 'email', 'phone'])
+    );
+    expect(r.cleaned).not.toContain('test@example.com');
+    expect(r.cleaned).not.toContain('+971501234567');
+  });
+
+  it('leaves PII-free text unchanged', () => {
+    const r = redactPiiForExternalQuery('Acme Trading LLC sanctions violation');
+    expect(r.cleaned).toBe('Acme Trading LLC sanctions violation');
+    expect(r.fieldsFound).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Engine: termination conditions
+// ---------------------------------------------------------------------------
+
+describe('runDeepResearch — termination', () => {
+  it('returns no_signal when reasoner is immediately done with empty claims', async () => {
+    const clock = makeClock();
+    const deps: DeepResearchDeps = {
+      search: async () => [],
+      extract: async () => null,
+      reason: async () => ({
+        newClaims: [],
+        nextQueries: [],
+        done: true,
+        rationale: 'Nothing found.',
+      }),
+      now: clock.now,
+    };
+    const r = await runDeepResearch(baseInput(), deps);
+    expect(r.terminationReason).toBe('no_signal');
+    expect(r.verdictHint).toBe('no_signal');
+    expect(r.confidence).toBe('low');
+    expect(r.claims).toHaveLength(0);
+  });
+
+  it('caps at maxIterations and reports truncation honestly', async () => {
+    const clock = makeClock();
+    let calls = 0;
+    const deps: DeepResearchDeps = {
+      search: async () => [{ url: 'https://a.com/x', title: 't', snippet: 's' }],
+      extract: async () => 'body',
+      reason: async () => {
+        calls++;
+        return {
+          newClaims: [],
+          nextQueries: ['next-iteration-query'],
+          done: false,
+          rationale: 'keep going',
+        };
+      },
+      now: clock.now,
+    };
+    const r = await runDeepResearch(baseInput({ maxIterations: 3 }), deps);
+    expect(calls).toBe(3);
+    expect(r.terminationReason).toBe('max_iterations');
+  });
+
+  it('honours wall-clock deadline', async () => {
+    const clock = makeClock();
+    const deps: DeepResearchDeps = {
+      search: async () => {
+        clock.advance(50);
+        return [];
+      },
+      extract: async () => null,
+      reason: async () => ({
+        newClaims: [],
+        nextQueries: ['x'],
+        done: false,
+        rationale: '',
+      }),
+      now: clock.now,
+    };
+    const r = await runDeepResearch(
+      baseInput({ maxIterations: 50, deadlineMs: 100 }),
+      deps
+    );
+    expect(r.truncated).toBe(true);
+    expect(r.terminationReason).toBe('deadline');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Engine: PII safety
+// ---------------------------------------------------------------------------
+
+describe('runDeepResearch — PII safety', () => {
+  it('redacts PII before sending to search backend (FDL Art.29 tip-off)', async () => {
+    const clock = makeClock();
+    const sentQueries: string[] = [];
+    const deps: DeepResearchDeps = {
+      search: async (q) => {
+        sentQueries.push(q);
+        return [];
+      },
+      extract: async () => null,
+      reason: async () => ({ newClaims: [], nextQueries: [], done: true, rationale: '' }),
+      now: clock.now,
+    };
+    const r = await runDeepResearch(
+      baseInput({
+        question: 'check 784-1990-1234567-1 and email john@acme.com',
+      }),
+      deps
+    );
+    expect(r.piiRedactionApplied).toBe(true);
+    for (const q of sentQueries) {
+      expect(q).not.toMatch(/784-1990-1234567-1/);
+      expect(q).not.toMatch(/john@acme\.com/);
+    }
+    // Audit log captures BOTH the original (private) query and the sent (redacted) one.
+    const searchEntries = r.auditLog.filter((e) => e.backend === 'search');
+    expect(searchEntries.length).toBeGreaterThan(0);
+    expect(searchEntries[0].originalQuery).toMatch(/784-1990-1234567-1/);
+    expect(searchEntries[0].sentQuery).not.toMatch(/784-1990-1234567-1/);
+    expect(searchEntries[0].redactedFields).toEqual(
+      expect.arrayContaining(['emirates_id', 'email'])
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Engine: corroboration + citation discipline
+// ---------------------------------------------------------------------------
+
+describe('runDeepResearch — corroboration + citations', () => {
+  it('drops claims with zero sources (citation discipline)', async () => {
+    const clock = makeClock();
+    const deps: DeepResearchDeps = {
+      search: async () => [{ url: 'https://reuters.com/a', title: 't', snippet: 's' }],
+      extract: async () => 'body',
+      reason: async () => ({
+        newClaims: [
+          { text: 'Has good sources', sources: ['https://reuters.com/a'], severity: 'material' },
+          { text: 'Has no sources at all', sources: [], severity: 'critical' },
+        ],
+        nextQueries: [],
+        done: true,
+        rationale: 'mixed',
+      }),
+      now: clock.now,
+    };
+    const r = await runDeepResearch(baseInput(), deps);
+    expect(r.claims).toHaveLength(1);
+    expect(r.claims[0].text).toBe('Has good sources');
+  });
+
+  it('upgrades confidence to high when >= 2 distinct hostnames corroborate a critical claim', async () => {
+    const clock = makeClock();
+    const hits: SearchHit[] = [
+      { url: 'https://reuters.com/a', title: 't', snippet: 's' },
+      { url: 'https://bbc.com/b', title: 't', snippet: 's' },
+    ];
+    const deps: DeepResearchDeps = {
+      search: async () => hits,
+      extract: async () => 'body',
+      reason: async () => ({
+        newClaims: [
+          {
+            text: 'Subject was indicted for sanctions violation',
+            sources: ['https://reuters.com/a', 'https://bbc.com/b'],
+            severity: 'critical',
+          },
+        ],
+        nextQueries: [],
+        done: true,
+        rationale: 'corroborated',
+      }),
+      now: clock.now,
+    };
+    const r = await runDeepResearch(baseInput(), deps);
+    expect(r.claims).toHaveLength(1);
+    expect(r.claims[0].confidence).toBe('high');
+    expect(r.claims[0].distinctHostnames).toBe(2);
+    expect(r.verdictHint).toBe('critical');
+  });
+
+  it('keeps a critical claim at low confidence when only one source supports it', async () => {
+    const clock = makeClock();
+    const deps: DeepResearchDeps = {
+      search: async () => [],
+      extract: async () => null,
+      reason: async () => ({
+        newClaims: [
+          {
+            text: 'Allegation in a single blog post',
+            sources: ['https://blogspot.example/x'],
+            severity: 'critical',
+          },
+        ],
+        nextQueries: [],
+        done: true,
+        rationale: 'thin',
+      }),
+      now: clock.now,
+    };
+    const r = await runDeepResearch(baseInput(), deps);
+    expect(r.claims[0].confidence).toBe('low');
+    // verdict still material_signal because severity=critical, but NOT 'critical'
+    // because corroboration floor wasn't met.
+    expect(r.verdictHint).toBe('material_signal');
+  });
+
+  it('builds an answer with inline numeric citations and a sources list', async () => {
+    const clock = makeClock();
+    const deps: DeepResearchDeps = {
+      search: async () => [],
+      extract: async () => null,
+      reason: async () => ({
+        newClaims: [
+          {
+            text: 'Indicted by US DOJ in 2024',
+            sources: ['https://justice.gov/p1', 'https://reuters.com/p2'],
+            severity: 'critical',
+          },
+          {
+            text: 'Adverse media in regional press',
+            sources: ['https://thenational.ae/q'],
+            severity: 'material',
+          },
+        ],
+        nextQueries: [],
+        done: true,
+        rationale: 'compose',
+      }),
+      now: clock.now,
+    };
+    const r = await runDeepResearch(baseInput(), deps);
+    expect(r.answer).toMatch(/\[1\]/);
+    expect(r.answer).toMatch(/\[2\]/);
+    expect(r.answer).toMatch(/Sources:/);
+    expect(r.answer).toMatch(/justice\.gov/);
+    expect(r.answer).toMatch(/reuters\.com/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Engine: bounded query budget
+// ---------------------------------------------------------------------------
+
+describe('runDeepResearch — bounded budget', () => {
+  it('never dispatches more than maxQueriesPerIteration per round', async () => {
+    const clock = makeClock();
+    let queriesPerCall = 0;
+    let maxQueriesObservedInOneRound = 0;
+    const deps: DeepResearchDeps = {
+      search: async () => {
+        queriesPerCall++;
+        return [];
+      },
+      extract: async () => null,
+      reason: async () => {
+        if (queriesPerCall > maxQueriesObservedInOneRound) {
+          maxQueriesObservedInOneRound = queriesPerCall;
+        }
+        queriesPerCall = 0;
+        return {
+          newClaims: [],
+          nextQueries: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'], // 8 follow-ups
+          done: false,
+          rationale: '',
+        };
+      },
+      now: clock.now,
+    };
+    await runDeepResearch(
+      baseInput({ maxIterations: 3, maxQueriesPerIteration: 3 }),
+      deps
+    );
+    expect(maxQueriesObservedInOneRound).toBeLessThanOrEqual(3);
+  });
+
+  it('records every external call in the audit log', async () => {
+    const clock = makeClock();
+    const deps: DeepResearchDeps = {
+      search: async () => [
+        { url: 'https://a.com/x', title: 't', snippet: 's' },
+        { url: 'https://b.com/y', title: 't', snippet: 's' },
+      ],
+      extract: async () => 'body',
+      reason: async () => ({
+        newClaims: [],
+        nextQueries: [],
+        done: true,
+        rationale: '',
+      }),
+      now: clock.now,
+    };
+    const r = await runDeepResearch(baseInput({ maxQueriesPerIteration: 1 }), deps);
+    // 1 search call + 2 extract calls + 1 reason call = 4 audit entries
+    expect(r.auditLog).toHaveLength(4);
+    const backends = r.auditLog.map((e) => e.backend);
+    expect(backends).toEqual(['search', 'extract', 'extract', 'reason']);
+  });
+
+  it('dedupes search hits by hostname before extract (extract budget bounded)', async () => {
+    const clock = makeClock();
+    const sameHostHits: SearchHit[] = Array.from({ length: 10 }, (_, i) => ({
+      url: `https://samehost.com/p${i}`,
+      title: 't',
+      snippet: 's',
+    }));
+    let extractCalls = 0;
+    const deps: DeepResearchDeps = {
+      search: async () => sameHostHits,
+      extract: async () => {
+        extractCalls++;
+        return 'body';
+      },
+      reason: async () => ({ newClaims: [], nextQueries: [], done: true, rationale: '' }),
+      now: clock.now,
+    };
+    await runDeepResearch(baseInput(), deps);
+    // All 10 hits are samehost.com → dedup leaves exactly 1 → 1 extract call
+    expect(extractCalls).toBe(1);
+  });
+});

--- a/tests/weaponizedBrain.test.ts
+++ b/tests/weaponizedBrain.test.ts
@@ -525,3 +525,162 @@ describe('weaponizedBrain — advisor escalation', () => {
     expect(received[0].reason).toContain('verdict=freeze');
   });
 });
+
+// ---------------------------------------------------------------------------
+// #98 Deep research engine integration
+// ---------------------------------------------------------------------------
+
+describe('weaponizedBrain — #98 deep research engine', () => {
+  it('subsystem is a no-op when req.deepResearch is omitted', async () => {
+    const r = await runWeaponizedBrain({ mega: cleanMegaRequest() });
+    expect(r.extensions.deepResearch).toBeUndefined();
+  });
+
+  it('runs the engine via injected deps and surfaces the result', async () => {
+    const r = await runWeaponizedBrain({
+      mega: cleanMegaRequest('E1', 'Acme Trading LLC'),
+      deepResearch: {
+        question: 'Any adverse media on this entity?',
+        entity: { displayName: 'Acme Trading LLC', jurisdiction: 'AE' },
+        purpose: 'adverse_media',
+        deps: {
+          search: async () => [],
+          extract: async () => null,
+          reason: async () => ({
+            newClaims: [],
+            nextQueries: [],
+            done: true,
+            rationale: 'nothing found',
+          }),
+        },
+      },
+    });
+    expect(r.extensions.deepResearch).toBeDefined();
+    expect(r.extensions.deepResearch?.verdictHint).toBe('no_signal');
+    expect(r.extensions.deepResearch?.terminationReason).toBe('no_signal');
+    // No clamp on a clean result
+    expect(r.clampReasons.some((c) => c.includes('deep research'))).toBe(false);
+  });
+
+  it('critical corroborated signal escalates a clean verdict', async () => {
+    const r = await runWeaponizedBrain({
+      mega: cleanMegaRequest('E2', 'Dirty Trading LLC'),
+      deepResearch: {
+        question: 'sanctions exposure',
+        entity: { displayName: 'Dirty Trading LLC', jurisdiction: 'AE' },
+        purpose: 'edd_counterparty',
+        deps: {
+          search: async () => [],
+          extract: async () => null,
+          reason: async () => ({
+            newClaims: [
+              {
+                text: 'OFAC SDN designation December 2025',
+                sources: ['https://treasury.gov/sdn/x', 'https://reuters.com/y'],
+                severity: 'critical',
+              },
+            ],
+            nextQueries: [],
+            done: true,
+            rationale: 'corroborated SDN hit',
+          }),
+        },
+      },
+    });
+    expect(r.extensions.deepResearch?.verdictHint).toBe('critical');
+    expect(['escalate', 'freeze']).toContain(r.finalVerdict);
+    expect(
+      r.clampReasons.some(
+        (c) => c.includes('deep research') && c.includes('corroborated critical')
+      )
+    ).toBe(true);
+  });
+
+  it('single-source critical claim does NOT trigger the clamp (corroboration floor)', async () => {
+    const r = await runWeaponizedBrain({
+      mega: cleanMegaRequest('E3', 'Borderline LLC'),
+      deepResearch: {
+        question: 'sanctions exposure',
+        entity: { displayName: 'Borderline LLC', jurisdiction: 'AE' },
+        purpose: 'edd_counterparty',
+        deps: {
+          search: async () => [],
+          extract: async () => null,
+          reason: async () => ({
+            newClaims: [
+              {
+                text: 'Allegation in a single blog post',
+                sources: ['https://blog.example/x'],
+                severity: 'critical',
+              },
+            ],
+            nextQueries: [],
+            done: true,
+            rationale: 'thin evidence',
+          }),
+        },
+      },
+    });
+    // Engine reports material_signal, NOT critical, because corroboration
+    // floor (>=2 distinct hostnames) wasn't met.
+    expect(r.extensions.deepResearch?.verdictHint).toBe('material_signal');
+    // Critical clamp must not have fired.
+    expect(
+      r.clampReasons.some(
+        (c) => c.includes('deep research') && c.includes('corroborated critical')
+      )
+    ).toBe(false);
+  });
+
+  it('engine failure escalates to manual review (FDL Art.24)', async () => {
+    const r = await runWeaponizedBrain({
+      mega: cleanMegaRequest('E4', 'Crash Corp'),
+      deepResearch: {
+        question: 'sanctions',
+        entity: { displayName: 'Crash Corp' },
+        purpose: 'general_compliance',
+        deps: {
+          search: async () => {
+            throw new Error('search backend offline');
+          },
+          extract: async () => null,
+          reason: async () => ({
+            newClaims: [],
+            nextQueries: [],
+            done: true,
+            rationale: '',
+          }),
+        },
+      },
+    });
+    expect(r.subsystemFailures).toContain('deepResearchEngine');
+    expect(
+      r.clampReasons.some(
+        (c) => c.includes('deepResearchEngine failed') && c.includes('FDL Art.24')
+      )
+    ).toBe(true);
+    expect(r.requiresHumanReview).toBe(true);
+  });
+
+  it('audit narrative includes the deep research line when present', async () => {
+    const r = await runWeaponizedBrain({
+      mega: cleanMegaRequest('E5'),
+      deepResearch: {
+        question: 'check',
+        entity: { displayName: 'X' },
+        purpose: 'general_compliance',
+        deps: {
+          search: async () => [],
+          extract: async () => null,
+          reason: async () => ({
+            newClaims: [],
+            nextQueries: [],
+            done: true,
+            rationale: '',
+          }),
+        },
+      },
+    });
+    expect(r.auditNarrative).toMatch(/Deep research \(#98\)/);
+  });
+});


### PR DESCRIPTION
## Summary

A real, working compliance research weapon — not just a spec.

Adapts the Jina node-DeepResearch pattern (`vendor/node-DeepResearch`, vendored 2026-04-16) into a browser-safe, dependency-injected iterative search/reason/cite engine, then wires it into `weaponizedBrain` as **subsystem #98**.

Powers compliance use cases the existing single-shot `adverseMediaSearch` + `adverseMediaRanker` pair cannot serve:

- Multi-step adverse media research (cross-corroboration across sources)
- EDD on opaque counterparties (iterative UBO trace, shell-company hunt)
- Pre-filing STR narrative drafting (gather facts → cite → draft)

## Engine — `src/services/deepResearchEngine.ts`

Pure orchestration logic. All I/O via injected `SearchFn` / `ExtractFn` / `ReasonFn` so the engine is unit-testable without network and the brain stays browser-safe (no transitive `fetch` dep).

### Compliance carve-outs (non-negotiable, not optional config)

| Carve-out | Mechanism | Regulation |
|---|---|---|
| **PII redaction** before any external query | Strips Emirates IDs, IBANs, passports, account numbers, emails, international phones | FDL No.10/2025 Art.29 (no tipping off) |
| **Audit log** of every external call | Records timestamp, original query, sent (redacted) query, backend, result count | FDL No.10/2025 Art.24 (record retention) |
| **Citation discipline** | Claims with 0 sources are dropped, not silently retained | FDL No.10/2025 Art.19 |
| **Corroboration floor** | `confidence='high'` requires ≥2 distinct hostnames; single-source critical claims stay at `low` and DON'T trigger the brain clamp | Conservative-bias risk policy |
| **Bounded budget** | Hard caps on `maxIterations`, `maxQueriesPerIteration`, optional wall-clock `deadlineMs` | Cost discipline |

### Termination is explicit

Returns one of `answer_found | max_iterations | deadline | no_signal` — auditor can see WHY the loop stopped.

## Brain integration — `src/services/weaponizedBrain.ts`

Registered as **subsystem #98** (next free slot after #97 `inducedRules`). Plugs in alongside the existing 19+ subsystems via the same pattern:

- Optional `req.deepResearch` input (no-op when absent)
- Populated `extensions.deepResearch` field
- Audit narrative line appended when present
- One safety clamp: `verdictHint === 'critical'` → `escalate` (fires only on corroborated critical signal — single-source claims are suppressed by the engine's corroboration floor)
- Failures escalate to manual review (`subsystemFailures + clampReasons + requiresHumanReview`) per FDL Art.24 — never silently swallowed
- Result is included in the quantum-resistant seal at the end of the pipeline so deep research output is part of the audit bundle

## Tests — 20 new, 100% pass

**`tests/deepResearchEngine.test.ts`** (14 tests):
- PII redactor coverage for all 6 patterns + ordering correctness
- Termination conditions (`no_signal`, `max_iterations`, `deadline`)
- PII safety end-to-end (audit log captures both original and sent query; sent query never contains PII)
- Corroboration + citation discipline (drops 0-source claims, upgrades to `high` only with ≥2 hostnames, single-source critical stays `low`)
- Bounded budget (queries-per-round cap, dedup-by-hostname for extract budget, every external call logged)

**`tests/weaponizedBrain.test.ts`** (+6 new, 34 total):
- No-op when `req.deepResearch` omitted
- End-to-end engine invocation with stubbed deps
- Critical corroborated signal → escalate clamp fires
- Single-source critical signal → clamp does NOT fire
- Engine failure → `subsystemFailures` + manual review forced (FDL Art.24)
- Audit narrative includes `Deep research (#98)` line

`npx tsc --noEmit` passes clean.

## Regulatory citations

- FDL No.10/2025 Art.19 — risk-based internal review
- FDL No.10/2025 Art.24 — audit trail of every external call
- FDL No.10/2025 Art.29 — no tipping off (PII redaction)
- Cabinet Res 134/2025 Art.14 — PEP / EDD enhanced research
- FATF Rec 10 — ongoing monitoring; adverse media as input

## Test plan

- [x] `npx vitest run tests/deepResearchEngine.test.ts` — 14/14 pass
- [x] `npx vitest run tests/weaponizedBrain.test.ts` — 34/34 pass
- [x] `npx tsc --noEmit` — no errors
- [ ] CI lint-and-test on the PR
- [ ] Production wiring: caller supplies real `SearchFn` / `ExtractFn` / `ReasonFn` — out of scope for this PR (engine is intentionally backend-agnostic)
- [ ] Follow-up: dashboard surface for `extensions.deepResearch.reasoningChain` in NORAD war room (xyflow integration)

https://claude.ai/code/session_01ToK6AULEvKGP6y15HcdypP