### PR TITLE
Mirror HAWKEYE_BRAIN_TOKEN to localStorage['auth.token'] so SPA API calls authenticate

### DIFF
--- a/app-core.js
+++ b/app-core.js
@@ -834,6 +834,15 @@ function hydrateKeys() {
   // pick it up without a page reload.
   if (HAWKEYE_BRAIN_TOKEN_VALUE) {
     window.HAWKEYE_BRAIN_TOKEN = HAWKEYE_BRAIN_TOKEN_VALUE;
+    // Mirror to the 'auth.token' localStorage key that brain-boot.js,
+    // warroom-client.js and compliance-suite.js read via getToken().
+    // Without this mirror every /api/brain, /api/warroom/stream and
+    // /api/asana-toast call returns 401 "Invalid token" — the SPA
+    // stored the token under the legacy key but the callers read it
+    // from the canonical key.
+    try { localStorage.setItem('auth.token', HAWKEYE_BRAIN_TOKEN_VALUE); } catch (_) { /* storage may be disabled */ }
+  } else {
+    try { localStorage.removeItem('auth.token'); } catch (_) { /* ignore */ }
   }
   GDRIVE_CLIENT_ID = (saved.gdriveClientId || '').trim();
   GDRIVE_FOLDER_ID = (saved.gdriveFolderId || '').trim();
@@ -923,6 +932,12 @@ function updateKeys() {
     // Inject into window immediately so the toast stream poller +
     // Brain Console probe pick it up without a reload.
     window.HAWKEYE_BRAIN_TOKEN = HAWKEYE_BRAIN_TOKEN_VALUE;
+    // Also mirror to localStorage['auth.token'] — the canonical key
+    // that brain-boot.js, warroom-client.js and compliance-suite.js
+    // read via getToken(). Same reason as hydrateKeys(): without this
+    // line every /api/brain, /api/warroom/stream and /api/asana-toast
+    // call returns 401 "Invalid token".
+    try { localStorage.setItem('auth.token', HAWKEYE_BRAIN_TOKEN_VALUE); } catch (_) { /* storage may be disabled */ }
   }
   persistKeys();
 


### PR DESCRIPTION
## Summary

Bug: a logged-in MLRO opening the **NORAD War Room**, clicking
**"Run Full Brain Analysis"**, or probing the **Asana Toast Stream**
all got `401 "Invalid token"` / `"Unauthorized"` responses — even
though `HAWKEYE_BRAIN_TOKEN` was correctly configured in Netlify
env AND entered in the in-app Settings panel.

Root cause: a setter/reader key mismatch in client-side storage.

## Evidence

| Caller | Reads from |
|---|---|
| `brain-boot.js:38` | `localStorage['auth.token']` |
| `warroom-client.js:200` | `localStorage['auth.token']` |
| `compliance-suite.js:4944` | `localStorage['auth.token']` |

| Setter | Writes to |
|---|---|
| `app-core.js` `updateKeys()` L921-926 | `localStorage['hawkeyeBrainToken']` + `window.HAWKEYE_BRAIN_TOKEN` |
| `app-core.js` `hydrateKeys()` L832-837 | `localStorage['hawkeyeBrainToken']` + `window.HAWKEYE_BRAIN_TOKEN` |

`auth.token` was never populated. Every bearer header went out empty
and `authenticate()` in `netlify/functions/middleware/auth.mts`
rejected with 401.

## Fix

Two mirror writes in `app-core.js`:

- **`hydrateKeys()`** — on app start, after restoring the token,
  also write it to `localStorage['auth.token']`. On clear, remove
  it.
- **`updateKeys()`** — when the Settings panel Save button fires,
  also write the token to `localStorage['auth.token']`.

Both writes are guarded with `try/catch` so storage-disabled
browsers (private mode, MDM policy) fall back gracefully.

## What is NOT changed

- No API change
- No new storage key
- No new env var
- No auth-middleware change
- No new endpoints

Pure client-side shim that aligns the setter path with the
existing reader path.

## What this unblocks in the live app

- **NORAD War Room** — `/api/warroom/stream` SSE feed starts
  streaming situational-awareness snapshots
- **Run Full Brain Analysis** — `/api/brain` POST returns 200
- **Asana Toast Stream probe** — `/api/asana-toast` returns 200
- Any future endpoint that reads via `getToken()`

## Operator follow-up (same browser, ~30 seconds)

1. Open the app → Settings → **Hawkeye Brain Token**.
2. Paste the same 48/64-hex value that is in Netlify env var
   `HAWKEYE_BRAIN_TOKEN` (the same value already on the wizard's
   Step 1 / Step 5 display).
3. Click **Save**. The new mirror write fires immediately.
4. Dashboard calls start returning 200; War Room SSE starts
   streaming.

No redeploy needed once this PR merges — the fix is client-side
JS that ships with the next Netlify build.

## Regulatory basis

- **Cabinet Res 134/2025 Art.19** — internal review. The War Room
  SSE stream is the firm's live monitoring evidence; a broken
  auth path silently suppresses that evidence.

## Test plan

- [ ] Clear `localStorage['auth.token']` in the browser devtools.
- [ ] Open the app; confirm Settings → Hawkeye Brain Token shows
      the saved value.
- [ ] Reload; verify `localStorage['auth.token']` is now populated
      by `hydrateKeys()`.
- [ ] Click "Run Full Brain Analysis" → expect 200, not 401.
- [ ] Open NORAD War Room → click Start Live → expect SSE stream
      to connect without 401.
- [ ] Probe Asana Toast Stream → expect 200.
- [ ] Clear the Settings field and re-save → confirm
      `localStorage['auth.token']` is removed.

https://claude.ai/code/session_018BLY2zjsVJqFTF2WLwXXge