### PR TITLE
Add asanaTenantProjectResolver (pure compute) — Phase 19 W-B (FDL Art.20, Art.29)

### DIFF
--- a/src/services/asanaTenantProjectResolver.ts
+++ b/src/services/asanaTenantProjectResolver.ts
@@ -1,0 +1,246 @@
+/**
+ * Asana Tenant Project Resolver — Phase 19 W-B (pure compute).
+ *
+ * Resolves a tenantId → Asana project GID at dispatch time on the
+ * server. Replaces the browser-side hardcoded `CUSTOMER_PROJECTS`
+ * map in `asana-project-resolver.js` for server-side call paths.
+ *
+ * The resolver is intentionally free of I/O. Callers provide the
+ * three lookup sources (registry, legacy map, default) and this
+ * module picks the first hit and returns a typed result.
+ * Surface-level wiring into `asana-dispatch.mts` and the
+ * orchestrator is a deliberate follow-on so each step is reviewed
+ * independently.
+ *
+ * Design:
+ *   - Three tiers of truth:
+ *       1. Runtime tenant registry (Netlify Blobs) — the long-term
+ *          canonical source, populated by tenant bootstrap.
+ *       2. Compiled-in legacy map — mirrors the six tenants shipped
+ *          in `asana-project-resolver.js`. Used for tenants
+ *          bootstrapped before Phase 19 W-B rolled out.
+ *       3. `ASANA_DEFAULT_PROJECT_GID` env var — last-resort safety
+ *          net. Never silently routes a known-tenant dispatch to
+ *          the default; the default is only returned for explicit
+ *          unknown-tenant requests.
+ *   - Hard-fail when a known tenant has no registry entry AND no
+ *     legacy entry AND no default is provided. A silent route to
+ *     a wrong project would cross tenant boundaries, which is
+ *     non-negotiable under FDL Art.20 (MLRO visibility — the MLRO
+ *     for tenant A cannot see tenant B's queue).
+ *   - Two project "kinds" per tenant: `compliance` and `workflow`.
+ *     Mirrors the browser-side shape.
+ *
+ * Regulatory anchor:
+ *   FDL No. 10 of 2025 Art.20 — MLRO visibility; no cross-tenant
+ *     dispatch.
+ *   FDL No. 10 of 2025 Art.29 — no tipping off; cross-tenant
+ *     dispatch would expose one tenant's matter to another.
+ *   Cabinet Resolution 134/2025 Art.18 — tenant bootstrap produces
+ *     the registry rows this resolver consumes.
+ */
+
+export type AsanaProjectKind = 'compliance' | 'workflow';
+
+export interface TenantProjectEntry {
+  tenantId: string;
+  compliance: string;
+  workflow: string;
+  /** Human-readable name for logs / audit trail. */
+  name?: string;
+}
+
+/**
+ * Source of the resolution. Useful in audit rows so an inspector
+ * can see whether the GID came from the authoritative registry,
+ * from the legacy hardcoded map, or from the default fallback.
+ */
+export type ResolutionSource = 'registry' | 'legacy' | 'default';
+
+export interface ResolveSuccess {
+  ok: true;
+  tenantId: string;
+  kind: AsanaProjectKind;
+  projectGid: string;
+  source: ResolutionSource;
+  /** Resolved entity name when available. */
+  name?: string;
+}
+
+export interface ResolveFailure {
+  ok: false;
+  tenantId: string;
+  kind: AsanaProjectKind;
+  reason:
+    | 'tenant_not_in_registry_and_no_legacy_entry'
+    | 'invalid_tenant_id'
+    | 'invalid_project_kind'
+    | 'registry_entry_missing_kind';
+}
+
+export type ResolveResult = ResolveSuccess | ResolveFailure;
+
+export interface ResolveOptions {
+  /** Registry row for the tenant, if one exists. */
+  registryEntry?: TenantProjectEntry | null;
+  /** Legacy compiled-in map. */
+  legacyMap?: Readonly<Record<string, TenantProjectEntry>>;
+  /** Default project GID from env — last-resort fallback. */
+  defaultProjectGid?: string | null;
+  /**
+   * Callers may set this to true for an explicit unknown-tenant
+   * lookup (for example, a firm-level broadcast task). When true,
+   * the resolver returns the default if none of the other sources
+   * hit. When false or unset, an unknown tenant is a failure even
+   * if a default is configured — the default is never used to
+   * mask a missing registry row.
+   */
+  allowDefaultFallback?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Legacy map (mirrors asana-project-resolver.js)
+// ---------------------------------------------------------------------------
+
+/**
+ * Six-tenant legacy map, imported from the browser-side file so
+ * server-side code does not need the browser file in its module
+ * graph. Tenants bootstrapped before Phase 19 W-B rolled out are
+ * resolved through this map until they are migrated into the
+ * runtime registry.
+ *
+ * Source of the GID values: `asana-project-resolver.js` at commit
+ * where this module was introduced. Any update to that file should
+ * be mirrored here in the same PR.
+ */
+export const LEGACY_TENANT_PROJECTS: Readonly<Record<string, TenantProjectEntry>> = Object.freeze({
+  'company-1': {
+    tenantId: 'company-1',
+    name: 'MADISON JEWELLERY TRADING L.L.C',
+    compliance: '1213825539896477',
+    workflow: '1213825580399850',
+  },
+  'company-2': {
+    tenantId: 'company-2',
+    name: 'NAPLES JEWELLERY TRADING L.L.C',
+    compliance: '1213825365472836',
+    workflow: '1213825542010518',
+  },
+  'company-3': {
+    tenantId: 'company-3',
+    name: 'GRAMALTIN KIYMETLI MADENLER RAFINERI SANAYI VE TICARET ANONIM SIRKETI',
+    compliance: '1213838252710765',
+    workflow: '1213825541970651',
+  },
+  'company-4': {
+    tenantId: 'company-4',
+    name: 'ZOE Precious Metals and Jewelery (FZE)',
+    compliance: '1213825578259027',
+    workflow: '1213825580398407',
+  },
+  'company-5': {
+    tenantId: 'company-5',
+    name: 'FINE GOLD LLC',
+    compliance: '1213900474912902',
+    workflow: '1213759768596515',
+  },
+  'company-6': {
+    tenantId: 'company-6',
+    name: 'FINE GOLD (BRANCH)',
+    compliance: '1213900370769721',
+    workflow: '1213899469870046',
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+function isValidTenantId(id: string | undefined | null): id is string {
+  if (typeof id !== 'string') return false;
+  if (id.length === 0 || id.length > 64) return false;
+  return /^[a-z0-9][a-z0-9-]*$/.test(id);
+}
+
+function isValidKind(kind: string | undefined): kind is AsanaProjectKind {
+  return kind === 'compliance' || kind === 'workflow';
+}
+
+function pickFromEntry(entry: TenantProjectEntry, kind: AsanaProjectKind): string {
+  return kind === 'compliance' ? entry.compliance : entry.workflow;
+}
+
+// ---------------------------------------------------------------------------
+// Resolver
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a (tenantId, kind) pair to an Asana project GID using the
+ * three-tier source chain. Pure compute — no I/O. Callers provide
+ * the registry entry (via Netlify Blobs read) before calling.
+ */
+export function resolveTenantProject(
+  tenantId: string,
+  kind: AsanaProjectKind,
+  options: ResolveOptions = {}
+): ResolveResult {
+  if (!isValidTenantId(tenantId)) {
+    return {
+      ok: false,
+      tenantId: typeof tenantId === 'string' ? tenantId : '',
+      kind,
+      reason: 'invalid_tenant_id',
+    };
+  }
+  if (!isValidKind(kind)) {
+    return { ok: false, tenantId, kind, reason: 'invalid_project_kind' };
+  }
+
+  // Tier 1 — runtime registry (authoritative).
+  if (options.registryEntry) {
+    const gid = pickFromEntry(options.registryEntry, kind);
+    if (!gid) {
+      return { ok: false, tenantId, kind, reason: 'registry_entry_missing_kind' };
+    }
+    return {
+      ok: true,
+      tenantId,
+      kind,
+      projectGid: gid,
+      source: 'registry',
+      name: options.registryEntry.name,
+    };
+  }
+
+  // Tier 2 — compiled-in legacy map.
+  const legacy = options.legacyMap ?? LEGACY_TENANT_PROJECTS;
+  const legacyEntry = legacy[tenantId];
+  if (legacyEntry) {
+    const gid = pickFromEntry(legacyEntry, kind);
+    if (gid) {
+      return {
+        ok: true,
+        tenantId,
+        kind,
+        projectGid: gid,
+        source: 'legacy',
+        name: legacyEntry.name,
+      };
+    }
+  }
+
+  // Tier 3 — default fallback, only for explicit unknown-tenant
+  // calls. Silently routing a known tenant to the default would
+  // cross tenant boundaries and is rejected.
+  if (options.allowDefaultFallback && options.defaultProjectGid) {
+    return {
+      ok: true,
+      tenantId,
+      kind,
+      projectGid: options.defaultProjectGid,
+      source: 'default',
+    };
+  }
+
+  return { ok: false, tenantId, kind, reason: 'tenant_not_in_registry_and_no_legacy_entry' };
+}

--- a/tests/asanaTenantProjectResolver.test.ts
+++ b/tests/asanaTenantProjectResolver.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Tests for asanaTenantProjectResolver.ts — pure compute, so every
+ * test passes sources inline and checks the typed return shape.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  LEGACY_TENANT_PROJECTS,
+  resolveTenantProject,
+  type ResolveOptions,
+  type TenantProjectEntry,
+} from '@/services/asanaTenantProjectResolver';
+
+const REGISTRY_ENTRY: TenantProjectEntry = {
+  tenantId: 'madison-llc',
+  name: 'Madison LLC',
+  compliance: 'REG_COMP_GID',
+  workflow: 'REG_WORK_GID',
+};
+
+describe('resolveTenantProject — tier 1 (registry)', () => {
+  it('returns registry compliance GID when registry hit and kind=compliance', () => {
+    const out = resolveTenantProject('madison-llc', 'compliance', {
+      registryEntry: REGISTRY_ENTRY,
+    });
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      expect(out.projectGid).toBe('REG_COMP_GID');
+      expect(out.source).toBe('registry');
+      expect(out.name).toBe('Madison LLC');
+    }
+  });
+
+  it('returns registry workflow GID when kind=workflow', () => {
+    const out = resolveTenantProject('madison-llc', 'workflow', {
+      registryEntry: REGISTRY_ENTRY,
+    });
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      expect(out.projectGid).toBe('REG_WORK_GID');
+      expect(out.source).toBe('registry');
+    }
+  });
+
+  it('registry wins over legacy map', () => {
+    // company-1 is in LEGACY_TENANT_PROJECTS.
+    const out = resolveTenantProject('company-1', 'workflow', {
+      registryEntry: {
+        ...REGISTRY_ENTRY,
+        tenantId: 'company-1',
+        compliance: 'FRESH_COMP',
+        workflow: 'FRESH_WORK',
+      },
+    });
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      expect(out.projectGid).toBe('FRESH_WORK');
+      expect(out.source).toBe('registry');
+    }
+  });
+
+  it('fails when registry entry is missing the requested kind', () => {
+    // A registry row with blank workflow should fail, not silently
+    // fall through to legacy.
+    const out = resolveTenantProject('madison-llc', 'workflow', {
+      registryEntry: { ...REGISTRY_ENTRY, workflow: '' },
+    });
+    expect(out.ok).toBe(false);
+    if (!out.ok) {
+      expect(out.reason).toBe('registry_entry_missing_kind');
+    }
+  });
+});
+
+describe('resolveTenantProject — tier 2 (legacy)', () => {
+  it('resolves all six legacy tenants for compliance', () => {
+    const ids = Object.keys(LEGACY_TENANT_PROJECTS);
+    expect(ids.length).toBe(6);
+    for (const id of ids) {
+      const out = resolveTenantProject(id, 'compliance');
+      expect(out.ok).toBe(true);
+      if (out.ok) {
+        expect(out.source).toBe('legacy');
+        expect(out.projectGid.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('resolves FG LLC legacy workflow GID', () => {
+    const out = resolveTenantProject('company-5', 'workflow');
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      expect(out.projectGid).toBe('1213759768596515');
+      expect(out.name).toBe('FINE GOLD LLC');
+    }
+  });
+
+  it('caller can override the legacy map for tests', () => {
+    const overrides: ResolveOptions = {
+      legacyMap: {
+        'test-tenant': {
+          tenantId: 'test-tenant',
+          name: 'Test',
+          compliance: 'TEST_COMP',
+          workflow: 'TEST_WORK',
+        },
+      },
+    };
+    const out = resolveTenantProject('test-tenant', 'workflow', overrides);
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      expect(out.projectGid).toBe('TEST_WORK');
+      expect(out.source).toBe('legacy');
+    }
+  });
+});
+
+describe('resolveTenantProject — tier 3 (default fallback)', () => {
+  it('returns default ONLY when allowDefaultFallback=true', () => {
+    const out = resolveTenantProject('unknown-tenant', 'workflow', {
+      defaultProjectGid: 'DEFAULT_GID',
+      allowDefaultFallback: true,
+    });
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      expect(out.projectGid).toBe('DEFAULT_GID');
+      expect(out.source).toBe('default');
+    }
+  });
+
+  it('does NOT fall back to default by default (no silent masking)', () => {
+    const out = resolveTenantProject('unknown-tenant', 'workflow', {
+      defaultProjectGid: 'DEFAULT_GID',
+      // allowDefaultFallback omitted — defaults to false.
+    });
+    expect(out.ok).toBe(false);
+    if (!out.ok) {
+      expect(out.reason).toBe('tenant_not_in_registry_and_no_legacy_entry');
+    }
+  });
+
+  it('does not fall back to default for a known legacy tenant even if allowed', () => {
+    // Explicit: the default is only used for EXPLICIT unknown-tenant
+    // requests. A known tenant must always route to its own project.
+    const out = resolveTenantProject('company-5', 'workflow', {
+      defaultProjectGid: 'DEFAULT_GID',
+      allowDefaultFallback: true,
+    });
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      expect(out.source).toBe('legacy');
+      expect(out.projectGid).not.toBe('DEFAULT_GID');
+    }
+  });
+
+  it('returns failure when unknown tenant and default not configured', () => {
+    const out = resolveTenantProject('unknown-tenant', 'workflow', {
+      allowDefaultFallback: true,
+      // defaultProjectGid not provided.
+    });
+    expect(out.ok).toBe(false);
+  });
+});
+
+describe('resolveTenantProject — validation', () => {
+  it('rejects empty tenantId', () => {
+    const out = resolveTenantProject('', 'workflow');
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.reason).toBe('invalid_tenant_id');
+  });
+
+  it('rejects tenantId with uppercase letters', () => {
+    const out = resolveTenantProject('Madison-LLC', 'workflow');
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.reason).toBe('invalid_tenant_id');
+  });
+
+  it('rejects tenantId starting with a hyphen', () => {
+    const out = resolveTenantProject('-madison', 'workflow');
+    expect(out.ok).toBe(false);
+  });
+
+  it('rejects tenantId longer than 64 chars', () => {
+    const out = resolveTenantProject('a'.repeat(65), 'workflow');
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.reason).toBe('invalid_tenant_id');
+  });
+
+  it('rejects invalid project kind', () => {
+    // @ts-expect-error — exercise the runtime guard.
+    const out = resolveTenantProject('company-5', 'reporting');
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.reason).toBe('invalid_project_kind');
+  });
+});
+
+describe('LEGACY_TENANT_PROJECTS — shape', () => {
+  it('contains the six shipping tenants', () => {
+    expect(Object.keys(LEGACY_TENANT_PROJECTS).sort()).toEqual([
+      'company-1',
+      'company-2',
+      'company-3',
+      'company-4',
+      'company-5',
+      'company-6',
+    ]);
+  });
+
+  it('every entry has non-empty compliance and workflow GIDs', () => {
+    for (const entry of Object.values(LEGACY_TENANT_PROJECTS)) {
+      expect(entry.compliance.length).toBeGreaterThan(0);
+      expect(entry.workflow.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('is frozen so it cannot be mutated at runtime', () => {
+    expect(Object.isFrozen(LEGACY_TENANT_PROJECTS)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Second deliverable of Phase 19 W-B (spec: #182). Adds a pure-compute
resolver that maps `(tenantId, projectKind)` → Asana project GID at
dispatch time on the server. Today the only resolver that covers
every tenant is the browser-side `asana-project-resolver.js` with a
hardcoded map — newly bootstrapped tenants cannot be routed
server-side without updating source. This module replaces that with
a three-tier chain.

## Resolution chain

1. **Runtime tenant registry** (Netlify Blobs) — authoritative.
   Populated at tenant bootstrap.
2. **Compiled-in legacy map** — mirrors the six tenants shipped in
   `asana-project-resolver.js`. Frozen so it cannot be mutated at
   runtime.
3. **`ASANA_DEFAULT_PROJECT_GID`** — last-resort fallback. **Never**
   used to mask a missing registry row for a known tenant.

## Hard-fail is the point

Silently routing a known-tenant dispatch to the default GID crosses
tenant boundaries:

- **FDL Art.20** — the MLRO for tenant A cannot see tenant B's queue.
- **FDL Art.29** — cross-tenant dispatch would expose one tenant's
  matter to another (tipping off).

The resolver returns a typed `ResolveResult` with four specific
failure reasons so callers can surface the right diagnostic.

## Scope of this PR

Pure compute only. No I/O, no Netlify Blobs read, no wiring into
`asana-dispatch.mts` or the orchestrator. Each piece ships as its
own PR.

## Regulatory anchor

- FDL No. 10 of 2025 Art.20 — MLRO visibility, no cross-tenant
  dispatch.
- FDL No. 10 of 2025 Art.29 — no tipping off.
- Cabinet Resolution 134/2025 Art.18 — tenant bootstrap produces
  the registry rows this resolver consumes.

## Test plan

- [x] `npx vitest run tests/asanaTenantProjectResolver.test.ts` →
  19/19 pass.
- [x] `npx prettier --check` → clean.

Coverage includes: tier-1 registry hits + override, tier-2 all six
legacy tenants, tier-3 default only fires for explicit unknown, and
every failure mode (invalid id, invalid kind, registry missing kind,
no source hit).

## Related

- #178, #179, #180, #181 — Track B hardening (all merged).
- #182 — Phase 19 spec (merged).
- #183 — Track A description audit (merged).
- #184 — Phase 19 W-E regulatory citation enricher (in flight).

https://claude.ai/code/session_018BLY2zjsVJqFTF2WLwXXge