### PR TITLE
Harden asana-webhook body-size check with Content-Length preflight (FDL Art.24)

### DIFF
--- a/netlify/functions/asana-webhook.mts
+++ b/netlify/functions/asana-webhook.mts
@@ -110,13 +110,39 @@ export default async (req: Request, context: Context): Promise<Response> => {
   }
 
   // Phase 2: signed payload. Look up the stored secret and verify.
+  //
+  // Defence in depth: refuse the request before buffering the body
+  // when Content-Length already exceeds the cap. Asana always sets
+  // Content-Length on webhook deliveries. A caller that omits the
+  // header is falling through to the post-read check as before.
+  const contentLengthHeader = req.headers.get('content-length');
+  if (contentLengthHeader) {
+    const declared = Number(contentLengthHeader);
+    if (Number.isFinite(declared) && declared > MAX_BODY_BYTES) {
+      await writeAudit({
+        event: 'asana_webhook_body_too_large',
+        workspaceGid,
+        ip: context.ip,
+        declaredBytes: declared,
+        cap: MAX_BODY_BYTES,
+      });
+      return Response.json({ error: 'Body exceeds 256 KB cap.' }, { status: 413 });
+    }
+  }
   const raw = await req.text();
   if (raw.length > MAX_BODY_BYTES) {
-    return Response.json({ error: 'Body exceeds 256 KB cap.' }, { status: 400 });
+    await writeAudit({
+      event: 'asana_webhook_body_too_large_post_read',
+      workspaceGid,
+      ip: context.ip,
+      actualBytes: raw.length,
+      cap: MAX_BODY_BYTES,
+    });
+    return Response.json({ error: 'Body exceeds 256 KB cap.' }, { status: 413 });
   }
-  const stored = (await secretStore.get(`secret:${workspaceGid}.json`, { type: 'json' })) as
-    | { secret?: string }
-    | null;
+  const stored = (await secretStore.get(`secret:${workspaceGid}.json`, { type: 'json' })) as {
+    secret?: string;
+  } | null;
   if (!stored?.secret) {
     await writeAudit({
       event: 'asana_webhook_unregistered',
@@ -174,9 +200,9 @@ export default async (req: Request, context: Context): Promise<Response> => {
     const routerModule = await import('../../src/services/asanaWebhookRouter');
     const skillModule = await import('../../src/services/asanaCommentSkillRouter');
     const routed = routerModule.routeAsanaWebhookEvents({
-      events: events as Parameters<typeof routerModule.routeAsanaWebhookEvents>[0] extends
-        | { events?: infer E }
-        | null
+      events: events as Parameters<typeof routerModule.routeAsanaWebhookEvents>[0] extends {
+        events?: infer E;
+      } | null
         ? E
         : never,
     });


### PR DESCRIPTION
## Summary

Defence in depth for the webhook receiver: refuse oversize deliveries
before buffering the body, not after. Changes status code from 400 to
413 to match the semantic.

## The problem

`asana-webhook.mts` enforced its 256 KB body cap by calling
`req.text()` first and then checking `raw.length`. A multi-megabyte
payload would see the server buffer all of it before rejection — a
resource-exhaustion vector on the Netlify function runtime.

## Changes

- Preflight `Content-Length` check — if declared bytes exceed
  `MAX_BODY_BYTES`, reject with 413 before `req.text()`.
- Post-read check preserved as a belt-and-braces for senders that
  omit the header.
- Both paths write structured audit entries (declared vs. actual
  bytes + cap) so the MLRO can see patterns.
- Status code aligned to 413 Payload Too Large.

## Non-regression

Asana always sets `Content-Length` on webhook deliveries. A payload
under 256 KB hits neither branch and proceeds through the existing
HMAC verification and event persistence path unchanged.

## Regulatory anchor

- FDL No. 10 of 2025 Art.20 — MLRO visibility; a DoS on the webhook
  receiver hides Asana → brain state transitions.
- FDL No. 10 of 2025 Art.24 — 10-year retention; oversize rejections
  are now auditable.

## Test plan

- [x] `npx vitest run tests/asanaWebhookRouter.test.ts` → 7/7 pass.
- [x] `npx prettier --check netlify/functions/asana-webhook.mts` →
  clean.
- No receiver integration test exists to regress against.

https://claude.ai/code/session_018BLY2zjsVJqFTF2WLwXXge