### PR TITLE
Warn-once observability for missing Asana custom-field GIDs (FDL Art.20)

### DIFF
--- a/src/services/asanaCustomFields.ts
+++ b/src/services/asanaCustomFields.ts
@@ -102,6 +102,41 @@ function env(key: string): string | undefined {
 }
 
 // ---------------------------------------------------------------------------
+// Observability — "silent degradation" but not silent ops.
+//
+// The builder intentionally returns an empty record when a field GID is
+// missing (see the file header for the design rationale). The cost of
+// that contract is that an operator cannot see from the Asana task alone
+// whether reporting was skipped for a field. We keep the degradation
+// but emit a warn-once log per missing key so the gap is observable in
+// the Netlify function log stream. The set is process-local; it resets
+// on cold start, which is the right behaviour — a fresh deploy should
+// re-emit warnings so a missing env var after a deploy is visible.
+// ---------------------------------------------------------------------------
+
+const warnedKeys: Set<string> = new Set();
+
+function warnMissing(key: string, context: string): void {
+  if (warnedKeys.has(key)) return;
+  warnedKeys.add(key);
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[asanaCustomFields] Skipping ${context}: env ${key} is not set. ` +
+      `Task will be created without this field. Run POST /api/asana/migrate-schema?apply=1 ` +
+      `to provision the workspace schema, then configure the returned GIDs as env vars.`
+  );
+}
+
+/**
+ * Reset the warn-once state. Exported for tests only; production code
+ * should never call this. Prefixed with an underscore to discourage
+ * accidental use.
+ */
+export function _resetWarnedKeysForTest(): void {
+  warnedKeys.clear();
+}
+
+// ---------------------------------------------------------------------------
 // Builder
 // ---------------------------------------------------------------------------
 
@@ -119,18 +154,26 @@ export function buildComplianceCustomFields(
   // Risk level (enum)
   if (input.riskLevel) {
     const fieldGid = env('ASANA_CF_RISK_LEVEL_GID');
-    const optionGid = env(`ASANA_CF_RISK_LEVEL_${input.riskLevel.toUpperCase()}`);
+    const optionKey = `ASANA_CF_RISK_LEVEL_${input.riskLevel.toUpperCase()}`;
+    const optionGid = env(optionKey);
     if (fieldGid && optionGid) {
       out[fieldGid] = optionGid;
+    } else {
+      if (!fieldGid) warnMissing('ASANA_CF_RISK_LEVEL_GID', 'risk_level field');
+      if (fieldGid && !optionGid) warnMissing(optionKey, `risk_level option ${input.riskLevel}`);
     }
   }
 
   // Verdict (enum)
   if (input.verdict) {
     const fieldGid = env('ASANA_CF_VERDICT_GID');
-    const optionGid = env(`ASANA_CF_VERDICT_${input.verdict.toUpperCase()}`);
+    const optionKey = `ASANA_CF_VERDICT_${input.verdict.toUpperCase()}`;
+    const optionGid = env(optionKey);
     if (fieldGid && optionGid) {
       out[fieldGid] = optionGid;
+    } else {
+      if (!fieldGid) warnMissing('ASANA_CF_VERDICT_GID', 'verdict field');
+      if (fieldGid && !optionGid) warnMissing(optionKey, `verdict option ${input.verdict}`);
     }
   }
 
@@ -139,15 +182,21 @@ export function buildComplianceCustomFields(
     const fieldGid = env('ASANA_CF_CASE_ID_GID');
     if (fieldGid) {
       out[fieldGid] = input.caseId;
+    } else {
+      warnMissing('ASANA_CF_CASE_ID_GID', 'case_id field');
     }
   }
 
   // Deadline type (enum)
   if (input.deadlineType) {
     const fieldGid = env('ASANA_CF_DEADLINE_TYPE_GID');
-    const optionGid = env(`ASANA_CF_DEADLINE_TYPE_${input.deadlineType}`);
+    const optionKey = `ASANA_CF_DEADLINE_TYPE_${input.deadlineType}`;
+    const optionGid = env(optionKey);
     if (fieldGid && optionGid) {
       out[fieldGid] = optionGid;
+    } else {
+      if (!fieldGid) warnMissing('ASANA_CF_DEADLINE_TYPE_GID', 'deadline_type field');
+      if (fieldGid && !optionGid) warnMissing(optionKey, `deadline_type option ${input.deadlineType}`);
     }
   }
 
@@ -156,6 +205,8 @@ export function buildComplianceCustomFields(
     const fieldGid = env('ASANA_CF_DAYS_REMAINING_GID');
     if (fieldGid) {
       out[fieldGid] = input.daysRemaining;
+    } else {
+      warnMissing('ASANA_CF_DAYS_REMAINING_GID', 'days_remaining field');
     }
   }
 
@@ -164,6 +215,8 @@ export function buildComplianceCustomFields(
     const fieldGid = env('ASANA_CF_CONFIDENCE_GID');
     if (fieldGid) {
       out[fieldGid] = Math.round(input.confidence * 100);
+    } else {
+      warnMissing('ASANA_CF_CONFIDENCE_GID', 'confidence field');
     }
   }
 
@@ -172,6 +225,8 @@ export function buildComplianceCustomFields(
     const fieldGid = env('ASANA_CF_REGULATION_GID');
     if (fieldGid) {
       out[fieldGid] = input.regulationCitation;
+    } else {
+      warnMissing('ASANA_CF_REGULATION_GID', 'regulation field');
     }
   }
 

--- a/src/services/asanaCustomFields.ts
+++ b/src/services/asanaCustomFields.ts
@@ -196,7 +196,8 @@ export function buildComplianceCustomFields(
       out[fieldGid] = optionGid;
     } else {
       if (!fieldGid) warnMissing('ASANA_CF_DEADLINE_TYPE_GID', 'deadline_type field');
-      if (fieldGid && !optionGid) warnMissing(optionKey, `deadline_type option ${input.deadlineType}`);
+      if (fieldGid && !optionGid)
+        warnMissing(optionKey, `deadline_type option ${input.deadlineType}`);
     }
   }
 

--- a/tests/asanaCustomFields.test.ts
+++ b/tests/asanaCustomFields.test.ts
@@ -3,8 +3,9 @@
  * mapping layer. These tests set env vars inline so they never touch
  * the real Asana API or a live workspace.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
+  _resetWarnedKeysForTest,
   buildComplianceCustomFields,
   deadlineTypeFromCaseType,
 } from '@/services/asanaCustomFields';
@@ -180,5 +181,54 @@ describe('deadlineTypeFromCaseType', () => {
   });
   it('returns undefined for unknown types', () => {
     expect(deadlineTypeFromCaseType('unknown case')).toBeUndefined();
+  });
+});
+
+describe('buildComplianceCustomFields — missing-env observability', () => {
+  beforeEach(() => {
+    _resetWarnedKeysForTest();
+  });
+
+  it('warns once per missing key across multiple calls', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // No env vars set — every call triggers a skip.
+    buildComplianceCustomFields({ caseId: 'C1' });
+    buildComplianceCustomFields({ caseId: 'C2' });
+    buildComplianceCustomFields({ caseId: 'C3' });
+    const calls = spy.mock.calls.filter((args) =>
+      String(args[0]).includes('ASANA_CF_CASE_ID_GID')
+    );
+    expect(calls.length).toBe(1);
+    spy.mockRestore();
+  });
+
+  it('warns separately for field gid and option gid', () => {
+    process.env.ASANA_CF_VERDICT_GID = 'field-verdict';
+    // ASANA_CF_VERDICT_FLAG intentionally not set.
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    buildComplianceCustomFields({ verdict: 'flag' });
+    const calls = spy.mock.calls
+      .map((args) => String(args[0]))
+      .filter((m) => m.includes('ASANA_CF_VERDICT_FLAG'));
+    expect(calls.length).toBe(1);
+    spy.mockRestore();
+  });
+
+  it('does not warn when the field is fully configured', () => {
+    process.env.ASANA_CF_CASE_ID_GID = 'field-case';
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    buildComplianceCustomFields({ caseId: 'C1' });
+    const calls = spy.mock.calls.filter((args) =>
+      String(args[0]).includes('ASANA_CF_CASE_ID_GID')
+    );
+    expect(calls.length).toBe(0);
+    spy.mockRestore();
+  });
+
+  it('does not warn when the input does not request a field', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    buildComplianceCustomFields({});
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

Adds warn-once log output to `buildComplianceCustomFields` so missing
custom-field env GIDs are observable in Netlify logs instead of
silently dropping fields from the Asana task.

## Why this matters

The builder's "lose reporting, not the task" degradation is the
correct contract: a brain verdict must not be dropped because a
reporting GID is unset. But today the operator can only discover the
gap by staring at an Asana task and noticing a missing custom field.
There is no log, no metric, and no signal that the schema needs
attention.

## Changes

- `warnMissing(key, context)` — per-process Set prevents spam.
- Wired into all skip paths: risk_level / verdict / case_id /
  deadline_type / days_remaining / confidence / regulation.
- Each warning names the exact env var (e.g.
  `ASANA_CF_VERDICT_FLAG`) and tells the operator to run
  `POST /api/asana/migrate-schema?apply=1`.
- Cold-start resets the Set so deploys re-emit (intentional).
- `_resetWarnedKeysForTest` export for test isolation.

## Degradation contract preserved

The builder still returns an empty record when env is unset. Tasks
are still created without the field. Only the observability changes.

## Regulatory basis

- FDL No. 10 of 2025 Art.20 — MLRO visibility of compliance controls.
- Cabinet Resolution 134/2025 Art.19 — internal review requires
  monitorable controls.

## Test plan

- [x] `npx vitest run tests/asanaCustomFields.test.ts` — 23/23 pass
  (19 existing + 4 new observability tests).
- [ ] Manual: deploy and grep the Netlify function log for
  `[asanaCustomFields] Skipping` on first dispatch.

## Related

Pairs with #178 (wire migrate-schema apply path) — once apply is
wired, the warning text's "run migrate-schema" remediation is
actionable end-to-end.

https://claude.ai/code/session_018BLY2zjsVJqFTF2WLwXXge