### PR TITLE
Validate Asana webhook target origin before handshake (FDL Art.20, Cabinet Res 134/2025 Art.18)

### DIFF
--- a/netlify/functions/setup-asana-bootstrap.mts
+++ b/netlify/functions/setup-asana-bootstrap.mts
@@ -283,15 +283,6 @@ export default async (req: Request, context: Context): Promise<Response> => {
 
   const accessToken = process.env.ASANA_ACCESS_TOKEN;
   const workspaceGid = process.env.ASANA_WORKSPACE_GID;
-  // The receiver function lives at /api/asana/webhook (see
-  // netlify/functions/asana-webhook.mts) and expects ?workspaceGid=<gid>
-  // as a query param so it can look up the right webhook secret per
-  // workspace. The previous /api/asana-webhook URL was a 404 →
-  // Asana's handshake POST got 404 → registration failed.
-  const origin = (process.env.HAWKEYE_ALLOWED_ORIGIN ?? '').replace(/\/+$/, '');
-  const webhookTarget = workspaceGid
-    ? `${origin}/api/asana/webhook?workspaceGid=${encodeURIComponent(workspaceGid)}`
-    : `${origin}/api/asana/webhook`;
 
   if (!accessToken || accessToken.length < 16) {
     return jsonResponse(
@@ -305,6 +296,53 @@ export default async (req: Request, context: Context): Promise<Response> => {
       { status: 503 }
     );
   }
+
+  // The receiver function lives at /api/asana/webhook (see
+  // netlify/functions/asana-webhook.mts) and expects ?workspaceGid=<gid>
+  // as a query param so it can look up the right webhook secret per
+  // workspace. The previous /api/asana-webhook URL was a 404 →
+  // Asana's handshake POST got 404 → registration failed.
+  //
+  // Asana requires an absolute https:// URL for the webhook target.
+  // If HAWKEYE_ALLOWED_ORIGIN is missing or relative, the request will
+  // 404 on Asana's side with an opaque error. Fail fast here so the
+  // operator sees a clear diagnostic instead of a mysterious Asana
+  // rejection during tenant bootstrap.
+  const rawOrigin = (process.env.HAWKEYE_ALLOWED_ORIGIN ?? '').trim();
+  if (!rawOrigin) {
+    return jsonResponse(
+      {
+        error: 'HAWKEYE_ALLOWED_ORIGIN env var missing',
+        hint:
+          'Asana webhook targets must be absolute https:// URLs. Set HAWKEYE_ALLOWED_ORIGIN to the public origin of this deployment (e.g. https://hawkeye-sterling-v2.netlify.app) before running tenant bootstrap.',
+      },
+      { status: 503 }
+    );
+  }
+  let originUrl: URL;
+  try {
+    originUrl = new URL(rawOrigin);
+  } catch {
+    return jsonResponse(
+      {
+        error: 'HAWKEYE_ALLOWED_ORIGIN is not a valid URL',
+        value: rawOrigin,
+      },
+      { status: 503 }
+    );
+  }
+  if (originUrl.protocol !== 'https:') {
+    return jsonResponse(
+      {
+        error: 'HAWKEYE_ALLOWED_ORIGIN must use https scheme',
+        value: rawOrigin,
+        hint: 'Asana webhook handshakes require TLS. Non-https origins are rejected.',
+      },
+      { status: 503 }
+    );
+  }
+  const origin = rawOrigin.replace(/\/+$/, '');
+  const webhookTarget = `${origin}/api/asana/webhook?workspaceGid=${encodeURIComponent(workspaceGid)}`;
 
   // Build the plan (pure).
   const plan = tenantProvisioningPlan(v.req.tenantId, {


### PR DESCRIPTION
## Summary

Adds three fail-fast validations in `setup-asana-bootstrap` before
constructing the Asana webhook target URL. If the webhook target is
wrong, Asana's handshake silently fails and the tenant gets
provisioned with a dead event channel — downstream four-eyes approvals
completed in Asana never reach HAWKEYE.

## The bug

`HAWKEYE_ALLOWED_ORIGIN` defaults to `''` when unset. The old code
then constructed the webhook target as `/api/asana/webhook?workspaceGid=…`
— a relative URL. Asana requires an absolute `https://` target.
Previous registrations with a malformed target failed the handshake
and left tenants with no live webhook. The operator had to reverse-
engineer this from log fragments because no validation caught it at
bootstrap time.

## Changes

1. **Missing origin** → 503 with a clear hint pointing to the env var
   and the expected value shape (e.g. `https://hawkeye-sterling-v2.netlify.app`).
2. **Unparseable origin** → 503 echoing the offending value.
3. **Non-https origin** → 503 with a note that Asana requires TLS.
4. Reordered checks so token, workspace, and origin are validated
   before the webhook target is built. Previous ordering built the
   URL first and validated second — the URL briefly held a malformed
   value on the error path.
5. Dropped the `workspaceGid ? … : …` ternary on the target; the
   workspace check above now guarantees it's present, so the
   conditional was dead code.

## Regulatory basis

- FDL No. 10 of 2025 Art.20 — MLRO visibility of compliance controls.
  A silently broken webhook means completed four-eyes approvals in
  Asana are never mirrored into the brain's audit trail.
- Cabinet Resolution 134/2025 Art.18 — notification of MLRO
  arrangements. Tenant bootstrap is where that lands; a silently
  failed bootstrap is not tolerable.

## Test plan

- [x] `npx vitest run tests/asanaClient.test.ts
  tests/asanaOrchestrator.test.ts
  tests/asanaComplianceOrchestrator.test.ts` → 56/56 pass.
- [x] No bootstrap unit test exists; the validation is behaviourally
  self-evident (all three error branches are type-narrowed by their
  `return` statements).
- [ ] Manual: run bootstrap with HAWKEYE_ALLOWED_ORIGIN unset and
  verify a 503 with the hint is returned immediately, not an opaque
  Asana 4xx after the fact.

## Related

Part of Track B of the HAWKEYE→Asana dispatcher hardening follow-on
to #178 (migrate-schema apply path) and #179 (custom-field
observability).

https://claude.ai/code/session_018BLY2zjsVJqFTF2WLwXXge