### PR TITLE
Wire Phase 19 W-E citation enricher into asanaSync (FDL Art.24)

### DIFF
--- a/src/services/asanaSync.ts
+++ b/src/services/asanaSync.ts
@@ -21,8 +21,47 @@ import {
 import { enqueueRetry } from './asanaQueue';
 import { addTaskLink } from './asanaTaskLinks';
 import { buildComplianceCustomFields, deadlineTypeFromCaseType } from './asanaCustomFields';
+import type { DeadlineType, Verdict } from './asanaCustomFields';
+import { appendCitationBlock } from './regulatoryCitationEnricher';
 
 const DEFAULT_PROJECT = '1213759768596515';
+
+// ─── Phase 19 W-E wiring — regulatory citation block ────────────────────────
+//
+// Every task dispatched from this module has the canonical Phase 19 W-E
+// citation block appended to its notes unless the escape hatch env var
+// ASANA_CITATION_BLOCK_DISABLED is set to "1" / "true". The enricher is
+// idempotent (see appendCitationBlock in regulatoryCitationEnricher.ts)
+// so repeat dispatches do not double the block.
+//
+// Default ON. To roll back without a code change, set
+// ASANA_CITATION_BLOCK_DISABLED=1 in the Netlify env and redeploy.
+//
+// Regulatory anchor: FDL No. 10 of 2025 Art.24 (reportable structure at
+// task level); Cabinet Resolution 134/2025 Art.19 (internal review
+// traceability from task → regulation).
+
+function citationDisabled(): boolean {
+  const raw =
+    typeof process !== 'undefined' ? process.env?.ASANA_CITATION_BLOCK_DISABLED : undefined;
+  if (!raw) return false;
+  const v = String(raw).trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes';
+}
+
+function maybeAppendCitation(
+  existingNotes: string,
+  input: {
+    verdict: Verdict;
+    deadlineType?: DeadlineType;
+    caseId?: string;
+    tenantId?: string;
+    additionalCitations?: readonly string[];
+  }
+): string {
+  if (citationDisabled()) return existingNotes;
+  return appendCitationBlock(existingNotes, input);
+}
 
 // ─── Project Resolution ─────────────────────────────────────────────────────
 
@@ -85,25 +124,33 @@ function buildCaseTaskPayload(caseObj: ComplianceCase, projectId: string): Asana
     daysRemaining: dueDays,
     regulationCitation: 'FDL No.10/2025 Art.12-14 + Cabinet Res 134/2025 Art.7-10',
   });
+  const baseNotes = [
+    `Case ID: ${caseObj.id}`,
+    `Type: ${caseObj.caseType}`,
+    `Status: ${caseObj.status}`,
+    `Risk: ${caseObj.riskLevel} (score ${caseObj.riskScore})`,
+    `Red Flags: ${flags}`,
+    `Recommendation: ${caseObj.recommendation}`,
+    ``,
+    `Narrative: ${caseObj.narrative}`,
+    ``,
+    `Findings:`,
+    ...caseObj.findings.map((f) => `  - ${f}`),
+    ``,
+    `---`,
+    `Auto-created by Hawkeye Sterling V2`,
+    `Timestamp: ${new Date().toISOString()}`,
+  ].join('\n');
   return {
     name: `[${caseObj.riskLevel.toUpperCase()}] ${caseObj.caseType} — ${caseObj.entityId}`,
-    notes: [
-      `Case ID: ${caseObj.id}`,
-      `Type: ${caseObj.caseType}`,
-      `Status: ${caseObj.status}`,
-      `Risk: ${caseObj.riskLevel} (score ${caseObj.riskScore})`,
-      `Red Flags: ${flags}`,
-      `Recommendation: ${caseObj.recommendation}`,
-      ``,
-      `Narrative: ${caseObj.narrative}`,
-      ``,
-      `Findings:`,
-      ...caseObj.findings.map((f) => `  - ${f}`),
-      ``,
-      `---`,
-      `Auto-created by Hawkeye Sterling V2`,
-      `Timestamp: ${new Date().toISOString()}`,
-    ].join('\n'),
+    notes: maybeAppendCitation(baseNotes, {
+      // Case-builder risk tiers map to the closest verdict. critical/high
+      // carry the TFS anchors (escalate); medium/low are flagged.
+      verdict:
+        caseObj.riskLevel === 'critical' || caseObj.riskLevel === 'high' ? 'escalate' : 'flag',
+      deadlineType: deadlineTypeFromCaseType(caseObj.caseType),
+      caseId: caseObj.id,
+    }),
     projects: [projectId],
     due_on: dueInDays(dueDays),
     ...(Object.keys(custom_fields).length > 0 ? { custom_fields } : {}),
@@ -122,20 +169,25 @@ function buildAlertTaskPayload(
     daysRemaining: dueDays,
     regulationCitation: 'Cabinet Res 134/2025 Art.14 + FATF Rec 10',
   });
