### PR TITLE
Add Tracking tab with AWB shipment table + per-tenant Asana Shipments section auto-sync

### DIFF
--- a/app-core.js
+++ b/app-core.js
@@ -346,6 +346,7 @@ function getAsanaComplianceProject() {
 const ASANA_WORKSPACE = '1213645083721316';
 const KEYS_STORAGE = 'fgl_keys';
 const SHIPMENTS_STORAGE = 'fgl_shipments';
+const TRACKING_STORAGE = 'fgl_tracking';
 const ALERTS_STORAGE = 'fgl_alerts';
 const EMAIL_TEST_STATUS_STORAGE = 'fgl_email_test_status';
 const COMPLIANCE_OPS_STORAGE = 'fgl_compliance_ops';
@@ -1095,6 +1096,7 @@ function switchTab(name) {
   if (name==='raci') { renderRACIMatrix(); loadRACIHistory(); }
   if (name==='employees') renderEmployeeDirectory();
   if (name==='localshipments') renderLocalShipments();
+  if (name==='tracking') renderTracking();
   if (name==='settings') { if (typeof renderUserManagement === 'function') renderUserManagement(); applyRoleRestrictions(); if (typeof loadComplianceConfigUI === 'function') loadComplianceConfigUI(); if (typeof checkStorageQuota === 'function') checkStorageQuota(); if (typeof initCloudSyncUI === 'function') initCloudSyncUI(); }
   if (name==='uploads') loadUploadedFiles();
   if (name==='incidents') { if (typeof updateIncidentMetrics === 'function') updateIncidentMetrics(); }
@@ -6263,6 +6265,254 @@ function exportLocalShipmentsCSV() {
   const blob = new Blob(['\ufeff'+csv],{type:'text/csv;charset=utf-8'});
   const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download='Local_Shipments_'+new Date().toISOString().slice(0,10)+'.csv';a.click();
   toast('CSV exported','success');
+}
+
+// ---------------------------------------------------------------------------
+// TRACKING — global AWB shipment tracking.
+//
+// Each record holds:
+//   id (uuid), awb, departure, arrival, acquired (yyyy-mm-dd), lastUpdated
+//   (iso), status (in-transit/arrived/delayed/delivered), carrier, weight,
+//   asanaGid (optional — set after successful Asana sync).
+//
+// Persistence: localStorage under TRACKING_STORAGE. On every add/edit/delete
+// the record is mirrored to Asana as a task in the per-tenant "Shipments"
+// section of the current tenant's workflow project. The section is
+// auto-created on first sync if it does not exist, so no re-bootstrap is
+// required on already-provisioned tenants.
+//
+// Regulatory basis: FDL No.10/2025 Art.24 (10-year retention), LBMA RGG v9
+// (chain of custody for gold shipments).
+// ---------------------------------------------------------------------------
+
+let editingTrackingId = null;
+
+function renderTracking() {
+  const list = safeLocalParse(TRACKING_STORAGE, []);
+  const el = document.getElementById('tracking-list');
+  if (!el) return;
+  if (!list.length) {
+    el.innerHTML = '<p style="font-size:13px;color:var(--muted)">No shipments tracked yet. Fill the form above and click "Add shipment".</p>';
+    return;
+  }
+  const rows = list.map(s => {
+    const statusColor = s.status === 'delivered' ? 'var(--green)' :
+                        s.status === 'arrived' ? 'var(--green)' :
+                        s.status === 'delayed' ? 'var(--red)' :
+                        'var(--amber)';
+    const updated = s.lastUpdated ? new Date(s.lastUpdated).toLocaleString() : '—';
+    const asanaTag = s.asanaGid
+      ? '<span style="font-size:10px;color:var(--green)">✓ Asana synced</span>'
+      : '<span style="font-size:10px;color:var(--muted)">not synced</span>';
+    return `<tr>
+      <td style="font-family:monospace">${escHtml(s.awb || '—')}</td>
+      <td>${escHtml(s.departure || '—')}</td>
+      <td>${escHtml(s.arrival || '—')}</td>
+      <td>${escHtml(s.acquired || '—')}</td>
+      <td style="font-size:11px;color:var(--muted)">${escHtml(updated)}</td>
+      <td style="font-weight:700;color:${statusColor}">${escHtml(s.status || '—')}</td>
+      <td>${escHtml(s.carrier || '—')}</td>
+      <td>${escHtml(String(s.weight ?? '—'))}</td>
+      <td style="white-space:nowrap">
+        <button class="btn btn-sm" style="padding:2px 8px;font-size:10px" data-action="editTrackingRecord" data-arg="${s.id}">Edit</button>
+        <button class="btn btn-sm" style="padding:2px 8px;font-size:10px" data-action="syncTrackingRecord" data-arg="${s.id}">↗ Asana</button>
+        <button class="btn btn-sm btn-red" style="padding:2px 8px;font-size:10px" data-action="deleteTrackingRecord" data-arg="${s.id}">Delete</button>
+        <div style="margin-top:4px">${asanaTag}</div>
+      </td>
+    </tr>`;
+  }).join('');
+  el.innerHTML = `
+    <table class="asana-table" style="width:100%; font-size:12px">
+      <thead>
+        <tr>
+          <th>AWB</th>
+          <th>Departure</th>
+          <th>Arrival</th>
+          <th>Acquired</th>
+          <th>Last updated</th>
+          <th>Status</th>
+          <th>Carrier</th>
+          <th>Weight (kg)</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>${rows}</tbody>
+    </table>
+  `;
+}
+
+function readTrackingForm() {
+  return {
+    awb: (document.getElementById('trackingAwb')?.value || '').trim(),
+    departure: (document.getElementById('trackingDeparture')?.value || '').trim(),
+    arrival: (document.getElementById('trackingArrival')?.value || '').trim(),
+    acquired: (document.getElementById('trackingAcquired')?.value || '').trim(),
+    carrier: (document.getElementById('trackingCarrier')?.value || '').trim(),
+    weight: (() => {
+      const raw = (document.getElementById('trackingWeight')?.value || '').trim();
+      if (!raw) return null;
+      const n = Number(raw);
+      return Number.isFinite(n) ? n : null;
+    })(),
+    status: (document.getElementById('trackingStatus')?.value || 'in-transit').trim(),
+  };
+}
+
+function clearTrackingForm() {
+  ['trackingAwb','trackingDeparture','trackingArrival','trackingAcquired','trackingCarrier','trackingWeight'].forEach(id => {
+    const el = document.getElementById(id); if (el) el.value = '';
+  });
+  const st = document.getElementById('trackingStatus'); if (st) st.value = 'in-transit';
+}
+
+function addTrackingRecord() {
+  const form = readTrackingForm();
+  if (!form.awb || !form.departure || !form.arrival || !form.acquired) {
+    toast('AWB, departure, arrival, and acquired date are required', 'error');
+    return;
+  }
+  const list = safeLocalParse(TRACKING_STORAGE, []);
+  const nowIso = new Date().toISOString();
+  if (editingTrackingId) {
+    const idx = list.findIndex(x => x.id === editingTrackingId);
+    if (idx === -1) { editingTrackingId = null; return; }
+    list[idx] = { ...list[idx], ...form, lastUpdated: nowIso };
+    safeLocalSave(TRACKING_STORAGE, list);
+    editingTrackingId = null;
+    const btn = document.querySelector('[data-action="addTrackingRecord"]');
+    if (btn) btn.textContent = '➕ Add shipment';
+    const cancel = document.getElementById('btnCancelEditTracking');
+    if (cancel) cancel.style.display = 'none';
+    clearTrackingForm();
+    renderTracking();
+    toast('Shipment updated', 'success');
+    syncTrackingRecord(list[idx].id);
+    return;
+  }
+  const rec = { id: (crypto.randomUUID ? crypto.randomUUID() : String(Date.now())), ...form, lastUpdated: nowIso, asanaGid: null };
+  list.push(rec);
+  safeLocalSave(TRACKING_STORAGE, list);
+  clearTrackingForm();
+  renderTracking();
+  toast('Shipment added', 'success');
+  syncTrackingRecord(rec.id);
+}
+
+function editTrackingRecord(id) {
+  const list = safeLocalParse(TRACKING_STORAGE, []);
+  const s = list.find(x => x.id === id);
+  if (!s) return;
+  editingTrackingId = id;
+  const map = {
+    trackingAwb: s.awb, trackingDeparture: s.departure, trackingArrival: s.arrival,
+    trackingAcquired: s.acquired, trackingCarrier: s.carrier,
+    trackingWeight: s.weight == null ? '' : String(s.weight),
+    trackingStatus: s.status || 'in-transit',
+  };
+  Object.entries(map).forEach(([k,v]) => { const el=document.getElementById(k); if(el) el.value = v || ''; });
+  const btn = document.querySelector('[data-action="addTrackingRecord"]');
+  if (btn) btn.textContent = '💾 Update shipment';
+  const cancel = document.getElementById('btnCancelEditTracking');
+  if (cancel) cancel.style.display = '';
+}
+
+function cancelEditTracking() {
+  editingTrackingId = null;
+  clearTrackingForm();
+  const btn = document.querySelector('[data-action="addTrackingRecord"]');
+  if (btn) btn.textContent = '➕ Add shipment';
+  const cancel = document.getElementById('btnCancelEditTracking');
+  if (cancel) cancel.style.display = 'none';
+}
+
+function deleteTrackingRecord(id) {
+  if (!confirm('Delete this tracked shipment? The linked Asana task is NOT deleted — close it manually in Asana if required.')) return;
+  let list = safeLocalParse(TRACKING_STORAGE, []);
+  list = list.filter(x => x.id !== id);
+  safeLocalSave(TRACKING_STORAGE, list);
+  renderTracking();
+  toast('Shipment removed', 'success');
+}
+
+// Asana sync — POST /api/asana/proxy is the browser-safe wrapper.
+// The asana-proxy endpoint keeps the Asana token server-side and
+// allowlists the paths we call: GET /projects/{gid}/sections,
+// POST /projects/{gid}/sections, POST /tasks.
+async function _asanaProxy(method, path, body) {
+  const token = localStorage.getItem('auth.token') || window.HAWKEYE_BRAIN_TOKEN || '';
+  const res = await fetch('/api/asana/proxy', {
+    method: 'POST',
+    headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ method: method, path: path, body: body || undefined }),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const reason = data && data.error ? data.error : ('HTTP ' + res.status);
+    throw new Error(reason);
+  }
+  return data;
+}
+
+async function _findOrCreateShipmentsSection(projectGid) {
+  // List sections, look for one named "Shipments" (case-insensitive),
+  // create it if missing. Returns the section GID.
+  const listRes = await _asanaProxy('GET', '/projects/' + encodeURIComponent(projectGid) + '/sections');
+  const existing = (listRes && listRes.data || []).find(s => (s.name || '').trim().toLowerCase() === 'shipments');
+  if (existing && existing.gid) return existing.gid;
+  const created = await _asanaProxy('POST', '/projects/' + encodeURIComponent(projectGid) + '/sections', { data: { name: 'Shipments' } });
+  if (!created || !created.data || !created.data.gid) throw new Error('Section create returned no GID');
+  return created.data.gid;
+}
+
+async function syncTrackingRecord(id) {
+  const list = safeLocalParse(TRACKING_STORAGE, []);
+  const rec = list.find(x => x.id === id);
+  if (!rec) return;
+  let projectGid;
+  try { projectGid = getAsanaProject(); } catch (_) { projectGid = null; }
+  if (!projectGid) { toast('No Asana project configured for the active tenant', 'error'); return; }
+  try {
+    const sectionGid = await _findOrCreateShipmentsSection(projectGid);
+    const taskName = 'AWB ' + (rec.awb || '—') + ' · ' + (rec.departure || '?') + ' → ' + (rec.arrival || '?');
+    const notesLines = [
+      'AWB: ' + (rec.awb || '—'),
+      'Departure country: ' + (rec.departure || '—'),
+      'Arrival country: ' + (rec.arrival || '—'),
+      'Acquired date: ' + (rec.acquired || '—'),
+      'Status: ' + (rec.status || '—'),
+      'Carrier: ' + (rec.carrier || '—'),
+      'Weight (kg): ' + (rec.weight == null ? '—' : String(rec.weight)),
+      'Last updated: ' + (rec.lastUpdated || '—'),
+      '',
+      'Source: Hawkeye Sterling Tracking tab. Auto-synced.',
+    ];
+    const body = {
+      data: {
+        name: taskName,
+        notes: notesLines.join('\n'),
+        projects: [projectGid],
+        memberships: [{ project: projectGid, section: sectionGid }],
+      },
+    };
+    if (rec.asanaGid) {
+      // Update existing task instead of creating a duplicate.
+      await _asanaProxy('PUT', '/tasks/' + encodeURIComponent(rec.asanaGid), {
+        data: { name: taskName, notes: notesLines.join('\n') },
+      });
+      toast('Asana task updated', 'success');
+    } else {
+      const created = await _asanaProxy('POST', '/tasks', body);
+      const gid = created && created.data && created.data.gid;
+      if (gid) {
+        rec.asanaGid = gid;
+        safeLocalSave(TRACKING_STORAGE, list);
+      }
+      toast('Asana task created in Shipments section', 'success');
+    }
+    renderTracking();
+  } catch (err) {
+    toast('Asana sync failed: ' + (err && err.message ? err.message : 'unknown'), 'error');
+  }
 }
 
 function exportLocalShipmentsDOCX() {

--- a/index.html
+++ b/index.html
@@ -3084,6 +3084,7 @@
             🔍 Analyze
           </div>
           <div class="tab" data-action="switchTab" data-arg="shipments">🚚 IAR Shipments</div>
+          <div class="tab" data-action="switchTab" data-arg="tracking">✈️ Tracking</div>
           <div class="tab" data-action="switchTab" data-arg="localshipments">
             📦 Local Shipments
           </div>
@@ -4046,6 +4047,65 @@ Examples:
               </p>
             </div>
           </div>
+        </div>
+
+        <!-- TRACKING TAB — global AWB shipment tracking.
+             Each record is persisted to localStorage AND mirrored to
+             Asana as a task in the per-tenant "Shipments" section
+             (auto-created on first sync). Regulatory basis:
+             FDL No.10/2025 Art.24 (10-year record retention),
+             LBMA RGG v9 (chain of custody for gold shipments). -->
+        <div id="tab-tracking" class="tab-content">
+          <div class="section-title">✈️ Global Shipment Tracking</div>
+          <div class="muted" style="margin-bottom:10px">
+            Track AWB shipments from origin to destination. Records
+            are stored locally and mirrored to the active tenant's
+            Asana project under a "Shipments" section (auto-created
+            on first sync).
+          </div>
+
+          <div class="form-grid" style="margin-bottom:14px">
+            <div>
+              <label>AWB number</label>
+              <input type="text" id="trackingAwb" placeholder="176-12345678">
+            </div>
+            <div>
+              <label>Departure country</label>
+              <input type="text" id="trackingDeparture" placeholder="AE">
+            </div>
+            <div>
+              <label>Arrival country</label>
+              <input type="text" id="trackingArrival" placeholder="CH">
+            </div>
+            <div>
+              <label>Acquired date</label>
+              <input type="date" id="trackingAcquired">
+            </div>
+            <div>
+              <label>Carrier</label>
+              <input type="text" id="trackingCarrier" placeholder="Emirates SkyCargo">
+            </div>
+            <div>
+              <label>Weight (kg)</label>
+              <input type="number" id="trackingWeight" min="0" step="0.01" placeholder="125.50">
+            </div>
+            <div>
+              <label>Status</label>
+              <select id="trackingStatus">
+                <option value="in-transit">in-transit</option>
+                <option value="arrived">arrived</option>
+                <option value="delayed">delayed</option>
+                <option value="delivered">delivered</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="row" style="margin-bottom:14px; gap:8px">
+            <button class="primary" data-action="addTrackingRecord">➕ Add shipment</button>
+            <button data-action="cancelEditTracking" id="btnCancelEditTracking" style="display:none">Cancel edit</button>
+          </div>
+
+          <div id="tracking-list"></div>
         </div>
 
         <!-- LOCAL SHIPMENTS TAB -->


### PR DESCRIPTION
## Summary

New top-nav tab **✈️ Tracking** between IAR Shipments and Local
Shipments. Lets the MLRO record every airline/cargo shipment and
get a real-time chain-of-custody view across the firm's global
flow, with automatic mirroring into a per-tenant Asana
"Shipments" section.

## What the operator sees

A single card with:

- **Form:** AWB · Departure country · Arrival country · Acquired
  date · Carrier · Weight (kg) · Status
- **Table** with the eight columns requested:
  `AWB · Departure · Arrival · Acquired · Last updated · Status ·
  Carrier · Weight (kg)`
- Row actions: **Edit** · **↗ Asana** (re-sync) · **Delete**
- Status values: `in-transit / arrived / delayed / delivered`

## What happens on Add / Edit

1. Record written to `localStorage` under `fgl_tracking`
   (matches the existing Local Shipments pattern).
2. Record auto-mirrored to the active tenant's Asana workflow
   project via `POST /api/asana/proxy`:
   - `GET /projects/{gid}/sections` — look for existing
     "Shipments" section.
   - If absent, `POST /projects/{gid}/sections` creates it.
     **Already-provisioned tenants do NOT need re-bootstrap** —
     the section is added lazily on first sync.
   - `POST /tasks` creates a task with
     `memberships: [{ project, section }]`. Task name:
     `AWB <number> · <dep> → <arr>`. Notes: all 8 fields in plain
     text.
   - The returned task GID is stored on the record so a later
     Edit calls `PUT /tasks/{gid}` instead of creating a
     duplicate.
3. Toast confirms success or reports the Asana error text.

## Why `asana-proxy` (not `asana-dispatch`)

`asana-dispatch` is for orchestration-event routing (STR
templates, four-eyes tasks, brain plan dispatch). Shipments are
plain CRUD data, so the simpler browser-safe proxy is the right
fit. The proxy keeps `ASANA_API_TOKEN` server-side and enforces a
path allowlist that already covers all four routes we call
(`GET`/`POST /projects/*/sections`, `POST /tasks`,
`PUT /tasks/*`).

## Storage + delegation

- Storage key: `fgl_tracking`
- Render on tab switch: `switchTab('tracking')` → `renderTracking()`
- Event delegation via `data-action` — no new event wiring

## What is deliberately NOT in this PR

- **No live airline API** (no 17track/TrackingMore/AfterShip
  call). Status is operator-entered for now. A follow-up PR will
  wire a provider and pull latest carrier status before updating
  the Asana task.
- **No tenantProvisioner change** — the "Shipments" section is
  created lazily on first sync, so existing provisioned tenants
  keep working and new ones get it on demand.

## Regulatory basis

- **FDL No.10/2025 Art.24** — 10-year record retention. Every
  shipment record is both local and mirrored to Asana.
- **LBMA RGG v9** — chain-of-custody for gold shipments.

## Test plan

- [ ] Refresh the SPA (hard reload). Click the **✈️ Tracking**
      tab. The form and an empty-state message should appear.
- [ ] Fill the form (AWB, Dep, Arr, Acquired, Carrier, Weight,
      Status). Click **Add shipment**.
- [ ] Expect: row appears in the table, toast "Shipment added",
      then "Asana task created in Shipments section".
- [ ] Open the active tenant's Asana workflow project in a
      second tab. Confirm a new section "Shipments" exists and
      contains the task with the AWB name.
- [ ] Click **Edit** on a row → change Status to `delivered` →
      Update. Expect "Asana task updated" toast; the same task
      in Asana should reflect the new fields.
- [ ] Click **↗ Asana** on a row; expect another "updated" toast
      (idempotent).
- [ ] Click **Delete** → confirm prompt. Expect row disappears;
      Asana task stays (closed manually if desired).

https://claude.ai/code/session_018BLY2zjsVJqFTF2WLwXXge