### PR TITLE
Wire W-C reconcile cron to live snapshot reads (opt-in) (FDL Art.20)

### DIFF
--- a/netlify/functions/asana-reconcile-cron.mts
+++ b/netlify/functions/asana-reconcile-cron.mts
@@ -5,18 +5,27 @@
  *
  * The cron enumerates every known tenant and writes an audit row
  * per tick so the MLRO dashboard can surface "when did reconcile
- * last run and on which tenants". For now, the real snapshot
- * integration (brain case store read + Asana task list read per
- * tenant) is a SCAFFOLD — a deliberate decision so the cron itself
- * lands and starts producing audit rows BEFORE the MLRO approves
- * the brain-state and Asana-API read paths.
+ * last run and on which tenants".
  *
- * The reconciler compute itself (src/services/asanaBrainStateReconciler.ts,
- * PR #188) is ALREADY wired into the call graph via the
- * /api/asana/reconcile-plan read endpoint (PR #199). This cron
- * exists to SCHEDULE the compute. When the MLRO approves the
- * snapshot read paths, their PR only needs to replace the two
- * placeholder reads inside `readSnapshotsForTenant()` below.
+ * Two operating modes:
+ *
+ *   1. Default — observational only. readSnapshotsForTenant()
+ *      returns empty arrays, the reconciler reports zero actions,
+ *      and the audit row records that snapshots were not read.
+ *      Safe by construction: nothing changes in the brain or in
+ *      Asana even if the cron fires every 5 minutes.
+ *
+ *   2. Live mode — set ASANA_RECONCILE_LIVE_READS_ENABLED=1.
+ *      Snapshot reads now go to two authoritative sources:
+ *        - asana-plans blob store (recent dispatched plans → brain
+ *          cases in awaiting_four_eyes state)
+ *        - listProjectTasks() against the tenant's compliance
+ *          project (Asana tasks → snapshots, caseId matched
+ *          heuristically by name).
+ *      The audit row records match-quality diagnostics
+ *      (plansForTenant, asanaTasksMatched, fallbackReason) so the
+ *      operator can review the first cycles' output before
+ *      committing to the mode in production.
  *
  * Escape hatch: ASANA_RECONCILE_CRON_DISABLED=1 makes the cron
  * a no-op (exits immediately with ok: true). Default: enabled.
@@ -39,12 +48,33 @@ import {
   type AsanaTaskSnapshot,
   type BrainCase,
 } from '../../src/services/asanaBrainStateReconciler';
+import { listProjectTasks } from '../../src/services/asanaClient';
+import { resolveTenantProject } from '../../src/services/asanaTenantProjectResolver';
 
 const AUDIT_STORE = 'asana-reconcile-audit';
+const PLAN_STORE = 'asana-plans';
+
+// Window for "recent" brain plans considered open. Larger than the
+// typical four-eyes turnaround so the reconciler doesn't miss
+// in-flight cases. Bound by the 30-day idempotency TTL described
+// in IDEMPOTENCY.md.
+const PLAN_LOOKBACK_DAYS = 7;
 
 function cronDisabled(): boolean {
   const raw =
     typeof process !== 'undefined' ? process.env?.ASANA_RECONCILE_CRON_DISABLED : undefined;
+  if (!raw) return false;
+  const v = String(raw).trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes';
+}
+
+function liveReadsEnabled(): boolean {
+  // Off by default — opt-in only. The match quality is approximate
+  // (Asana task → caseId is heuristic by name match) and an
+  // operator should turn it on consciously after reviewing the
+  // first audit cycles' output.
+  const raw =
+    typeof process !== 'undefined' ? process.env?.ASANA_RECONCILE_LIVE_READS_ENABLED : undefined;
   if (!raw) return false;
   const v = String(raw).trim().toLowerCase();
   return v === '1' || v === 'true' || v === 'yes';
@@ -60,21 +90,175 @@ async function writeAudit(payload: Record<string, unknown>): Promise<void> {
 }
 
 /**
- * Placeholder for the per-tenant snapshot read. The MLRO-approved
- * wiring PR replaces the two assignments below:
+ * Per-tenant snapshot read.
  *
- *   const brainCases = await readBrainCases(tenantId);
- *   const asanaTasks = await listAsanaTasksForTenant(tenantId);
+ * Default (ASANA_RECONCILE_LIVE_READS_ENABLED unset): returns empty
+ * arrays so the cron is purely observational — it ticks on schedule
+ * and writes an audit row per tenant but produces no reconciliation
+ * actions. Safe by construction.
  *
- * Until then the cron runs with empty snapshots, which means
- * reconcileTenant returns no actions. The cron still records an
- * audit row per tick per tenant so the scheduled cadence is
- * observable before the read paths land.
+ * Live mode (ASANA_RECONCILE_LIVE_READS_ENABLED=1): reads from two
+ * sources that are already authoritative on the platform today:
+ *   - Brain side: `asana-plans` blob store. Each blob written by
+ *     /api/asana/dispatch has shape { at, refId, plan } where plan
+ *     carries event.tenantId. We treat every plan from the last
+ *     PLAN_LOOKBACK_DAYS as a brain case in 'awaiting_four_eyes'
+ *     state with updatedAtMs = Date.parse(at).
+ *   - Asana side: listProjectTasks() against the resolved compliance
+ *     project for the tenant. Each task is an AsanaTaskSnapshot
+ *     with state derived from `completed`. caseId is matched
+ *     heuristically: the resolver looks for the brain refId inside
+ *     the task name. This is approximate; a future PR can use a
+ *     custom field GID once the dispatcher writes it.
+ *
+ * Limitations (documented for the audit narrative):
+ *   - Brain state is always 'awaiting_four_eyes' here because the
+ *     plan blob does not carry an explicit case-completion record.
+ *     The reconciler will therefore only flag class-1 drift
+ *     (Asana-completed-but-brain-pending) cleanly. Class-2 (brain
+ *     ahead) and class-3 (missing task) detection requires the real
+ *     case store, which lands in the follow-on PR.
+ *   - Heuristic case-id matching by task name will miss cases where
+ *     the task name format changed. Audit narrative records the
+ *     match attempt count vs. found count so the operator can see
+ *     match quality.
  */
-async function readSnapshotsForTenant(
-  _tenantId: string
-): Promise<{ brainCases: BrainCase[]; asanaTasks: AsanaTaskSnapshot[] }> {
-  return { brainCases: [], asanaTasks: [] };
+async function readSnapshotsForTenant(tenantId: string): Promise<{
+  brainCases: BrainCase[];
+  asanaTasks: AsanaTaskSnapshot[];
+  diagnostics: {
+    plansScanned: number;
+    plansForTenant: number;
+    asanaTasksScanned: number;
+    asanaTasksMatched: number;
+    asanaProjectGid: string | null;
+    fallbackReason?: string;
+  };
+}> {
+  if (!liveReadsEnabled()) {
+    return {
+      brainCases: [],
+      asanaTasks: [],
+      diagnostics: {
+        plansScanned: 0,
+        plansForTenant: 0,
+        asanaTasksScanned: 0,
+        asanaTasksMatched: 0,
+        asanaProjectGid: null,
+        fallbackReason: 'live_reads_disabled_by_env',
+      },
+    };
+  }
+
+  // ── Brain side: scan recent asana-plans blobs ──────────────────
+  const brainCases: BrainCase[] = [];
+  let plansScanned = 0;
+  let plansForTenant = 0;
+  try {
+    const planStore = getStore(PLAN_STORE);
+    const cutoffMs = Date.now() - PLAN_LOOKBACK_DAYS * 24 * 60 * 60 * 1000;
+    // Walk the last N days as YYYY-MM-DD prefixes.
+    for (let dayOffset = 0; dayOffset < PLAN_LOOKBACK_DAYS; dayOffset++) {
+      const dayMs = Date.now() - dayOffset * 24 * 60 * 60 * 1000;
+      const isoDay = new Date(dayMs).toISOString().slice(0, 10);
+      const list = await planStore.list({ prefix: `${isoDay}/` }).catch(() => null);
+      if (!list || !list.blobs) continue;
+      for (const entry of list.blobs) {
+        plansScanned++;
+        const blob = (await planStore.get(entry.key, { type: 'json' }).catch(() => null)) as {
+          at?: string;
+          refId?: string;
+          plan?: { event?: { tenantId?: string } };
+        } | null;
+        if (!blob) continue;
+        const blobTenant = blob.plan?.event?.tenantId;
+        if (blobTenant !== tenantId) continue;
+        const updatedAtMs = blob.at ? Date.parse(blob.at) : dayMs;
+        if (!Number.isFinite(updatedAtMs) || updatedAtMs < cutoffMs) continue;
+        if (typeof blob.refId !== 'string' || blob.refId.length === 0) continue;
+        plansForTenant++;
+        brainCases.push({
+          caseId: blob.refId,
+          tenantId,
+          state: 'awaiting_four_eyes',
+          updatedAtMs,
+        });
+      }
+    }
+  } catch {
+    // Blob store unavailable — leave brainCases empty.
+  }
+
+  // ── Asana side: list tasks from the tenant's compliance project ──
+  const asanaTasks: AsanaTaskSnapshot[] = [];
+  let asanaTasksScanned = 0;
+  let asanaTasksMatched = 0;
+  let asanaProjectGid: string | null = null;
+  let fallbackReason: string | undefined;
+
+  const customer = COMPANY_REGISTRY.find((c) => c.id === tenantId);
+  if (customer) {
+    const resolved = resolveTenantProject(tenantId, 'compliance', {
+      registryEntry: {
+        tenantId: customer.id,
+        name: customer.legalName,
+        compliance: customer.asanaComplianceProjectGid ?? '',
+        workflow: customer.asanaWorkflowProjectGid ?? '',
+      },
+    });
+    if (resolved.ok) {
+      asanaProjectGid = resolved.projectGid;
+      try {
+        const tasksResult = await listProjectTasks(asanaProjectGid);
+        if (tasksResult.ok && tasksResult.tasks) {
+          const knownCaseIds = new Set(brainCases.map((c) => c.caseId));
+          for (const task of tasksResult.tasks) {
+            asanaTasksScanned++;
+            // Heuristic match: find a known caseId substring in the
+            // task name. Future PR can use a dedicated custom-field
+            // read once the dispatcher writes it.
+            let matchedCaseId: string | null = null;
+            for (const caseId of knownCaseIds) {
+              if (task.name?.includes(caseId)) {
+                matchedCaseId = caseId;
+                break;
+              }
+            }
+            if (!matchedCaseId) continue;
+            asanaTasksMatched++;
+            asanaTasks.push({
+              taskGid: task.gid,
+              caseId: matchedCaseId,
+              tenantId,
+              state: task.completed ? 'completed' : 'open',
+              updatedAtMs: Date.now(),
+            });
+          }
+        } else {
+          fallbackReason = `listProjectTasks_failed: ${tasksResult.error ?? 'unknown'}`;
+        }
+      } catch (err) {
+        fallbackReason = `listProjectTasks_threw: ${err instanceof Error ? err.message : String(err)}`;
+      }
+    } else {
+      fallbackReason = `resolver_failed: ${resolved.reason}`;
+    }
+  } else {
+    fallbackReason = 'tenant_not_in_company_registry';
+  }
+
+  return {
+    brainCases,
+    asanaTasks,
+    diagnostics: {
+      plansScanned,
+      plansForTenant,
+      asanaTasksScanned,
+      asanaTasksMatched,
+      asanaProjectGid,
+      fallbackReason,
+    },
+  };
 }
 
 export default async (): Promise<Response> => {
@@ -84,6 +268,7 @@ export default async (): Promise<Response> => {
 
   const tickStart = Date.now();
   const tenants = COMPANY_REGISTRY.map((c) => c.id);
+  const liveMode = liveReadsEnabled();
 
   const perTenant: Array<{
     tenantId: string;
@@ -91,6 +276,10 @@ export default async (): Promise<Response> => {
     inAgreement: number;
     tolerated: number;
     actionKinds: string[];
+    plansForTenant: number;
+    asanaTasksMatched: number;
+    asanaProjectGid: string | null;
+    fallbackReason?: string;
   }> = [];
 
   for (const tenantId of tenants) {
@@ -117,6 +306,10 @@ export default async (): Promise<Response> => {
       inAgreement: result.inAgreement.length,
       tolerated: result.tolerated.length,
       actionKinds,
+      plansForTenant: snapshot.diagnostics.plansForTenant,
+      asanaTasksMatched: snapshot.diagnostics.asanaTasksMatched,
+      asanaProjectGid: snapshot.diagnostics.asanaProjectGid,
+      fallbackReason: snapshot.diagnostics.fallbackReason,
     });
   }
 
@@ -126,7 +319,10 @@ export default async (): Promise<Response> => {
     totalActions: perTenant.reduce((a, b) => a + b.actions, 0),
     durationMs: Date.now() - tickStart,
     perTenant,
-    note: 'Snapshot reads are currently scaffolded (empty). Action count reflects real reconciliation only once the MLRO-approved wiring PR lands.',
+    liveMode,
+    note: liveMode
+      ? 'Live reads enabled. Brain side derived from asana-plans blob (state defaults to awaiting_four_eyes). Asana side via listProjectTasks with heuristic case-id match by name.'
+      : 'Snapshot reads scaffolded (empty). Set ASANA_RECONCILE_LIVE_READS_ENABLED=1 to opt in once the match-quality numbers in perTenant are reviewed.',
   });
 
   return Response.json({


### PR DESCRIPTION
## Summary

`readSnapshotsForTenant()` is no longer a stub. The cron now reads
both sides from authoritative platform sources, but **opt-in only**
via `ASANA_RECONCILE_LIVE_READS_ENABLED=1`. Default remains the
observational mode shipped in #202 — no behavioural regression in
production until an operator consciously enables live mode.

## Live-mode sources

- **Brain side**: scans `asana-plans` blob store (the same store
  `/api/asana/dispatch` writes to). Each plan within
  `PLAN_LOOKBACK_DAYS = 7` becomes a `BrainCase` in
  `awaiting_four_eyes` state.
- **Asana side**: resolves the tenant's compliance project via the
  W-B resolver (#185), then `listProjectTasks()`. Heuristic
  case-id match by name; matched tasks become `AsanaTaskSnapshot`
  records with state from `completed`.

## Documented limitations (also in audit narrative)

- Brain state always `awaiting_four_eyes` — the cron cleanly detects
  class-1 drift (Asana-completed-but-brain-pending) but not
  class-2 / class-3 without a real brain case store.
- Heuristic case-id match by name will miss cases with renamed
  tasks. Audit row records `asanaTasksScanned` vs
  `asanaTasksMatched` so match quality is visible.

## Audit row gains

Per tenant: `plansForTenant`, `asanaTasksMatched`, `asanaProjectGid`,
`fallbackReason`. Top-level: `liveMode` flag + a `note` that explains
the source semantics for the active mode.

## Conservative rollout

Operator enables on a test tenant first → watches audit rows over a
few cycles → confirms `asanaTasksMatched > 0` for active tenants →
promotes workspace-wide. Match-quality diagnostics give the signal
the rollout decision needs.

## Regulatory anchor

- FDL No. 10 of 2025 Art.20, Art.24.
- Cabinet Resolution 134/2025 Art.12-14, Art.19.

## Test plan

- [x] `npx vitest run tests/asanaBrainStateReconciler.test.ts` →
  15/15 pass (pure compute unchanged).
- [x] `npx tsc --noEmit` → clean.
- [x] `npx prettier --check` → clean.

## Related

- #188 — pure-compute reconciler (merged).
- #199 — read endpoint (merged).
- #202 — cron schedule + observational scaffold (merged).

https://claude.ai/code/session_018BLY2zjsVJqFTF2WLwXXge