### PR TITLE
Add "Generate MFA seed" button to setup wizard (no terminal required)

### DIFF
--- a/setup.html
+++ b/setup.html
@@ -291,6 +291,42 @@
     <div class="output" id="verify-output">(click verify to check)</div>
   </div>
 
+  <!-- Generate MFA seed (one-time, replaces terminal openssl step) -->
+  <div class="step">
+    <h2>Generate MFA seed (one-time)</h2>
+    <p class="muted">
+      Click below to generate a new 20-byte TOTP seed in your browser
+      using <code>crypto.getRandomValues</code>. The seed is shown
+      ONCE — copy it to:
+    </p>
+    <ol class="muted" style="margin-left:1.2em">
+      <li>Netlify env var <code>SETUP_MFA_TOTP_SECRET</code> (all scopes) and redeploy.</li>
+      <li>Your authenticator app (1Password, Authy, Google Authenticator, Bitwarden) — manual entry, SHA1, 6 digits, 30 s.</li>
+      <li>A password-manager secure note as an offline backup.</li>
+    </ol>
+    <p class="muted">
+      <strong>Do not screenshot this page.</strong> Do not paste the
+      seed into email, Slack, or any log. The seed is not persisted;
+      refresh or navigate away and it is gone.
+    </p>
+    <div class="row">
+      <button class="primary" id="btn-generate-mfa-seed">🔐 Generate MFA seed</button>
+      <span id="mfa-seed-status"></span>
+    </div>
+    <div id="mfa-seed-block" style="display:none; margin-top:12px">
+      <label>Base32 seed (paste into Netlify env + authenticator app)</label>
+      <input type="text" id="mfa-seed-output" readonly style="font-family:monospace">
+      <div class="row" style="margin-top:6px">
+        <button class="copy-btn" id="btn-copy-mfa-seed">Copy seed</button>
+      </div>
+      <label style="margin-top:12px">otpauth:// URL (tap on mobile to auto-enrol)</label>
+      <input type="text" id="mfa-seed-otpauth" readonly style="font-family:monospace">
+      <div class="row" style="margin-top:6px">
+        <button class="copy-btn" id="btn-copy-mfa-otpauth">Copy otpauth URL</button>
+      </div>
+    </div>
+  </div>
+
   <!-- MFA (required for Steps 7, 8, 9) -->
   <div class="step">
     <h2>MFA — 6-digit code (required for Steps 7, 8, 9)</h2>

--- a/setup.js
+++ b/setup.js
@@ -226,6 +226,59 @@
     if (el) el.addEventListener('input', saveState);
   });
 
