### PR TITLE
Add asanaTenantBootstrapStateMachine (pure compute) — Phase 19 W-D (Cabinet Res 134/2025 Art.18)

### DIFF
--- a/src/services/asanaTenantBootstrapStateMachine.ts
+++ b/src/services/asanaTenantBootstrapStateMachine.ts
@@ -1,0 +1,238 @@
+/**
+ * Asana Tenant Bootstrap State Machine — Phase 19 W-D (pure compute).
+ *
+ * Tenant bootstrap is a multi-step workflow: project create, section
+ * create, custom-field provisioning, webhook registration, idempotency
+ * namespace seeding, registry row write. Today each step is fire-and-
+ * forget. If any step fails, the operator debugs from log fragments
+ * and re-runs the whole workflow, which may re-create a project or
+ * re-provision a field that already exists.
+ *
+ * This module produces a resumable plan: given the current state of a
+ * tenant's bootstrap (read from the setup-audit blob), it returns the
+ * ordered list of steps that still need to run. A re-run after a
+ * partial failure skips completed steps and retries only the ones
+ * that are still pending.
+ *
+ * The module does not perform I/O. Callers read the prior-state blob,
+ * pass it in, receive the plan, execute each step, and write the
+ * updated state back.
+ *
+ * Design:
+ *   - Each step has a stable name. Re-running the planner with the
+ *     same prior state produces the same plan (deterministic).
+ *   - A step can be in one of four states: pending, in_progress,
+ *     done, failed. The planner treats in_progress conservatively —
+ *     it does NOT re-run an in-flight step on a second invocation,
+ *     because a concurrent run would fight over Asana state. The
+ *     caller handles stale in_progress via a separate staleness
+ *     check (default: 10 minutes).
+ *   - failed is re-runnable. The planner includes a failed step in
+ *     the next plan so a fix-forward retry can succeed.
+ *   - Ordering is enforced by the static STEPS array. A step is only
+ *     included in the plan if all its predecessors are done.
+ *
+ * Regulatory anchor:
+ *   FDL No. 10 of 2025 Art.20 — MLRO visibility; a partially
+ *     bootstrapped tenant means the MLRO cannot see the full queue.
+ *   Cabinet Resolution 134/2025 Art.18 — MLRO arrangement
+ *     notification; tenant bootstrap is where that lands, and a
+ *     failed bootstrap is not a tolerable silent outcome.
+ *   Cabinet Resolution 134/2025 Art.19 — internal review; the audit
+ *     trail produced by this state machine is what the review reads.
+ */
+
+export type BootstrapStepName =
+  | 'validate_inputs'
+  | 'create_project_compliance'
+  | 'create_project_workflow'
+  | 'create_sections'
+  | 'provision_custom_fields'
+  | 'emit_custom_field_env_vars'
+  | 'register_webhook'
+  | 'seed_idempotency_namespace'
+  | 'write_registry_row';
+
+export type BootstrapStepState = 'pending' | 'in_progress' | 'done' | 'failed';
+
+export interface BootstrapStepRecord {
+  name: BootstrapStepName;
+  state: BootstrapStepState;
+  /** Millisecond timestamp of the last state transition. */
+  updatedAtMs: number;
+  /** Per-step output blob (project gid, section gid, webhook gid, etc.). */
+  output?: Record<string, unknown>;
+  /** Populated when state === 'failed'. */
+  error?: string;
+}
+
+export interface BootstrapState {
+  tenantId: string;
+  startedAtMs: number;
+  /** One record per step that has started. Missing steps are pending. */
+  steps: Readonly<Record<string, BootstrapStepRecord>>;
+}
+
+/**
+ * Canonical ordering. A step is only considered for the next-plan
+ * output if every predecessor has state === 'done'. This enforces
+ * the dependency chain without the planner having to re-derive it
+ * from a graph walk.
+ */
+export const STEPS: readonly BootstrapStepName[] = [
+  'validate_inputs',
+  'create_project_compliance',
+  'create_project_workflow',
+  'create_sections',
+  'provision_custom_fields',
+  'emit_custom_field_env_vars',
+  'register_webhook',
+  'seed_idempotency_namespace',
+  'write_registry_row',
+];
+
+export interface PlanOptions {
+  /**
+   * Milliseconds after which an in_progress step is considered
+   * stale (abandoned by a prior run) and safe to restart. Default
+   * 10 minutes — long enough to absorb a slow Asana call but short
+   * enough that operator re-runs aren't blocked forever.
+   */
+  staleInProgressMs?: number;
+  /** Current wall clock; caller-supplied for deterministic testing. */
+  nowMs: number;
+}
+
+export interface BootstrapPlan {
+  tenantId: string;
+  nextSteps: readonly BootstrapStepName[];
+  alreadyDone: readonly BootstrapStepName[];
+  failed: readonly BootstrapStepName[];
+  /** Steps that are in_progress and not yet considered stale. */
+  inProgressFresh: readonly BootstrapStepName[];
+  /** True when every step is done (tenant fully provisioned). */
+  complete: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Planner
+// ---------------------------------------------------------------------------
+
+const DEFAULT_STALE_IN_PROGRESS_MS = 10 * 60 * 1000;
+
+/**
+ * Produce the list of steps that should run next for this tenant.
+ * Pure function of (state, now, options). Safe to call any number
+ * of times; it does not mutate the input state.
+ */
+export function planBootstrap(state: BootstrapState, options: PlanOptions): BootstrapPlan {
+  const staleMs = options.staleInProgressMs ?? DEFAULT_STALE_IN_PROGRESS_MS;
+  const records = state.steps;
+
+  const done: BootstrapStepName[] = [];
+  const failed: BootstrapStepName[] = [];
+  const inProgressFresh: BootstrapStepName[] = [];
+  const next: BootstrapStepName[] = [];
+  let blockedByPredecessor = false;
+
+  for (const step of STEPS) {
+    const record = records[step];
+
+    if (!record) {
+      // No record yet — this is a pending step. Schedule only if no
+      // predecessor is blocking.
+      if (!blockedByPredecessor) {
+        next.push(step);
+        // Continue the loop; subsequent steps may also be pending
+        // and will be gated below.
+        blockedByPredecessor = true;
+      }
+      continue;
+    }
+
+    if (record.state === 'done') {
+      done.push(step);
+      continue;
+    }
+
+    if (record.state === 'failed') {
+      failed.push(step);
+      // A failed step blocks its successors AND is itself a candidate
+      // for the next plan — fix-forward retry.
+      if (!blockedByPredecessor) {
+        next.push(step);
+        blockedByPredecessor = true;
+      }
+      continue;
+    }
+
+    if (record.state === 'in_progress') {
+      const age = options.nowMs - record.updatedAtMs;
+      if (age >= staleMs) {
+        // Stale — treat as failed for planning purposes; the caller
+        // can force-restart this step.
+        if (!blockedByPredecessor) {
+          next.push(step);
+          blockedByPredecessor = true;
+        }
+      } else {
+        inProgressFresh.push(step);
+        blockedByPredecessor = true;
+      }
+      continue;
+    }
+
+    // Explicit pending state (caller can set pending instead of
+    // omitting the record). Treated the same as a missing record.
+    if (!blockedByPredecessor) {
+      next.push(step);
+      blockedByPredecessor = true;
+    }
+  }
+
+  return {
+    tenantId: state.tenantId,
+    nextSteps: next,
+    alreadyDone: done,
+    failed,
+    inProgressFresh,
+    complete: done.length === STEPS.length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// State transitions (pure)
+// ---------------------------------------------------------------------------
+
+/**
+ * Produce a new BootstrapState with one step's record updated.
+ * Immutable — input is not modified.
+ */
+export function withStepState(
+  state: BootstrapState,
+  step: BootstrapStepName,
+  patch: Partial<Omit<BootstrapStepRecord, 'name'>> & { state: BootstrapStepState },
+  nowMs: number
+): BootstrapState {
+  const existing = state.steps[step];
+  const record: BootstrapStepRecord = {
+    name: step,
+    state: patch.state,
+    updatedAtMs: nowMs,
+    output: patch.output ?? existing?.output,
+    error: patch.state === 'failed' ? patch.error : undefined,
+  };
+  return {
+    ...state,
+    steps: { ...state.steps, [step]: record },
+  };
+}
+
+/**
+ * Convenience: build an initial state for a brand-new tenant
+ * bootstrap. No steps are recorded; planBootstrap will return
+ * every step as next.
+ */
+export function initialState(tenantId: string, nowMs: number): BootstrapState {
+  return { tenantId, startedAtMs: nowMs, steps: {} };
+}

--- a/tests/asanaTenantBootstrapStateMachine.test.ts
+++ b/tests/asanaTenantBootstrapStateMachine.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for asanaTenantBootstrapStateMachine.ts — pure compute.
+ * All wall-clock values are synthetic.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  STEPS,
+  initialState,
+  planBootstrap,
+  withStepState,
+} from '@/services/asanaTenantBootstrapStateMachine';
+
+const NOW = 1_750_000_000_000;
+
+describe('initialState + planBootstrap — brand-new tenant', () => {
+  it('returns the first step as next, everything else queued behind it', () => {
+    const state = initialState('madison-llc', NOW);
+    const plan = planBootstrap(state, { nowMs: NOW });
+    expect(plan.nextSteps).toEqual([STEPS[0]]);
+    expect(plan.alreadyDone).toEqual([]);
+    expect(plan.failed).toEqual([]);
+    expect(plan.inProgressFresh).toEqual([]);
+    expect(plan.complete).toBe(false);
+  });
+
+  it('tenantId is carried through', () => {
+    const state = initialState('zoe-fze', NOW);
+    const plan = planBootstrap(state, { nowMs: NOW });
+    expect(plan.tenantId).toBe('zoe-fze');
+  });
+});
+
+describe('planBootstrap — ordering', () => {
+  it('only releases the next step once the predecessor is done', () => {
+    let state = initialState('madison-llc', NOW);
+    state = withStepState(state, 'validate_inputs', { state: 'done' }, NOW);
+    const plan = planBootstrap(state, { nowMs: NOW });
+    expect(plan.nextSteps).toEqual(['create_project_compliance']);
+    expect(plan.alreadyDone).toEqual(['validate_inputs']);
+  });
+
+  it('skips completed steps but schedules the first pending one', () => {
+    let state = initialState('madison-llc', NOW);
+    for (const step of STEPS.slice(0, 4)) {
+      state = withStepState(state, step, { state: 'done' }, NOW);
+    }
+    const plan = planBootstrap(state, { nowMs: NOW });
+    expect(plan.alreadyDone.length).toBe(4);
+    expect(plan.nextSteps).toEqual(['provision_custom_fields']);
+  });
+});
+
+describe('planBootstrap — completion', () => {
+  it('complete=true when every step is done', () => {
+    let state = initialState('madison-llc', NOW);
+    for (const step of STEPS) {
+      state = withStepState(state, step, { state: 'done' }, NOW);
+    }
+    const plan = planBootstrap(state, { nowMs: NOW });
+    expect(plan.complete).toBe(true);
+    expect(plan.nextSteps).toEqual([]);
+    expect(plan.alreadyDone.length).toBe(STEPS.length);
+  });
+});
+
+describe('planBootstrap — failure retry (fix-forward)', () => {
+  it('a failed step is returned as the next step to retry', () => {
+    let state = initialState('madison-llc', NOW);
+    state = withStepState(state, 'validate_inputs', { state: 'done' }, NOW);
+    state = withStepState(
+      state,
+      'create_project_compliance',
+      { state: 'failed', error: 'asana 429' },
+      NOW
+    );
+    const plan = planBootstrap(state, { nowMs: NOW });
+    expect(plan.nextSteps).toEqual(['create_project_compliance']);
+    expect(plan.failed).toEqual(['create_project_compliance']);
+  });
+
+  it('a failed step blocks its successors from running', () => {
+    let state = initialState('madison-llc', NOW);
+    state = withStepState(state, 'validate_inputs', { state: 'done' }, NOW);
+    state = withStepState(state, 'create_project_compliance', { state: 'failed', error: 'x' }, NOW);
+    const plan = planBootstrap(state, { nowMs: NOW });
+    // create_project_workflow is a successor and must not run yet.
+    expect(plan.nextSteps).not.toContain('create_project_workflow');
+  });
+});
+
+describe('planBootstrap — in_progress', () => {
+  it('fresh in_progress blocks further progress but is not restarted', () => {
+    let state = initialState('madison-llc', NOW);
+    state = withStepState(state, 'validate_inputs', { state: 'done' }, NOW);
+    state = withStepState(
+      state,
+      'create_project_compliance',
+      { state: 'in_progress' },
+      NOW - 60_000 // 1 minute old — not stale yet at default 10 min
+    );
+    const plan = planBootstrap(state, { nowMs: NOW });
+    expect(plan.inProgressFresh).toEqual(['create_project_compliance']);
+    expect(plan.nextSteps).toEqual([]);
+  });
+
+  it('stale in_progress is re-scheduled', () => {
+    let state = initialState('madison-llc', NOW);
+    state = withStepState(state, 'validate_inputs', { state: 'done' }, NOW);
+    state = withStepState(
+      state,
+      'create_project_compliance',
+      { state: 'in_progress' },
+      NOW - 20 * 60 * 1000 // 20 min old
+    );
+    const plan = planBootstrap(state, { nowMs: NOW });
+    expect(plan.nextSteps).toEqual(['create_project_compliance']);
+    expect(plan.inProgressFresh).toEqual([]);
+  });
+
+  it('staleInProgressMs override is respected', () => {
+    let state = initialState('madison-llc', NOW);
+    state = withStepState(state, 'validate_inputs', { state: 'done' }, NOW);
+    state = withStepState(
+      state,
+      'create_project_compliance',
+      { state: 'in_progress' },
+      NOW - 30_000 // 30 sec
+    );
+    // Strict 15s threshold — 30s age is stale.
+    const plan = planBootstrap(state, { nowMs: NOW, staleInProgressMs: 15_000 });
+    expect(plan.nextSteps).toEqual(['create_project_compliance']);
+  });
+});
+
+describe('withStepState — immutability', () => {
+  it('returns a new object; original is not mutated', () => {
+    const original = initialState('madison-llc', NOW);
+    const updated = withStepState(original, 'validate_inputs', { state: 'done' }, NOW);
+    expect(original.steps.validate_inputs).toBeUndefined();
+    expect(updated.steps.validate_inputs?.state).toBe('done');
+  });
+
+  it('preserves output across state transitions when not overridden', () => {
+    let state = initialState('madison-llc', NOW);
+    state = withStepState(
+      state,
+      'create_project_compliance',
+      { state: 'in_progress', output: { projectGid: 'GID-123' } },
+      NOW
+    );
+    state = withStepState(state, 'create_project_compliance', { state: 'done' }, NOW + 1_000);
+    expect(state.steps.create_project_compliance?.output).toEqual({
+      projectGid: 'GID-123',
+    });
+  });
+
+  it('clears error on non-failed transitions', () => {
+    let state = initialState('madison-llc', NOW);
+    state = withStepState(state, 'register_webhook', { state: 'failed', error: 'asana 503' }, NOW);
+    expect(state.steps.register_webhook?.error).toBe('asana 503');
+    state = withStepState(state, 'register_webhook', { state: 'done' }, NOW + 1);
+    expect(state.steps.register_webhook?.error).toBeUndefined();
+  });
+});
+
+describe('STEPS — shape', () => {
+  it('has the expected ordered sequence', () => {
+    expect(STEPS).toEqual([
+      'validate_inputs',
+      'create_project_compliance',
+      'create_project_workflow',
+      'create_sections',
+      'provision_custom_fields',
+      'emit_custom_field_env_vars',
+      'register_webhook',
+      'seed_idempotency_namespace',
+      'write_registry_row',
+    ]);
+  });
+});
+
+describe('end-to-end resume scenario', () => {
+  it('kill mid-flight + resume five times converges on complete', () => {
+    let state = initialState('madison-llc', NOW);
+    let now = NOW;
+    const killAt = [2, 4, 6, 8, STEPS.length];
+
+    for (const k of killAt) {
+      // Execute up to index k - 1 as done.
+      for (let i = 0; i < k && i < STEPS.length; i++) {
+        const step = STEPS[i];
+        if (state.steps[step]?.state === 'done') continue;
+        state = withStepState(state, step, { state: 'done' }, now++);
+      }
+      if (k < STEPS.length) {
+        // The next step gets in_progress then stale.
+        state = withStepState(
+          state,
+          STEPS[k],
+          { state: 'in_progress' },
+          now - 60 * 60 * 1000 // make it stale
+        );
+      }
+      const plan = planBootstrap(state, { nowMs: now });
+      if (k === STEPS.length) {
+        expect(plan.complete).toBe(true);
+      } else {
+        expect(plan.nextSteps[0]).toBe(STEPS[k]);
+      }
+    }
+    const finalPlan = planBootstrap(state, { nowMs: now });
+    expect(finalPlan.complete).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fourth Phase 19 pure-compute deliverable (spec: #182). Produces a
resumable plan for tenant bootstrap. Given the current state (read
from the setup-audit blob), returns the ordered list of steps still
to run so a failure-recovery re-run skips completed steps and
retries only what's pending.

## The problem

Today bootstrap is multi-step and fire-and-forget: project create,
section create, custom-field provisioning, webhook registration,
idempotency namespace seeding, registry row write. A failure in any
step leaves the operator debugging from log fragments and re-running
the whole workflow, which may re-create a project or re-provision a
field that already exists.

## Design

- **Nine canonical steps** in strict order (`STEPS` array). A step is
  only scheduled if every predecessor has state `done`.
- **Four states** (`pending` / `in_progress` / `done` / `failed`)
  with explicit semantics:
  - `done` → skip.
  - `failed` → include in next plan (fix-forward); block successors
    until it succeeds.
  - `in_progress` fresh → block further progress; do NOT restart
    (concurrent run would fight over Asana state).
  - `in_progress` stale (age ≥ 10 min, configurable) → treat as
    failed for planning so operator re-runs aren't blocked forever.
- **Pure compute.** Caller passes `now` and owns the blob I/O.
- `withStepState` is immutable and preserves `output` across
  transitions (project GIDs captured during `in_progress` survive
  into `done`).

## Scope

Pure compute only. No wiring into `setup-asana-bootstrap.mts` yet.

## Regulatory anchor

- FDL No. 10 of 2025 Art.20 — MLRO visibility; a partially
  bootstrapped tenant means the MLRO cannot see the full queue.
- Cabinet Resolution 134/2025 Art.18 — MLRO arrangement
  notification lands at tenant bootstrap; a failed bootstrap is not
  a tolerable silent outcome.
- Cabinet Resolution 134/2025 Art.19 — internal review reads the
  audit trail this state machine produces.

## Test plan

- [x] `npx vitest run tests/asanaTenantBootstrapStateMachine.test.ts`
  → 15/15 pass.
- [x] `npx prettier --check` → clean.

Coverage: brand-new tenant, ordering, completion, failure retry,
fresh vs. stale in_progress, staleness threshold override,
immutability + output preservation + error clearing, end-to-end
resume scenario (kill mid-flight + resume five times converges).

## Related

- #178-181 — Track B hardening (merged).
- #182 — Phase 19 spec (merged).
- #183 — Track A audit memo (merged).
- #184 — Phase 19 W-E citation enricher (merged).
- #185 — Phase 19 W-B tenant project resolver (merged).
- #186 — Phase 19 W-A per-tenant rate limit (in flight).

https://claude.ai/code/session_018BLY2zjsVJqFTF2WLwXXge