### PR TITLE
Add Bootstrap ALL 6 tenants button to setup wizard Step 8

### DIFF
--- a/setup.html
+++ b/setup.html
@@ -320,6 +320,13 @@ cust-2,Bob Smith,tenant-a,Robert Smith,1985-04-15,GB,2026-04-10T00:00:00Z</pre>
       <span id="bootstrap-status"></span>
     </div>
     <div class="output" id="bootstrap-output">(click to provision)</div>
+
+    <p class="muted" style="margin-top:1rem">Or provision all six canonical tenants in one click (fine-gold-llc, fine-gold-branch, madison-llc, naples-llc, gramaltin-as, zoe-fze). Idempotent: existing projects are reused.</p>
+    <div class="row">
+      <button class="primary" id="btn-bootstrap-all">🚀 Bootstrap ALL 6 tenants</button>
+      <span id="bootstrap-all-status"></span>
+    </div>
+    <div class="output" id="bootstrap-all-output">(click to provision all 6)</div>
   </div>
 
   <!-- STEP 9 -->

--- a/setup.js
+++ b/setup.js
@@ -329,6 +329,29 @@
     });
   });
 
+  // --- Step 8b: bootstrap ALL 6 canonical tenants ---
+  byId('btn-bootstrap-all').addEventListener('click', function () {
+    readInputs();
+    setStatus('bootstrap-all-status', 'pending', 'Provisioning all 6 tenants…');
+    var token = state.brainToken;
+    fetch(apiBase() + '/api/setup/asana-bootstrap-all', {
+      method: 'POST',
+      headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    }).then(function (r) {
+      return r.json().then(function (body) { return { status: r.status, body: body }; });
+    }).then(function (res) {
+      var ok = res.status < 400 && res.body && res.body.ok !== false;
+      var partial = res.status === 207;
+      var label = ok ? 'All 6 ready' : (partial ? 'Partial — see output' : 'Failed');
+      setStatus('bootstrap-all-status', ok ? 'ok' : 'err', label);
+      writeOutput('bootstrap-all-output', JSON.stringify(res.body, null, 2));
+    }).catch(function (err) {
+      setStatus('bootstrap-all-status', 'err', 'Network error');
+      writeOutput('bootstrap-all-output', String(err));
+    });
+  });
+
   // --- Step 9: provision KYC/CDD Tracker sections ---
   byId('btn-kyc-cdd-sections').addEventListener('click', function () {
     readInputs();


### PR DESCRIPTION
## Summary

One-line UI wiring for the `/api/setup/asana-bootstrap-all` endpoint
merged yesterday in #207. Adds a second button to Step 8 of the setup
wizard that provisions all six canonical tenants in a single click
instead of running Step 8 six times.

### Changes

- **`setup.html`** — adds `btn-bootstrap-all` button + status + output
  panel directly under the existing per-tenant control in Step 8.
- **`setup.js`** — wires the button to `POST /api/setup/asana-bootstrap-all`
  with the brain bearer token, handles HTTP 200 (full success), 207
  (partial), and ≥400 (error) states distinctly so the MLRO can triage.

### Regulatory citations

- **Cabinet Resolution 134/2025 Art.18** — CO change notification:
  one-click path reduces operational risk of inconsistent provisioning
  across tenants during the MoE Art.18 filing window.
- **Cabinet Resolution 134/2025 Art.19** — internal review: each
  tenant's provisioning still writes to `setup-audit` blob store
  (unchanged behaviour, inherited from #207).

## Test plan

- [ ] Deploy preview builds
- [ ] Setup wizard Step 8 renders two buttons (per-tenant + all)
- [ ] Click "Bootstrap ALL 6" with valid token → green "All 6 ready"
- [ ] Re-click immediately → still green, blobs show reused not created
- [ ] Click without token → red "Failed" with clear error in output
- [ ] Force a per-tenant error (invalid PAT scope) → yellow "Partial" +
      per-tenant breakdown in output

https://claude.ai/code/session_018BLY2zjsVJqFTF2WLwXXge