### PR TITLE
Harden asana-proxy and asana-simulate body-size checks (FDL Art.24)

### DIFF
--- a/netlify/functions/asana-proxy.mts
+++ b/netlify/functions/asana-proxy.mts
@@ -99,9 +99,19 @@ export default async (req: Request, context: Context): Promise<Response> => {
     );
   }
 
+  // Preflight body-size check — refuse before buffering if
+  // Content-Length already exceeds the cap. Mirrors the pattern in
+  // asana-webhook.mts and asana-dispatch.mts.
+  const contentLengthHeader = req.headers.get('content-length');
+  if (contentLengthHeader) {
+    const declared = Number(contentLengthHeader);
+    if (Number.isFinite(declared) && declared > MAX_BODY_BYTES) {
+      return Response.json({ error: 'Body exceeds 256 KB cap.' }, { status: 413 });
+    }
+  }
   const raw = await req.text();
   if (raw.length > MAX_BODY_BYTES) {
-    return badRequest('Body exceeds 256 KB cap.');
+    return Response.json({ error: 'Body exceeds 256 KB cap.' }, { status: 413 });
   }
   let parsed: { method?: string; path?: string; body?: unknown };
   try {

--- a/netlify/functions/asana-simulate.mts
+++ b/netlify/functions/asana-simulate.mts
@@ -44,9 +44,23 @@ export default async (req: Request, context: Context): Promise<Response> => {
   const auth = authenticate(req);
   if (!auth.ok) return auth.response ?? Response.json({ error: 'Unauthorized' }, { status: 401 });
 
+  // Small-body endpoint — simulate only accepts { count?, seed? }.
+  // Cap the body at 4 KB to match the input shape.
+  const SIMULATE_MAX_BODY_BYTES = 4 * 1024;
+  const contentLengthHeader = req.headers.get('content-length');
+  if (contentLengthHeader) {
+    const declared = Number(contentLengthHeader);
+    if (Number.isFinite(declared) && declared > SIMULATE_MAX_BODY_BYTES) {
+      return Response.json({ error: 'Body exceeds 4 KB cap for this endpoint.' }, { status: 413 });
+    }
+  }
+
   let body: { count?: number; seed?: number } = {};
   try {
     const raw = await req.text();
+    if (raw.length > SIMULATE_MAX_BODY_BYTES) {
+      return Response.json({ error: 'Body exceeds 4 KB cap for this endpoint.' }, { status: 413 });
+    }
     if (raw.length > 0) body = JSON.parse(raw) as typeof body;
   } catch {
     return Response.json({ error: 'Invalid JSON body.' }, { status: 400 });


### PR DESCRIPTION
## Summary

Completes the Content-Length preflight pattern across the four Asana
Netlify endpoints that buffer a request body. PRs #190 (webhook) and
#191 (dispatch) are in flight; this PR finishes `asana-proxy` (256 KB
cap) and `asana-simulate` (tightened to a 4 KB cap matching its
`{ count?, seed? }` input shape).

## Changes

- `asana-proxy.mts` — preflight Content-Length + 413 status + belt-
  and-braces post-read check.
- `asana-simulate.mts` — adds body-size cap (previously none). Cap
  is a named constant at the top of the block for easy review; if
  the input shape ever grows, the cap must grow with it.

## Why tighten `asana-simulate` to 4 KB?

The endpoint only reads `count` and `seed` from the body — both
numeric. 4 KB is several orders of magnitude more than any
legitimate payload needs while blocking an obviously malformed or
adversarial request from ever reaching `JSON.parse`.

## Regulatory anchor

- FDL No. 10 of 2025 Art.20 — MLRO visibility; a DoS on any of the
  four Asana endpoints degrades brain ↔ Asana state sync.
- FDL No. 10 of 2025 Art.24 — 10-year retention. Audit entries on
  webhook + dispatch paths were added in #190 / #191; proxy +
  simulate do not have a structured audit store wired today, which
  is a separate hardening workstream and not in scope here.

## Test plan

- [x] `npx prettier --check` → clean.
- No integration test exists for either endpoint's body check.

## Related

- #190 — asana-webhook preflight (in flight).
- #191 — asana-dispatch preflight (in flight).

https://claude.ai/code/session_018BLY2zjsVJqFTF2WLwXXge