### PR TITLE
Correct IDEMPOTENCY.md to match implemented orchestrator key (FDL Art.20)

### DIFF
--- a/asana-workflow/CLAUDE.md
+++ b/asana-workflow/CLAUDE.md
@@ -35,10 +35,13 @@ real human's queue with the right SLA and the right four-eyes gate.
    `src/services/asana/orchestrator.ts`. No file outside this
    directory may call `asanaQueue.ts` directly.
 
-2. **Idempotency first.** Every orchestrator call computes a
-   sha3_512 idempotency key from `tenantId | caseId | verdict |
-   timestampHour | dispatchKind`. Replays within 30 days return the
-   cached response without writing to Asana.
+2. **Idempotency first.** Every orchestrator call computes a key
+   of the form `${tenantId}:${verdictId}`. The brain's `verdictId`
+   is unique per decision, so same-decision retries dedupe while a
+   fresh decision produces a fresh key. Replays within 30 days
+   return the cached response without writing to Asana. Source of
+   truth: `makeIdempotencyKey()` in `src/services/asana/orchestrator.ts`;
+   full rules in `IDEMPOTENCY.md`.
 
 3. **Retry queue last.** The queue wraps every Asana API call with
    exponential backoff (2s → 4s → 8s → 16s, max 4 retries). Anything

--- a/asana-workflow/IDEMPOTENCY.md
+++ b/asana-workflow/IDEMPOTENCY.md
@@ -1,8 +1,8 @@
 # ASANA WORKFLOW — Idempotency
 
 The orchestrator is idempotent by construction. Every dispatch
-computes a key from the request shape; replaying the same key within
-30 days returns the cached response without writing to Asana.
+computes a key from the verdict identity; replaying the same key
+within 30 days returns the cached response without writing to Asana.
 
 This is the load-bearing guarantee that makes webhook double-delivery,
 cron retries, and network jitter safe.
@@ -11,23 +11,32 @@ cron retries, and network jitter safe.
 
 ## Key shape
 
+```typescript
+`${tenantId}:${verdictId}`
 ```
-sha3_512(
-  tenantId        + '|' +
-  caseId          + '|' +
-  dispatchKind    + '|' +
-  Math.floor(Date.now() / 3_600_000) + '|' +    // hour bucket
-  sha3_512(JSON.stringify(payload))
-)
-```
+
+Source of truth: `makeIdempotencyKey()` in
+`src/services/asana/orchestrator.ts`.
 
 | Field | Why it's in the key |
 |---|---|
 | `tenantId` | Tasks are scoped per tenant. No cross-tenant collisions. |
-| `caseId` | Same case, different verdicts → different tasks. |
-| `dispatchKind` | A four-eyes pair and a brain-verdict task for the same case are different keys. |
-| `hour bucket` | Same call within the same hour deduplicates; an hour later is a fresh event. |
-| `payload hash` | If the verdict changes, the key changes. |
+| `verdictId` | Unique per brain decision. A fresh decision produces a fresh id, and a fresh id produces a fresh key. |
+
+The key is intentionally simple. It relies on `verdictId` being
+unique-per-decision at the brain layer. The brain produces a fresh
+id every time it runs `runComplianceDecision()`, so the same case
+screened at 08:00 and 14:00 produces two different verdicts with two
+different ids and therefore two different Asana tasks.
+
+This design choice replaces the earlier proposed
+sha3_512(tenantId|caseId|dispatchKind|hour-bucket|payloadHash)
+shape. The earlier shape is not implemented in the orchestrator and
+is not required — the verdictId already embeds the time and the
+dispatch context, so deriving a composite hash added no safety and
+one more failure mode (hash-collision tests on every dispatch).
+If the key shape ever needs to grow, update this file and
+`makeIdempotencyKey()` in the same commit.
 
 ---
 
@@ -95,26 +104,23 @@ auditing.
 
 ---
 
-## Hour-bucket rationale
+## Why `verdictId` alone is enough
 
-The hour bucket is the most important part of the key shape. Without
-it, the same payload would deduplicate forever — including a stale
-verdict from yesterday that should have triggered a fresh task today.
+Replacement for the earlier hour-bucket design. The rationale for
+relying on the brain's `verdictId`:
 
-With it:
+- Same verdict dispatched twice (cron retry, webhook double-delivery,
+  jitter) → same id → replay, no duplicate task.
+- Fresh decision on the same case an hour later → new
+  `runComplianceDecision()` call → new `id` → new Asana task.
+- Different tenants can never collide because the tenant prefix is
+  part of the key.
+- Cross-case collisions are impossible because `id` is unique across
+  all verdicts, not just within a case.
 
-- Same payload, same hour → 1 task (deduplication works)
-- Same payload, next hour → 2 tasks (operator sees the new event)
-- Different payload, same hour → 2 tasks (different key)
-
-Choose 1 hour because:
-
-- Fast enough to recover from a brief outage with a fresh task
-- Slow enough to deduplicate Asana webhook double-delivery (they
-  retry within minutes)
-- Aligned with the `asana-sync-cron` schedule (also hourly)
-
-Do not change this without a regression test on the cron sync path.
+The brain is the authority on "is this the same decision or a new
+one?". The idempotency layer mirrors that authority rather than
+trying to re-derive it from payload shape.
 
 ---
 
@@ -150,19 +156,18 @@ The cleanup counter is published to telemetry under
 
 ## Testing
 
-Tests live in `tests/asana/idempotency.test.ts` and cover:
+Coverage lives in `tests/asanaOrchestrator.test.ts` and exercises
+the idempotency contract end-to-end through
+`AsanaOrchestrator.dispatchBrainVerdict` and `dispatchWithTemplate`:
 
-- HIT within TTL returns cached response with `replayed=true`
-- HIT past TTL is treated as MISS
-- MISS executes dispatch and writes blob
-- Failed dispatch does NOT write blob
-- Hour boundary creates a fresh key
-- `idempotencyOverride` bypasses cache lookup but still writes
-- Two concurrent calls with same key — only one writes (last writer
-  wins on the blob)
+- Replay of the same verdict returns the cached `taskGid` without
+  re-dispatching.
+- A verdict with a new `id` always produces a fresh dispatch.
+- `IdempotencyStore.clear()` resets the store for tests.
+- Failed dispatches are not cached (retried by the queue).
 
-Run them in isolation:
+Run in isolation:
 
 ```bash
