### PR TITLE
Sweep Content-Length preflight across 5 non-asana Netlify endpoints (FDL Art.24)

### DIFF
--- a/netlify/functions/ai-proxy.mts
+++ b/netlify/functions/ai-proxy.mts
@@ -114,9 +114,7 @@ const STREAM_KEEPALIVE_MS = 10_000;
  * Sonnet-executor + Opus-advisor pairing cannot invoke the tool through the
  * proxy.
  */
-const ALLOWED_ANTHROPIC_BETAS = new Set<string>([
-  'advisor-tool-2026-03-01',
-]);
+const ALLOWED_ANTHROPIC_BETAS = new Set<string>(['advisor-tool-2026-03-01']);
 
 // ─── Handler ────────────────────────────────────────────────────────────────
 
@@ -148,10 +146,20 @@ export default async (req: Request, context: Context) => {
     betas?: string[];
   };
 
+  // Preflight Content-Length — refuse before buffering if already
+  // declared too large. Mirrors the pattern used by the Asana
+  // Netlify functions.
+  const contentLengthHeader = req.headers.get('content-length');
+  if (contentLengthHeader) {
+    const declared = Number(contentLengthHeader);
+    if (Number.isFinite(declared) && declared > MAX_BODY_SIZE) {
+      return Response.json({ error: 'Request body too large (max 1 MB).' }, { status: 413 });
+    }
+  }
   try {
     const raw = await req.text();
     if (raw.length > MAX_BODY_SIZE) {
-      return Response.json({ error: 'Request body too large (max 1 MB).' }, { status: 400 });
+      return Response.json({ error: 'Request body too large (max 1 MB).' }, { status: 413 });
     }
     body = JSON.parse(raw);
   } catch {
@@ -164,7 +172,9 @@ export default async (req: Request, context: Context) => {
   const config = PROVIDERS[providerName?.toLowerCase()];
   if (!config) {
     return Response.json(
-      { error: `Unknown provider: ${providerName}. Available: ${Object.keys(PROVIDERS).join(', ')}` },
+      {
+        error: `Unknown provider: ${providerName}. Available: ${Object.keys(PROVIDERS).join(', ')}`,
+      },
       { status: 400 }
     );
   }
@@ -196,7 +206,9 @@ export default async (req: Request, context: Context) => {
   // Exact pathname match — no more prefix-based SSRF surface.
   if (!config.allowedPaths.includes(parsedTarget.pathname)) {
     return Response.json(
-      { error: `Path "${parsedTarget.pathname}" not allowed for ${providerName}. Allowed: ${config.allowedPaths.join(', ')}` },
+      {
+        error: `Path "${parsedTarget.pathname}" not allowed for ${providerName}. Allowed: ${config.allowedPaths.join(', ')}`,
+      },
       { status: 400 }
     );
   }
@@ -224,7 +236,9 @@ export default async (req: Request, context: Context) => {
     // Forward allowlisted Anthropic beta flags as `anthropic-beta` header.
     // Only applies to the Anthropic provider; silently dropped for others.
     if (providerName.toLowerCase() === 'anthropic' && Array.isArray(betas) && betas.length > 0) {
-      const allowed = betas.filter((b): b is string => typeof b === 'string' && ALLOWED_ANTHROPIC_BETAS.has(b));
+      const allowed = betas.filter(
+        (b): b is string => typeof b === 'string' && ALLOWED_ANTHROPIC_BETAS.has(b)
+      );
       if (allowed.length > 0) {
         headers['anthropic-beta'] = allowed.join(',');
       }
@@ -242,7 +256,8 @@ export default async (req: Request, context: Context) => {
       upstreamAbort.abort(new DOMException('Upstream timeout', 'TimeoutError'));
     }, timeoutMs);
     const clientSignal = (req as unknown as { signal?: AbortSignal }).signal;
-    const onClientAbort = () => upstreamAbort.abort(new DOMException('Client disconnected', 'AbortError'));
+    const onClientAbort = () =>
+      upstreamAbort.abort(new DOMException('Client disconnected', 'AbortError'));
     if (clientSignal) {
       if (clientSignal.aborted) onClientAbort();
       else clientSignal.addEventListener('abort', onClientAbort, { once: true });
@@ -339,9 +354,7 @@ export default async (req: Request, context: Context) => {
               // the client gets a diagnosable message instead of a
               // silent truncation.
               const message = err instanceof Error ? err.message : String(err);
-              safeEnqueue(
-                encoder.encode(`event: error\ndata: ${JSON.stringify({ message })}\n\n`)
-              );
+              safeEnqueue(encoder.encode(`event: error\ndata: ${JSON.stringify({ message })}\n\n`));
             } finally {
               finish();
             }
@@ -393,10 +406,7 @@ export default async (req: Request, context: Context) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
     console.error(`[ai-proxy] ${providerName} request failed:`, message);
-    return Response.json(
-      { error: `AI provider request failed: ${message}` },
-      { status: 502 }
-    );
+    return Response.json({ error: `AI provider request failed: ${message}` }, { status: 502 });
   }
 };
 

--- a/netlify/functions/decision-stream.mts
+++ b/netlify/functions/decision-stream.mts
@@ -92,9 +92,18 @@ export default async (req: Request, context: Context): Promise<Response> => {
   const auth = authenticate(req);
   if (!auth.ok) return auth.response ?? Response.json({ error: 'Unauthorized' }, { status: 401 });
 
+  // Preflight Content-Length — refuse before buffering if already
+  // declared too large.
+  const contentLengthHeader = req.headers.get('content-length');
+  if (contentLengthHeader) {
+    const declared = Number(contentLengthHeader);
+    if (Number.isFinite(declared) && declared > MAX_BODY_BYTES) {
+      return Response.json({ error: 'Body exceeds 512 KB limit.' }, { status: 413 });
+    }
+  }
   const raw = await req.text();
   if (raw.length > MAX_BODY_BYTES) {
-    return Response.json({ error: 'Body exceeds 512 KB limit.' }, { status: 400 });
+    return Response.json({ error: 'Body exceeds 512 KB limit.' }, { status: 413 });
   }
 
   let parsed: unknown;

--- a/netlify/functions/decision.mts
+++ b/netlify/functions/decision.mts
@@ -107,10 +107,20 @@ export default async (req: Request, context: Context): Promise<Response> => {
   const auth = authenticate(req);
   if (!auth.ok) return auth.response ?? Response.json({ error: 'Unauthorized' }, { status: 401 });
 
+  // Preflight Content-Length — refuse before buffering if already
+  // declared too large. The post-read check remains as a safety
+  // net for callers that omit Content-Length.
+  const contentLengthHeader = req.headers.get('content-length');
+  if (contentLengthHeader) {
+    const declared = Number(contentLengthHeader);
+    if (Number.isFinite(declared) && declared > MAX_BODY_BYTES) {
+      return Response.json({ error: 'Request body exceeds 512 KB limit.' }, { status: 413 });
+    }
+  }
   // Read the raw body with a hard size cap.
   const raw = await req.text();
   if (raw.length > MAX_BODY_BYTES) {
-    return badRequest('Request body exceeds 512 KB limit.');
+    return Response.json({ error: 'Request body exceeds 512 KB limit.' }, { status: 413 });
   }
 
   let parsed: unknown;

--- a/netlify/functions/orchestrate.mts
+++ b/netlify/functions/orchestrate.mts
@@ -71,9 +71,18 @@ export default async (req: Request, context: Context): Promise<Response> => {
   const auth = authenticate(req);
   if (!auth.ok) return auth.response ?? Response.json({ error: 'Unauthorized' }, { status: 401 });
 
+  // Preflight Content-Length — refuse before buffering if already
+  // declared too large.
+  const contentLengthHeader = req.headers.get('content-length');
+  if (contentLengthHeader) {
+    const declared = Number(contentLengthHeader);
+    if (Number.isFinite(declared) && declared > MAX_BODY_BYTES) {
+      return Response.json({ error: 'Request body exceeds 512 KB limit.' }, { status: 413 });
+    }
+  }
   const raw = await req.text();
   if (raw.length > MAX_BODY_BYTES) {
-    return badRequest('Request body exceeds 512 KB limit.');
+    return Response.json({ error: 'Request body exceeds 512 KB limit.' }, { status: 413 });
   }
   let parsed: unknown;
   try {

--- a/netlify/functions/watchlist.mts
+++ b/netlify/functions/watchlist.mts
@@ -106,11 +106,19 @@ async function saveToStore(data: SerialisedWatchlist): Promise<void> {
 // ---------------------------------------------------------------------------
 
 type PostAction =
-  | { action: 'add'; id: string; subjectName: string; riskTier?: RiskTier; metadata?: Record<string, string | number | boolean> }
+  | {
+      action: 'add';
+      id: string;
+      subjectName: string;
+      riskTier?: RiskTier;
+      metadata?: Record<string, string | number | boolean>;
+    }
   | { action: 'remove'; id: string }
   | { action: 'replace'; watchlist: SerialisedWatchlist };
 
-function validatePostBody(input: unknown): { ok: true; body: PostAction } | { ok: false; error: string } {
+function validatePostBody(
+  input: unknown
+): { ok: true; body: PostAction } | { ok: false; error: string } {
   if (!input || typeof input !== 'object') {
     return { ok: false, error: 'body must be a JSON object' };
   }
@@ -133,7 +141,10 @@ function validatePostBody(input: unknown): { ok: true; body: PostAction } | { ok
     if (raw.riskTier !== undefined && !['high', 'medium', 'low'].includes(raw.riskTier as string)) {
       return { ok: false, error: 'add: riskTier must be "high" | "medium" | "low"' };
     }
-    if (raw.metadata !== undefined && (typeof raw.metadata !== 'object' || raw.metadata === null || Array.isArray(raw.metadata))) {
+    if (
+      raw.metadata !== undefined &&
+      (typeof raw.metadata !== 'object' || raw.metadata === null || Array.isArray(raw.metadata))
+    ) {
       return { ok: false, error: 'add: metadata must be an object' };
     }
     return {
@@ -219,6 +230,15 @@ export default async (req: Request, context: Context): Promise<Response> => {
 
   // ─── POST /api/watchlist ───────────────────────────────────────────────
   if (req.method === 'POST') {
+    // Preflight Content-Length — refuse before buffering if already
+    // declared too large.
+    const contentLengthHeader = req.headers.get('content-length');
+    if (contentLengthHeader) {
+      const declared = Number(contentLengthHeader);
+      if (Number.isFinite(declared) && declared > MAX_BODY_SIZE) {
+        return jsonResponse({ ok: false, error: 'request body too large' }, { status: 413 });
+      }
+    }
     // Parse body with size cap
     let parsed: unknown;
     try {
@@ -307,10 +327,7 @@ export type ApplyActionResult =
   | { ok: true; status: number; updated: SerialisedWatchlist; response: unknown }
   | { ok: false; status: number; error: string };
 
-export function applyAction(
-  current: SerialisedWatchlist,
-  action: PostAction
-): ApplyActionResult {
+export function applyAction(current: SerialisedWatchlist, action: PostAction): ApplyActionResult {
   const wl = deserialiseWatchlist(current);
 
   if (action.action === 'add') {


### PR DESCRIPTION
## Summary

Completes the Content-Length preflight sweep across every body-buffering
Netlify function in the repo. PRs #190 (webhook), #191 (dispatch),
and #192 (proxy + simulate) covered the Asana endpoints; this PR
covers the five non-Asana endpoints:

- `ai-proxy.mts` — 1 MB cap
- `decision-stream.mts` — 512 KB cap
- `decision.mts` — 512 KB cap
- `orchestrate.mts` — 512 KB cap
- `watchlist.mts` — 256 KB cap

## What changed

Every endpoint now:

1. Refuses oversize deliveries before buffering, via a
   Content-Length preflight.
2. Returns 413 Payload Too Large (was 400 on most paths;
   `watchlist` was already 413).
3. Retains a post-read check as a belt-and-braces for callers that
   omit Content-Length.

## Non-regression

Legitimate callers hit neither new branch. The compute path
(auth, schema validation, engine invocation) is unchanged.

## Regulatory anchor

- FDL No. 10 of 2025 Art.20 — MLRO visibility. A DoS on the
  brain-decision or orchestrator endpoints breaks the MLRO's view
  of in-flight cases.
- FDL No. 10 of 2025 Art.24 — 10-year retention. The decision and
  orchestrator endpoints are the two principal write paths into
  that retention store.

## Test plan

- [x] `npx prettier --check` on every changed file → clean.
- No integration tests cover body-size checks today.

## Related

- #190 — webhook preflight (merged).
- #191 — dispatch preflight (in flight).
- #192 — proxy + simulate preflight (in flight).

https://claude.ai/code/session_018BLY2zjsVJqFTF2WLwXXge