### PR TITLE
Unify hero typography — 'Sterling' matches 'HAWKEYE' serif

### DIFF
--- a/index.html
+++ b/index.html
@@ -2586,12 +2586,12 @@
                 style="
                   font-family: Georgia, 'Times New Roman', serif;
                   font-weight: 300;
-                  font-style: italic;
                   font-size: 64px;
-                  letter-spacing: 0.05em;
+                  letter-spacing: 0.18em;
                   color: #d4af37;
                   margin: 0 0 28px;
                   line-height: 1.05;
+                  text-transform: uppercase;
                 "
               >
                 Sterling
@@ -2599,10 +2599,10 @@
               <div
                 style="
                   font-family: Georgia, 'Times New Roman', serif;
-                  font-style: italic;
                   font-size: 18px;
                   color: #cfc7b3;
                   margin-bottom: 32px;
+                  letter-spacing: 0.08em;
                 "
               >
                 Where Vision Meets Vigilance
@@ -3028,10 +3028,10 @@
             <div
               style="
                 font-family: Georgia, 'Times New Roman', serif;
-                font-style: italic;
                 font-size: 15px;
                 color: #cfc7b3;
                 margin-bottom: 32px;
+                letter-spacing: 0.08em;
               "
             >
               By invitation. By reputation. By design.


### PR DESCRIPTION
## Summary

The hero card mixed italic and non-italic Georgia on the same
logotype: "HAWKEYE" was rendered in upright serif with 0.18em
tracking, while "Sterling" directly beneath it used italic
Georgia at 0.05em tracking — the two lines read as different
fonts to a casual viewer and broke the "same font design" rule
the user asked for.

## Fixes

- **`Sterling` h2** — drop `font-style: italic`, bump
  `letter-spacing` from `0.05em` to `0.18em`, add
  `text-transform: uppercase` so both lines share the same
  case, weight, tracking, and style. Gold colour
  (`#d4af37`) kept as the only deliberate distinction.
- **"Where Vision Meets Vigilance"** subtitle — drop italic,
  add `0.08em` tracking so kerning matches the rest of the
  hero.
- **"By invitation. By reputation. By design."** — same
  treatment, italic dropped, 0.08em tracking added.

Zero behaviour change; purely presentational. No other italic
Georgia left in `index.html` after this commit.

## Test plan

- [ ] Deploy preview renders the hero with "HAWKEYE" and
      "STERLING" in matching serif caps, gold on the second
      line.
- [ ] The red scribble the user made on the screenshot — the
      italic cursive feel — is gone; the letters now stand
      upright.
- [ ] The two taglines under the logotype are upright serif,
      not italic.

https://claude.ai/code/session_018BLY2zjsVJqFTF2WLwXXge