### PR TITLE
Add ETA (expected arrival date + time) to Tracking tab + mirror to Asana due_at

### DIFF
--- a/app-core.js
+++ b/app-core.js
@@ -6295,12 +6295,48 @@ function renderTracking() {
     el.innerHTML = '<p style="font-size:13px;color:var(--muted)">No shipments tracked yet. Fill the form above and click "Add shipment".</p>';
     return;
   }
+  const now = Date.now();
   const rows = list.map(s => {
     const statusColor = s.status === 'delivered' ? 'var(--green)' :
                         s.status === 'arrived' ? 'var(--green)' :
                         s.status === 'delayed' ? 'var(--red)' :
                         'var(--amber)';
     const updated = s.lastUpdated ? new Date(s.lastUpdated).toLocaleString() : '—';
+
+    // ETA display + countdown. Input comes from <input type="datetime-local">
+    // so it is local wall-clock; Date() parses it as local too.
+    let etaCell = '<span style="color:var(--muted)">—</span>';
+    if (s.eta) {
+      const etaDate = new Date(s.eta);
+      if (!Number.isNaN(etaDate.getTime())) {
+        const delta = etaDate.getTime() - now;
+        const absMs = Math.abs(delta);
+        const days = Math.floor(absMs / 86400000);
+        const hours = Math.floor((absMs % 86400000) / 3600000);
+        const mins = Math.floor((absMs % 3600000) / 60000);
+        const parts = [];
+        if (days) parts.push(days + 'd');
+        if (hours) parts.push(hours + 'h');
+        if (!days) parts.push(mins + 'm');
+        const rel = parts.join(' ');
+        let tag;
+        const terminal = s.status === 'arrived' || s.status === 'delivered';
+        if (terminal) {
+          tag = `<span style="font-size:10px;color:var(--green)">✓ completed</span>`;
+        } else if (delta < 0) {
+          tag = `<span style="font-size:10px;color:var(--red)">overdue by ${rel}</span>`;
+        } else if (delta < 24 * 3600000) {
+          tag = `<span style="font-size:10px;color:var(--amber)">arriving in ${rel}</span>`;
+        } else {
+          tag = `<span style="font-size:10px;color:var(--muted)">in ${rel}</span>`;
+        }
+        etaCell = `
+          <div>${escHtml(etaDate.toLocaleString())}</div>
+          <div>${tag}</div>
+        `;
+      }
+    }
+
     const asanaTag = s.asanaGid
       ? '<span style="font-size:10px;color:var(--green)">✓ Asana synced</span>'
       : '<span style="font-size:10px;color:var(--muted)">not synced</span>';
@@ -6309,6 +6345,7 @@ function renderTracking() {
       <td>${escHtml(s.departure || '—')}</td>
       <td>${escHtml(s.arrival || '—')}</td>
       <td>${escHtml(s.acquired || '—')}</td>
+      <td>${etaCell}</td>
       <td style="font-size:11px;color:var(--muted)">${escHtml(updated)}</td>
       <td style="font-weight:700;color:${statusColor}">${escHtml(s.status || '—')}</td>
       <td>${escHtml(s.carrier || '—')}</td>
@@ -6329,6 +6366,7 @@ function renderTracking() {
           <th>Departure</th>
           <th>Arrival</th>
           <th>Acquired</th>
+          <th>ETA (expected arrival)</th>
           <th>Last updated</th>
           <th>Status</th>
           <th>Carrier</th>
@@ -6347,6 +6385,7 @@ function readTrackingForm() {
     departure: (document.getElementById('trackingDeparture')?.value || '').trim(),
     arrival: (document.getElementById('trackingArrival')?.value || '').trim(),
     acquired: (document.getElementById('trackingAcquired')?.value || '').trim(),
+    eta: (document.getElementById('trackingEta')?.value || '').trim(),
     carrier: (document.getElementById('trackingCarrier')?.value || '').trim(),
     weight: (() => {
       const raw = (document.getElementById('trackingWeight')?.value || '').trim();
@@ -6359,7 +6398,7 @@ function readTrackingForm() {
 }
 
 function clearTrackingForm() {
-  ['trackingAwb','trackingDeparture','trackingArrival','trackingAcquired','trackingCarrier','trackingWeight'].forEach(id => {
+  ['trackingAwb','trackingDeparture','trackingArrival','trackingAcquired','trackingEta','trackingCarrier','trackingWeight'].forEach(id => {
     const el = document.getElementById(id); if (el) el.value = '';
   });
   const st = document.getElementById('trackingStatus'); if (st) st.value = 'in-transit';
@@ -6405,7 +6444,8 @@ function editTrackingRecord(id) {
   editingTrackingId = id;
   const map = {
     trackingAwb: s.awb, trackingDeparture: s.departure, trackingArrival: s.arrival,
-    trackingAcquired: s.acquired, trackingCarrier: s.carrier,
+    trackingAcquired: s.acquired, trackingEta: s.eta || '',
+    trackingCarrier: s.carrier,
     trackingWeight: s.weight == null ? '' : String(s.weight),
     trackingStatus: s.status || 'in-transit',
   };
@@ -6474,11 +6514,23 @@ async function syncTrackingRecord(id) {
   try {
     const sectionGid = await _findOrCreateShipmentsSection(projectGid);
     const taskName = 'AWB ' + (rec.awb || '—') + ' · ' + (rec.departure || '?') + ' → ' + (rec.arrival || '?');
+    // ETA pretty-print: store as the user typed it (local datetime),
+    // echo back to Asana in ISO + local so both MLRO and auditor see
+    // the same moment.
+    const etaDisplay = rec.eta
+      ? (() => {
+          const d = new Date(rec.eta);
+          return Number.isNaN(d.getTime())
+            ? rec.eta
+            : d.toLocaleString() + ' (' + d.toISOString() + ')';
+        })()
+      : '—';
     const notesLines = [
       'AWB: ' + (rec.awb || '—'),
       'Departure country: ' + (rec.departure || '—'),
       'Arrival country: ' + (rec.arrival || '—'),
       'Acquired date: ' + (rec.acquired || '—'),
+      'Expected arrival (ETA): ' + etaDisplay,
       'Status: ' + (rec.status || '—'),
       'Carrier: ' + (rec.carrier || '—'),
       'Weight (kg): ' + (rec.weight == null ? '—' : String(rec.weight)),
@@ -6486,18 +6538,29 @@ async function syncTrackingRecord(id) {
       '',
       'Source: Hawkeye Sterling Tracking tab. Auto-synced.',
     ];
-    const body = {
-      data: {
-        name: taskName,
-        notes: notesLines.join('\n'),
-        projects: [projectGid],
-        memberships: [{ project: projectGid, section: sectionGid }],
-      },
+    // Asana due_at wants ISO 8601 UTC. If the MLRO entered an ETA,
+    // normalise it; otherwise omit so Asana does not set a due date.
+    const dueAt = rec.eta
+      ? (() => {
+          const d = new Date(rec.eta);
+          return Number.isNaN(d.getTime()) ? undefined : d.toISOString();
+        })()
+      : undefined;
+    const taskData = {
+      name: taskName,
+      notes: notesLines.join('\n'),
+      projects: [projectGid],
+      memberships: [{ project: projectGid, section: sectionGid }],
     };
+    if (dueAt) taskData.due_at = dueAt;
+    const body = { data: taskData };
     if (rec.asanaGid) {
       // Update existing task instead of creating a duplicate.
+      const updatePayload = { name: taskName, notes: notesLines.join('\n') };
+      if (dueAt) updatePayload.due_at = dueAt;
+      else updatePayload.due_at = null; // clear previous ETA if removed
       await _asanaProxy('PUT', '/tasks/' + encodeURIComponent(rec.asanaGid), {
-        data: { name: taskName, notes: notesLines.join('\n') },
+        data: updatePayload,
       });
       toast('Asana task updated', 'success');
     } else {

--- a/index.html
+++ b/index.html
@@ -4082,6 +4082,10 @@ Examples:
               <input type="date" id="trackingAcquired">
             </div>
             <div>
+              <label>Expected arrival (ETA, date + time)</label>
+              <input type="datetime-local" id="trackingEta">
+            </div>
+            <div>
               <label>Carrier</label>
               <input type="text" id="trackingCarrier" placeholder="Emirates SkyCargo">
             </div>


### PR DESCRIPTION
## Summary

Adds a ninth column on the Tracking tab: **ETA — Expected
Arrival (date + time)**. The MLRO needs to know exactly when
each AWB shipment is due so they can spot delays against route-
norm timings and plan documentation windows for LBMA chain-of-
custody checks.

## Operator-facing

- New form input: "Expected arrival (ETA, date + time)" using
  `<input type="datetime-local">`. Native date+time picker in
  Chrome / Edge / Safari / Firefox.
- New table column "ETA (expected arrival)" showing:
  - Local-timezone timestamp
  - Colour-coded countdown:
    - **amber** within 24 h
    - **red** "overdue by …" when the ETA has passed and the
      shipment is still in-transit / delayed
    - **green** ✓ completed once the record is marked arrived or
      delivered
    - **muted grey** for distant ETAs (days away)
- Edit round-trips the field; Delete/CSV export unchanged.

## Asana sync

- Asana `due_at` (ISO 8601 UTC) is set on POST `/tasks` and PUT
  `/tasks/{gid}` so the shipment lands on the tenant's Asana
  project calendar at the right moment.
- If the ETA is cleared on edit, `due_at: null` is sent so a
  stale calendar entry is removed, not left pointing at an old
  date.
- Task notes include a line `Expected arrival (ETA): <local>
  (<ISO>)` so auditors reading the task in any timezone see the
  exact moment without re-conversion.

## Regulatory basis

- **FDL No.10/2025 Art.24** — full record (incl. ETA) retained
  10 years in both browser storage and Asana.
- **LBMA RGG v9** — chain-of-custody steps are time-boxed; a
  concrete ETA enables the MLRO to challenge any bar that turns
  up outside the expected window.

## Test plan

- [ ] Deploy preview → hard reload → ✈️ Tracking tab shows the
      new ETA input between "Acquired date" and "Carrier".
- [ ] Add a new shipment with an ETA 2 hours from now. Row shows
      the ETA and an amber "arriving in 2h" label.
- [ ] Edit the shipment; set ETA to yesterday. Row shows red
      "overdue by 1d".
- [ ] Change status to `arrived`. Row shows green "✓ completed".
- [ ] Open the active tenant's Asana workflow project → the task
      shows the ETA as its due date on the calendar view.
- [ ] Edit again and clear the ETA field → PUT with `due_at: null`
      removes the task's due date in Asana.

https://claude.ai/code/session_018BLY2zjsVJqFTF2WLwXXge