-npx vitest run tests/asana/idempotency.test.ts
+npx vitest run tests/asanaOrchestrator.test.ts
 ```


### PR DESCRIPTION
## Summary

Docs-only PR. Brings `asana-workflow/IDEMPOTENCY.md` and the
Architecture section of `asana-workflow/CLAUDE.md` into agreement
with the implemented orchestrator idempotency key.

## The drift

- **Code (source of truth)**: `makeIdempotencyKey()` in
  `src/services/asana/orchestrator.ts` returns
  `${tenantId}:${verdictId}`.
- **Docs (stale)**: IDEMPOTENCY.md described a hashed composite
  key `sha3_512(tenantId | caseId | dispatchKind | hour-bucket |
  sha3_512(payload))` that was never implemented.
- **Docs also referenced**: tests at `tests/asana/idempotency.test.ts`
  that do not exist. Coverage actually lives in
  `tests/asanaOrchestrator.test.ts`.

## Why not keep the aspirational design and build toward it?

The brain's `verdictId` is already unique per decision and already
embeds the per-decision time + dispatch context. Composing a sha3
hash on every dispatch adds a collision-test burden without changing
behaviour. The simpler key is correct; it just needed its
documentation to say so.

## Compliance implication

An operator reading `IDEMPOTENCY.md` to audit HAWKEYE's deduplication
guarantees would have seen a design that does not match reality.
Regulatory audits of an AML control require that documentation
describes what the code does, not what an earlier iteration planned.

## Changes

- "Key shape" section rewritten to describe `tenantId:verdictId` and
  point at `makeIdempotencyKey()`.
- "Hour-bucket rationale" replaced by "Why verdictId alone is enough".
- "Testing" section now points at `tests/asanaOrchestrator.test.ts`.
- `asana-workflow/CLAUDE.md` Architecture rule #2 updated with
  matching wording.

## Regulatory basis

- FDL No. 10 of 2025 Art.20 — MLRO controls must be documented
  truthfully for audit.
- Cabinet Resolution 134/2025 Art.19 — internal review requires
  that documentation matches implementation.

## Test plan

- [x] `npx prettier --check asana-workflow/IDEMPOTENCY.md
  asana-workflow/CLAUDE.md` → clean.
- No executable change; no vitest regression possible.

https://claude.ai/code/session_018BLY2zjsVJqFTF2WLwXXge