### PR TITLE
Document ASANA_CITATION_BLOCK_DISABLED escape hatch in .env.example (FDL Art.24)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,18 @@ ASANA_CF_PEP_FLAG_CLEAR=
 ASANA_CF_PEP_FLAG_POTENTIAL=
 ASANA_CF_PEP_FLAG_MATCH=
 
+# ---------------------------------------------------------------------------
+# Phase 19 W-E — Regulatory citation block escape hatch.
+# ---------------------------------------------------------------------------
+# Every task dispatched via asanaSync.ts has the canonical Phase 19 W-E
+# regulatory citation block appended to its notes by default. Set this
+# to "1" (or "true" / "yes") to disable the append without a code
+# revert. Enricher source: src/services/regulatoryCitationEnricher.ts.
+# Wiring: src/services/asanaSync.ts (maybeAppendCitation).
+#
+# Leave blank in production. Intended use: emergency rollback only.
+ASANA_CITATION_BLOCK_DISABLED=
+
 # Awaiting Manual Action chip (enum field — Tier-4 #13). Set
 # automatically on freeze verdicts so the MLRO sees a red chip on
 # the task card prompting them to execute the freeze in the bank


### PR DESCRIPTION
## Summary

Documents the `ASANA_CITATION_BLOCK_DISABLED` escape hatch introduced
in PR #195 (W-E wiring) in `.env.example` so an operator reading the
file during an incident can find the rollback path immediately.

## Changes

- One-line env var entry with a comment block explaining:
  - what the flag does (disables the citation-block append),
  - what it applies to (`asanaSync.ts` task builders),
  - where the underlying code lives (`regulatoryCitationEnricher.ts`
    and `maybeAppendCitation` in `asanaSync.ts`),
  - intended use (emergency rollback only; leave blank in prod).

## Regulatory anchor

FDL No. 10 of 2025 Art.24 — the citation block is part of the
task-level reportable structure retention depends on; disabling it
should be a visible, auditable operator choice, not a buried env
default.

## Test plan

- [x] grep for the new var in `.env.example` → one entry.
- No code change, no regression possible.

## Related

- #184 — pure-compute enricher (merged).
- #195 — W-E wiring into asanaSync (merged).

https://claude.ai/code/session_018BLY2zjsVJqFTF2WLwXXge