+  const baseNotes = [
+    `Alert ID: ${alertItem.id}`,
+    `Type: ${alertItem.type}`,
+    `Severity: ${alertItem.severity}`,
+    `Subject: ${alertItem.subjectType} / ${alertItem.subjectId}`,
+    ``,
+    alertItem.message,
+    ``,
+    `---`,
+    `Auto-created by Hawkeye Sterling V2 Alert Engine`,
+    `Timestamp: ${alertItem.createdAt}`,
+  ].join('\n');
   return {
     name: `[ALERT] ${alertItem.type} — ${entityName}`,
-    notes: [
-      `Alert ID: ${alertItem.id}`,
-      `Type: ${alertItem.type}`,
-      `Severity: ${alertItem.severity}`,
-      `Subject: ${alertItem.subjectType} / ${alertItem.subjectId}`,
-      ``,
-      alertItem.message,
-      ``,
-      `---`,
-      `Auto-created by Hawkeye Sterling V2 Alert Engine`,
-      `Timestamp: ${alertItem.createdAt}`,
-    ].join('\n'),
+    notes: maybeAppendCitation(baseNotes, {
+      verdict:
+        alertItem.severity === 'critical' || alertItem.severity === 'high' ? 'escalate' : 'flag',
+      caseId: alertItem.id,
+    }),
     projects: [projectId],
     due_on: dueInDays(dueDays),
     ...(Object.keys(custom_fields).length > 0 ? { custom_fields } : {}),
@@ -155,27 +207,31 @@ function buildApprovalTaskPayload(
     regulationCitation:
       approval.regulatoryBasis ?? 'Cabinet Res 134/2025 Art.12-14 + 4-Eyes Principle',
   });
+  const baseNotes = [
+    `Approval ID: ${approval.id}`,
+    `Case: ${approval.caseId}`,
+    `Required For: ${approval.requiredFor}`,
+    `Status: ${approval.status}`,
+    `Requested By: ${approval.requestedBy}`,
+    `Requested At: ${approval.requestedAt}`,
+    ``,
+    `Case Risk: ${caseObj.riskLevel} (score ${caseObj.riskScore})`,
+    `Recommendation: ${caseObj.recommendation}`,
+    ``,
+    `Regulatory Basis: ${approval.regulatoryBasis ?? 'Cabinet Resolution 134/2025 Art.12-14 | 4-Eyes Principle'}`,
+    approval.urgency === 'immediate' ? `URGENCY: IMMEDIATE — requires action within 24 hours` : '',
+    ``,
+    `---`,
+    `Auto-created by Hawkeye Sterling V2 Approval Workflow`,
+  ].join('\n');
   return {
     name: `[APPROVAL] ${approval.requiredFor} — ${caseObj.entityId}`,
-    notes: [
-      `Approval ID: ${approval.id}`,
-      `Case: ${approval.caseId}`,
-      `Required For: ${approval.requiredFor}`,
-      `Status: ${approval.status}`,
-      `Requested By: ${approval.requestedBy}`,
-      `Requested At: ${approval.requestedAt}`,
-      ``,
-      `Case Risk: ${caseObj.riskLevel} (score ${caseObj.riskScore})`,
-      `Recommendation: ${caseObj.recommendation}`,
-      ``,
-      `Regulatory Basis: ${approval.regulatoryBasis ?? 'Cabinet Resolution 134/2025 Art.12-14 | 4-Eyes Principle'}`,
-      approval.urgency === 'immediate'
-        ? `URGENCY: IMMEDIATE — requires action within 24 hours`
-        : '',
-      ``,
-      `---`,
-      `Auto-created by Hawkeye Sterling V2 Approval Workflow`,
-    ].join('\n'),
+    notes: maybeAppendCitation(baseNotes, {
+      // Approval tasks are always escalate-grade by definition —
+      // they exist because a human gate is required.
+      verdict: 'escalate',
+      caseId: approval.caseId,
+    }),
     projects: [projectId],
     due_on: dueInDays(dueDays),
     ...(Object.keys(custom_fields).length > 0 ? { custom_fields } : {}),
@@ -191,23 +247,28 @@ function buildReviewTaskPayload(
     caseId: review.id,
     regulationCitation: 'FDL No.10/2025 Art.12-14 + FATF Rec 10',
   });