+  // --- Generate MFA seed (one-time) ---
+  // Uses crypto.getRandomValues so the seed never leaves the
+  // browser. 20 bytes (160 bits) is the RFC 6238 reference length
+  // for HMAC-SHA1. The seed is shown once; not persisted.
+  var BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+  function base32Encode(bytes) {
+    var bits = 0, value = 0, out = '';
+    for (var i = 0; i < bytes.length; i++) {
+      value = (value << 8) | bytes[i];
+      bits += 8;
+      while (bits >= 5) {
+        bits -= 5;
+        out += BASE32_ALPHABET.charAt((value >> bits) & 0x1f);
+      }
+    }
+    if (bits > 0) out += BASE32_ALPHABET.charAt((value << (5 - bits)) & 0x1f);
+    return out;
+  }
+
+  byId('btn-generate-mfa-seed').addEventListener('click', function () {
+    try {
+      var bytes = new Uint8Array(20);
+      window.crypto.getRandomValues(bytes);
+      var seed = base32Encode(bytes);
+      var label = encodeURIComponent('Hawkeye Sterling:MLRO');
+      var issuer = encodeURIComponent('Hawkeye Sterling');
+      var otpauth = 'otpauth://totp/' + label +
+        '?secret=' + seed +
+        '&issuer=' + issuer +
+        '&algorithm=SHA1&digits=6&period=30';
+      byId('mfa-seed-output').value = seed;
+      byId('mfa-seed-otpauth').value = otpauth;
+      byId('mfa-seed-block').style.display = 'block';
+      setStatus('mfa-seed-status', 'ok', 'Generated — copy to Netlify + authenticator NOW');
+    } catch (err) {
+      setStatus('mfa-seed-status', 'err', 'crypto.getRandomValues unavailable');
+    }
+  });
+
+  function wireMfaCopy(buttonId, inputId, defaultLabel) {
+    byId(buttonId).addEventListener('click', function () {
+      var val = byId(inputId).value;
+      if (!val) return;
+      navigator.clipboard.writeText(val).then(function () {
+        byId(buttonId).textContent = 'Copied!';
+        setTimeout(function () { byId(buttonId).textContent = defaultLabel; }, 2000);
+      });
+    });
+  }
+  wireMfaCopy('btn-copy-mfa-seed', 'mfa-seed-output', 'Copy seed');
+  wireMfaCopy('btn-copy-mfa-otpauth', 'mfa-seed-otpauth', 'Copy otpauth URL');
+
   // --- Step 5: copy env block ---
   byId('btn-copy-env').addEventListener('click', function () {
     var text = byId('env-output').textContent;


### PR DESCRIPTION
## Summary

Follow-up to #212. The MFA-on-setup-wizard work landed on `main`
but the one-time seed generation still required the operator to
run `openssl rand -base32 20` in a terminal. MLROs who operate
without a terminal had to fall back to password-manager TOTP
generators, which works but varies by app and adds friction.

This PR closes the gap with a single **"🔐 Generate MFA seed"**
button in `setup.html`. One click → a cryptographically strong
20-byte (160-bit) seed appears, generated by
`window.crypto.getRandomValues`. The seed never leaves the
browser; no server round-trip.

### What the new card shows
- **Base32 seed** — paste into Netlify env
  `SETUP_MFA_TOTP_SECRET` (all scopes), then redeploy.
- **`otpauth://` URL** — tap on mobile to auto-enrol into the
  authenticator app (1Password, Authy, Google Authenticator,
  Bitwarden) without manual entry.
- **"Copy" buttons** for each, so clipboard-only flows work.

### Security semantics
- In-memory only. Not persisted, not sent anywhere, not logged.
- Refresh the page → seed is unrecoverable (by design).
- Explicit "do not screenshot / do not paste into chat" warning
  on the card.
- Same security posture as the existing 6-digit MFA input
  directly below it.

## No backend changes

- No new routes.
- No new env vars.
- No test changes — the card is pure UI glue. Server-side MFA
  verification tests from #212 remain authoritative.

## Regulatory citations

- **Cabinet Res 134/2025 Art.5** — firm risk appetite. A
  browser-only seed-creation path reduces the attack surface
  around seed handling (no terminal history, no CI log, no
  clipboard through a shell).
- **Cabinet Res 134/2025 Art.19** — internal review. Seed never
  transits a third-party service.
- **CLAUDE.md `Seguridad` §2** — no secret in source; the repo
  only references `SETUP_MFA_TOTP_SECRET` by name.

## Test plan

- [ ] Open `/setup.html` on the deploy preview.
- [ ] Click "🔐 Generate MFA seed"; confirm a 32-character base32
      string and an `otpauth://totp/...` URL both appear.
- [ ] "Copy seed" and "Copy otpauth URL" buttons each write to
      clipboard.
- [ ] Paste the seed into a Netlify env and the authenticator
      app, redeploy, enter the current 6-digit code in the card
      below, bootstrap a tenant. Expect `ok: true`.
- [ ] Refresh the page; confirm the seed card is back to the
      empty state — no persistence.

https://claude.ai/code/session_018BLY2zjsVJqFTF2WLwXXge