+  const baseNotes = [
+    `Review ID: ${review.id}`,
+    `Customer: ${review.customerName} (${review.customerId})`,
+    `Risk Rating: ${review.riskRating}`,
+    `Review Type: ${review.reviewType}`,
+    `Frequency: Every ${review.frequencyMonths} months`,
+    `Last Review: ${review.lastReviewDate}`,
+    `Next Review: ${review.nextReviewDate}`,
+    `Status: ${review.status}`,
+    ``,
+    `Regulatory Basis: FDL No.10/2025, FATF Rec 10`,
+    ``,
+    `---`,
+    `Auto-created by Hawkeye Sterling V2 Periodic Review`,
+  ].join('\n');
   return {
     name: `[REVIEW] ${review.reviewType} — ${review.customerName}`,
-    notes: [
-      `Review ID: ${review.id}`,
-      `Customer: ${review.customerName} (${review.customerId})`,
-      `Risk Rating: ${review.riskRating}`,
-      `Review Type: ${review.reviewType}`,
-      `Frequency: Every ${review.frequencyMonths} months`,
-      `Last Review: ${review.lastReviewDate}`,
-      `Next Review: ${review.nextReviewDate}`,
-      `Status: ${review.status}`,
-      ``,
-      `Regulatory Basis: FDL No.10/2025, FATF Rec 10`,
-      ``,
-      `---`,
-      `Auto-created by Hawkeye Sterling V2 Periodic Review`,
-    ].join('\n'),
+    notes: maybeAppendCitation(baseNotes, {
+      // Periodic review is a flag-grade task by default.
+      verdict: 'flag',
+      caseId: review.id,
+    }),
     projects: [projectId],
     due_on: review.nextReviewDate.slice(0, 10),
     ...(Object.keys(custom_fields).length > 0 ? { custom_fields } : {}),


### PR DESCRIPTION
## Summary

First wiring PR of the Phase 19 pure-compute layer. Calls
`appendCitationBlock()` (PR #184) at the end of each of the four
`asanaSync.ts` task builders so every newly-dispatched task ends with
the canonical regulatory citation block.

## Changes

All four builders updated:

| Builder | Verdict mapping |
|---|---|
| `buildCaseTaskPayload` | `escalate` for critical/high, `flag` for medium/low. `deadlineType` carried over from the case. |
| `buildAlertTaskPayload` | `escalate` for critical/high severity, `flag` otherwise. |
| `buildApprovalTaskPayload` | `escalate` by construction — approval tasks exist because a human gate is required. |
| `buildReviewTaskPayload` | `flag` — periodic review is not verdict-driving. |

## Escape hatch

Set `ASANA_CITATION_BLOCK_DISABLED=1` (or `"true"`/`"yes"`) in the
Netlify env and redeploy. `maybeAppendCitation` short-circuits and
returns the base notes unchanged. Default is ON.

## Idempotency

`appendCitationBlock` guards on the literal header string. A task
already containing the block header is returned unchanged — safe
for any downstream re-sync of an existing task body.

## Regulatory anchor

- FDL No. 10 of 2025 Art.24 — 10-year retention with reportable
  structure at task level.
- Cabinet Resolution 134/2025 Art.19 — task → regulation
  traceability for internal review.

## Test plan

- [x] `npx vitest run tests/filingAsanaSync.test.ts` → 16/16 pass.
- [x] `npx tsc --noEmit` → no new errors introduced.
- [x] `npx prettier --check src/services/asanaSync.ts` → clean.
- Pure-compute side is already covered by
  `tests/regulatoryCitationEnricher.test.ts` (19 tests including
  idempotency).

## Related

- #184 — pure-compute enricher (merged).
- #182 — Phase 19 spec (merged).

https://claude.ai/code/session_018BLY2zjsVJqFTF2WLwXXge