### PR TITLE
fix: Harden daily compliance report modules — XSS, NaN%, risk matrix, scheduler (FDL No.10/2025 Art.24, LBMA RGG v9)

### DIFF
--- a/asana-brain-daily-report-executor.js
+++ b/asana-brain-daily-report-executor.js
@@ -25,6 +25,34 @@ const axios = require('axios');
 const fs = require('fs');
 const path = require('path');
 
+// HTML escape for any value interpolated into a report template.
+// Raw concatenation into `generateHTMLReport` would otherwise allow
+// an Asana project name or task title to break the DOM or inject
+// script-carrying markup into the emailed HTML body.
+function escapeHtml(value) {
+  if (value === null || value === undefined) return '';
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// Safe percentage helper to avoid NaN when the denominator is 0.
+function pct(numerator, denominator, digits = 1) {
+  if (!denominator || denominator <= 0) return (0).toFixed(digits);
+  return ((numerator / denominator) * 100).toFixed(digits);
+}
+
+// Constrain a path segment so an external projectId cannot traverse
+// out of the reports directory.
+function safePathSegment(value, fallback = 'unknown') {
+  const raw = String(value == null ? '' : value);
+  const cleaned = raw.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 128);
+  return cleaned || fallback;
+}
+
 class AsanaBrainDailyReportExecutor {
   constructor(config) {
     this.config = config;
@@ -110,13 +138,21 @@ class AsanaBrainDailyReportExecutor {
    */
   loadExecutionHistory() {
     const historyFile = path.join(process.cwd(), 'reports', 'execution-history.json');
-    if (fs.existsSync(historyFile)) {
-      try {
-        this.executionHistory = JSON.parse(fs.readFileSync(historyFile, 'utf-8'));
-      } catch (error) {
-        this.logger.warn('Failed to load execution history', { error: error.message });
-        this.executionHistory = [];
+    if (!fs.existsSync(historyFile)) return;
+    try {
+      const parsed = JSON.parse(fs.readFileSync(historyFile, 'utf-8'));
+      // A corrupted or hand-edited history file can easily contain a
+      // non-array shape; guarding here avoids later .push / .filter
+      // crashes that would otherwise take down the whole executor.
+      this.executionHistory = Array.isArray(parsed) ? parsed : [];
+      if (!Array.isArray(parsed)) {
+        this.logger.warn('Execution history file was not an array, resetting', {
+          historyFile,
+        });
       }
+    } catch (error) {
+      this.logger.warn('Failed to load execution history', { error: error.message });
+      this.executionHistory = [];
     }
   }
 
@@ -277,16 +313,34 @@ class AsanaBrainDailyReportExecutor {
     const reportDate = new Date();
     const reportId = `compliance-report-${project.id}-${reportDate.toISOString().split('T')[0]}`;
 
-    // Calculate risk matrix
-    const criticalTasks = tasks.filter(t => this.calculateDaysOverdue(t) > 30);
-    const highRiskTasks = tasks.filter(t => this.calculateDaysOverdue(t) > 14 && this.calculateDaysOverdue(t) <= 30);
-    const mediumRiskTasks = tasks.filter(t => this.calculateDaysOverdue(t) > 7 && this.calculateDaysOverdue(t) <= 14);
+    // Precompute daysOverdue once per task; the old code called
+    // calculateDaysOverdue multiple times per task across the filter,
+    // sort and percentage passes, which is O(N) per call and does
+    // not scale past a few thousand tasks.
+    const tasksWithDaysOverdue = tasks.map(t => ({
+      task: t,
+      daysOverdue: this.calculateDaysOverdue(t),
+    }));
+
+    const criticalTasks = tasksWithDaysOverdue.filter(x => x.daysOverdue > 30).map(x => x.task);
+    const highRiskTasks = tasksWithDaysOverdue.filter(x => x.daysOverdue > 14 && x.daysOverdue <= 30).map(x => x.task);
+    const mediumRiskTasks = tasksWithDaysOverdue.filter(x => x.daysOverdue > 7 && x.daysOverdue <= 14).map(x => x.task);
+
+    // "Low" means "overdue by 1-7 days", not "every remaining task".
+    // The old computation (tasks.length - critical - high - medium)
+    // silently lumped completed and not-yet-due tasks into the low
+    // bucket, which both over-counted low risk and stopped the four
+    // buckets from matching the overdue total shown elsewhere in the
+    // report.
+    const lowRiskTasks = tasksWithDaysOverdue
+      .filter(x => x.daysOverdue > 0 && x.daysOverdue <= 7)
+      .map(x => x.task);
 
     const riskMatrix = {
       critical: criticalTasks.length,
       high: highRiskTasks.length,
       medium: mediumRiskTasks.length,
-      low: tasks.length - criticalTasks.length - highRiskTasks.length - mediumRiskTasks.length,
+      low: lowRiskTasks.length,
     };
 
     // Generate recommendations
@@ -328,10 +382,10 @@ class AsanaBrainDailyReportExecutor {
       },
 
       riskMatrix: {
-        critical: { count: riskMatrix.critical, percentage: ((riskMatrix.critical / tasks.length) * 100).toFixed(1) },
-        high: { count: riskMatrix.high, percentage: ((riskMatrix.high / tasks.length) * 100).toFixed(1) },
-        medium: { count: riskMatrix.medium, percentage: ((riskMatrix.medium / tasks.length) * 100).toFixed(1) },
-        low: { count: riskMatrix.low, percentage: ((riskMatrix.low / tasks.length) * 100).toFixed(1) },
+        critical: { count: riskMatrix.critical, percentage: pct(riskMatrix.critical, tasks.length) },
+        high: { count: riskMatrix.high, percentage: pct(riskMatrix.high, tasks.length) },
+        medium: { count: riskMatrix.medium, percentage: pct(riskMatrix.medium, tasks.length) },
+        low: { count: riskMatrix.low, percentage: pct(riskMatrix.low, tasks.length) },
       },
 
       recommendations: recommendations,
@@ -411,23 +465,21 @@ class AsanaBrainDailyReportExecutor {
   /**
    * Identify top issues
    */
-  identifyTopIssues(tasks, metrics) {
-    const issues = [];
-
-    const mostOverdue = tasks
+  identifyTopIssues(tasks, _metrics) {
+    // Compute daysOverdue once per task, not per filter/sort comparator
+    // call — the previous implementation re-parsed due_date O(N log N)
+    // times just for the sort, on top of the filter and loop calls.
+    const annotated = tasks
       .filter(t => t.status !== 'completed')
-      .sort((a, b) => this.calculateDaysOverdue(b) - this.calculateDaysOverdue(a))
+      .map(t => ({ task: t, daysOverdue: this.calculateDaysOverdue(t) }))
+      .sort((a, b) => b.daysOverdue - a.daysOverdue)
       .slice(0, 5);
 
-    for (const task of mostOverdue) {
-      issues.push({
-        issue: `Task overdue: ${task.title}`,
-        daysOverdue: this.calculateDaysOverdue(task),
-        priority: this.calculateDaysOverdue(task) > 30 ? 'CRITICAL' : 'HIGH',
-      });
-    }
-
-    return issues;
+    return annotated.map(({ task, daysOverdue }) => ({
+      issue: `Task overdue: ${task.title}`,
+      daysOverdue,
+      priority: daysOverdue > 30 ? 'CRITICAL' : 'HIGH',
+    }));
   }
 
   /**
@@ -480,15 +532,22 @@ class AsanaBrainDailyReportExecutor {
     const performance = [];
     for (const member in teamMembers) {
       const tm = teamMembers[member];
+      // `rateNum` is kept as a number for a correct sort; `completionRate`
+      // stays as the formatted string used by the report renderer so
+      // the downstream template output is unchanged.
+      const rateNum = tm.total > 0 ? (tm.completed / tm.total) * 100 : 0;
       performance.push({
         member,
         total: tm.total,
         completed: tm.completed,
-        completionRate: ((tm.completed / tm.total) * 100).toFixed(1),
+        completionRate: rateNum.toFixed(1),
+        _rate: rateNum,
       });
     }
 
-    return performance.sort((a, b) => b.completionRate - a.completionRate);
+    return performance
+      .sort((a, b) => b._rate - a._rate)
+      .map(({ _rate, ...row }) => row);
   }
 
   /**
@@ -517,11 +576,15 @@ class AsanaBrainDailyReportExecutor {
    * Save report to file
    */
   async saveReport(report, projectId) {
-    const reportsDir = path.join(process.cwd(), 'reports', projectId);
-
-    if (!fs.existsSync(reportsDir)) {
-      fs.mkdirSync(reportsDir, { recursive: true });
+    // Sanitize the projectId so a malformed/malicious ID cannot
+    // escape the reports root via "../" segments.
+    const safeProjectId = safePathSegment(projectId);
+    const reportsRoot = path.resolve(process.cwd(), 'reports');
+    const reportsDir = path.resolve(reportsRoot, safeProjectId);
+    if (!reportsDir.startsWith(reportsRoot + path.sep) && reportsDir !== reportsRoot) {
+      throw new Error(`Refusing to write report outside reports directory: ${reportsDir}`);
     }
+    fs.mkdirSync(reportsDir, { recursive: true });
 
     const fileName = `compliance-report-${report.reportDate.toISOString().split('T')[0]}.json`;
     const filePath = path.join(reportsDir, fileName);
@@ -645,10 +708,24 @@ class AsanaBrainDailyReportExecutor {
    */
   async sendAsanaReport(report) {
     try {
+      // Asana's createTask accepts `notes` (plain text) or `html_notes`
+      // (bounded HTML) — `description` is silently dropped by the API,
+      // which is why the report body was never landing on the task.
+      // Keep the body short: full JSON can exceed Asana's notes limit
+      // and the file is already attached/saved elsewhere.
+      const notes = [
+        `Daily Compliance Report for ${report.projectName}`,
+        `Generated: ${report.generatedAt && report.generatedAt.toISOString ? report.generatedAt.toISOString() : ''}`,
+        `Overall status: ${report.executiveSummary && report.executiveSummary.overallStatus}`,
+        `Compliance rate: ${report.metrics && report.metrics.complianceRate}%`,
+        `Health score: ${report.metrics && report.metrics.healthScore}`,
+        `Risk score: ${report.metrics && report.metrics.riskScore}%`,
+      ].join('\n');
+
       const task = await this.asanaClient.createTask({
         projects: [report.projectId],
         name: `Daily Compliance Report - ${report.reportDate.toLocaleDateString()}`,
-        description: JSON.stringify(report, null, 2),
+        notes,
       });
 
       this.logger.info('Asana report task created', { taskId: task.id });
@@ -663,12 +740,25 @@ class AsanaBrainDailyReportExecutor {
    * Generate HTML report
    */
   generateHTMLReport(report) {
+    // Escape every externally-sourced value before interpolating it
+    // into the HTML email body. Asana project and task names are
+    // operator-controlled, so without escaping they could inject
+    // arbitrary markup (or script, if rendered by a lax email client)
+    // into the report.
+    const summary = report.executiveSummary || {};
+    const metrics = report.metrics || {};
+    const risk = report.riskMatrix || {
+      critical: { count: 0, percentage: '0.0' },
+      high: { count: 0, percentage: '0.0' },
+      medium: { count: 0, percentage: '0.0' },
+      low: { count: 0, percentage: '0.0' },
+    };
     return `
 <!DOCTYPE html>
 <html>
 <head>
   <meta charset="UTF-8">
-  <title>${report.executiveSummary.title}</title>
+  <title>${escapeHtml(summary.title)}</title>
   <style>
     body { font-family: Arial, sans-serif; margin: 20px; background-color: #f5f5f5; }
     .header { background-color: #1a1a1a; color: white; padding: 20px; border-radius: 5px; margin-bottom: 20px; }
@@ -683,25 +773,25 @@ class AsanaBrainDailyReportExecutor {
 </head>
 <body>
   <div class="header">
-    <h1>${report.executiveSummary.title}</h1>
-    <p>Generated: ${report.executiveSummary.date}</p>
+    <h1>${escapeHtml(summary.title)}</h1>
+    <p>Generated: ${escapeHtml(summary.date)}</p>
   </div>
   <div class="section">
     <h2>Executive Summary</h2>
     <div class="metric">
-      <div class="metric-value">${report.metrics.complianceRate}%</div>
+      <div class="metric-value">${escapeHtml(metrics.complianceRate)}%</div>
       <div class="metric-label">Compliance Rate</div>
     </div>
     <div class="metric">
-      <div class="metric-value">${report.metrics.healthScore}</div>
+      <div class="metric-value">${escapeHtml(metrics.healthScore)}</div>
       <div class="metric-label">Health Score</div>
     </div>
     <div class="metric">
-      <div class="metric-value">${report.metrics.riskScore}%</div>
+      <div class="metric-value">${escapeHtml(metrics.riskScore)}%</div>
       <div class="metric-label">Risk Score</div>
     </div>
     <div class="metric">
-      <div class="metric-value">${report.metrics.completedTasks}/${report.metrics.totalTasks}</div>
+      <div class="metric-value">${escapeHtml(metrics.completedTasks)}/${escapeHtml(metrics.totalTasks)}</div>
       <div class="metric-label">Tasks Completed</div>
     </div>
   </div>
@@ -709,15 +799,15 @@ class AsanaBrainDailyReportExecutor {
     <h2>Risk Matrix</h2>
     <table>
       <tr><th>Risk Level</th><th>Count</th><th>Percentage</th></tr>
-      <tr><td>Critical</td><td>${report.riskMatrix.critical.count}</td><td>${report.riskMatrix.critical.percentage}%</td></tr>
-      <tr><td>High</td><td>${report.riskMatrix.high.count}</td><td>${report.riskMatrix.high.percentage}%</td></tr>
-      <tr><td>Medium</td><td>${report.riskMatrix.medium.count}</td><td>${report.riskMatrix.medium.percentage}%</td></tr>
-      <tr><td>Low</td><td>${report.riskMatrix.low.count}</td><td>${report.riskMatrix.low.percentage}%</td></tr>
+      <tr><td>Critical</td><td>${escapeHtml(risk.critical.count)}</td><td>${escapeHtml(risk.critical.percentage)}%</td></tr>
+      <tr><td>High</td><td>${escapeHtml(risk.high.count)}</td><td>${escapeHtml(risk.high.percentage)}%</td></tr>
+      <tr><td>Medium</td><td>${escapeHtml(risk.medium.count)}</td><td>${escapeHtml(risk.medium.percentage)}%</td></tr>
+      <tr><td>Low</td><td>${escapeHtml(risk.low.count)}</td><td>${escapeHtml(risk.low.percentage)}%</td></tr>
     </table>
   </div>
   <div class="section" style="text-align: center; color: #666; font-size: 12px;">
     <p>This report was automatically generated by ASANA Brain Compliance Intelligence System</p>
-    <p>Generated: ${new Date().toISOString()}</p>
+    <p>Generated: ${escapeHtml(new Date().toISOString())}</p>
   </div>
 </body>
 </html>

--- a/automated-daily-report-generator.js
+++ b/automated-daily-report-generator.js
@@ -18,6 +18,36 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 
+// HTML entities that must be escaped in any text value that is
+// interpolated into a generated HTML report. Unlike React, raw string
+// concatenation into templates does not escape anything, so Asana
+// task names or assignee labels containing "<", ">", "&", quotes or
+// the unicode line separators would break the DOM or enable stored
+// HTML injection in emailed reports.
+function escapeHtml(value) {
+  if (value === null || value === undefined) return '';
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// Safe percentage helper that avoids NaN when the denominator is 0.
+function pct(numerator, denominator, digits = 1) {
+  if (!denominator || denominator <= 0) return (0).toFixed(digits);
+  return ((numerator / denominator) * 100).toFixed(digits);
+}
+
+// Restrict a filesystem segment to a single, safe directory name so a
+// caller-supplied projectId cannot traverse out of the reports dir.
+function safePathSegment(value, fallback = 'unknown') {
+  const raw = String(value == null ? '' : value);
+  const cleaned = raw.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 128);
+  return cleaned || fallback;
+}
+
 class AutomatedDailyReportGenerator {
   constructor(config) {
     this.config = config;
@@ -131,36 +161,47 @@ class AutomatedDailyReportGenerator {
   }
 
   /**
-   * Start the daily scheduler
+   * Start the daily scheduler. Fires at 08:00 UTC every day; schedules
+   * each subsequent run from a freshly computed 08:00 UTC so there is
+   * no drift across DST transitions or leap seconds. Rejections from
+   * the async executor are captured locally instead of leaking into
+   * the global unhandled-rejection handler.
    */
   startScheduler() {
     const span = this.tracer.startSpan('start_scheduler');
     try {
       this.logger.info('Starting daily report scheduler...');
-      
-      // Calculate time until 8:00 AM
-      const now = new Date();
-      const scheduledTime = new Date();
-      scheduledTime.setHours(8, 0, 0, 0);
-      
-      // If it's already past 8:00 AM, schedule for tomorrow
-      if (now > scheduledTime) {
-        scheduledTime.setDate(scheduledTime.getDate() + 1);
-      }
-      
-      const timeUntilExecution = scheduledTime - now;
-      
-      this.logger.info(`Next report generation scheduled for: ${scheduledTime.toISOString()}`);
-      
-      // Set up daily execution
-      this.dailyTimer = setTimeout(() => {
-        this.executeDailyReports();
-        // Set up recurring daily execution
-        this.dailyInterval = setInterval(() => {
-          this.executeDailyReports();
-        }, 24 * 60 * 60 * 1000); // 24 hours
-      }, timeUntilExecution);
-      
+
+      const scheduleNext = () => {
+        const now = new Date();
+        const next = new Date(Date.UTC(
+          now.getUTCFullYear(),
+          now.getUTCMonth(),
+          now.getUTCDate(),
+          8, 0, 0, 0,
+        ));
+        if (next.getTime() <= now.getTime()) {
+          next.setUTCDate(next.getUTCDate() + 1);
+        }
+        const delay = next.getTime() - now.getTime();
+        this.logger.info(`Next report generation scheduled for: ${next.toISOString()}`);
+        this.dailyTimer = setTimeout(() => {
+          Promise.resolve()
+            .then(() => this.executeDailyReports())
+            .catch((err) => {
+              this.logger.error('Unhandled error in scheduled report execution', err);
+              this.metrics.increment('report_generation.execution_error', 1);
+            })
+            .finally(() => {
+              // Always schedule the next day, even on failure, so one
+              // bad run does not permanently stop the scheduler.
+              if (this.isRunning) scheduleNext();
+            });
+        }, delay);
+      };
+
+      scheduleNext();
+
       this.logger.info('✅ Scheduler started');
       span.finish();
     } catch (error) {
@@ -315,25 +356,28 @@ class AutomatedDailyReportGenerator {
         // Count completed tasks
         if (task.completed) {
           completed++;
+          continue;
         }
-        
-        // Calculate overdue status
-        if (task.due_on && new Date(task.due_on) < now && !task.completed) {
-          overdue++;
-          const daysOverdue = Math.floor((now - new Date(task.due_on)) / (1000 * 60 * 60 * 24));
-          totalDaysOverdue += daysOverdue;
-          
-          // Categorize by risk level
-          if (daysOverdue >= 30) {
-            critical++;
-          } else if (daysOverdue >= 14) {
-            high++;
-          } else if (daysOverdue >= 7) {
-            medium++;
-          } else {
-            low++;
-          }
-        } else if (!task.completed) {
+
+        // Only open tasks with a past due date count towards the risk
+        // tiers — open-but-not-yet-due tasks should not silently land
+        // in "low risk" or the bucket totals stop matching the
+        // overdue count reported above them.
+        if (!task.due_on) continue;
+        const due = new Date(task.due_on);
+        if (!Number.isFinite(due.getTime()) || due >= now) continue;
+
+        overdue++;
+        const daysOverdue = Math.floor((now - due) / (1000 * 60 * 60 * 24));
+        totalDaysOverdue += daysOverdue;
+
+        if (daysOverdue >= 30) {
+          critical++;
+        } else if (daysOverdue >= 14) {
+          high++;
+        } else if (daysOverdue >= 7) {
+          medium++;
+        } else {
           low++;
         }
       }
@@ -384,53 +428,63 @@ class AutomatedDailyReportGenerator {
         template = this.templates.dataProtection;
       }
       
-      // Replace placeholders with actual data
+      // Percentages are of the total task count when that is > 0, or
+      // 0 otherwise — never NaN. Text values are HTML-escaped before
+      // interpolation to prevent template injection from Asana names.
+      const total = metrics.totalTasks || 0;
+      const projectName = escapeHtml(projectData && projectData.name || 'Compliance Project');
+      const organization = escapeHtml(config && config.organization || 'Organization');
+      const weeklyVelocity = Math.round(total / 4); // Weekly velocity
+
       let html = template
-        .replace(/\[PROJECT_NAME\]/g, projectData.name || 'Compliance Project')
-        .replace(/\[REPORT_DATE\]/g, reportDate)
-        .replace(/\[ORGANIZATION_NAME\]/g, config.organization || 'Organization')
-        .replace(/\[COMPLIANCE_RATE\]/g, metrics.complianceRate)
-        .replace(/\[HEALTH_SCORE\]/g, metrics.healthScore)
-        .replace(/\[RISK_SCORE\]/g, metrics.riskScore)
-        .replace(/\[VELOCITY\]/g, Math.round(metrics.totalTasks / 4)) // Weekly velocity
-        .replace(/\[COMPLETED_TASKS\]/g, metrics.completedTasks)
-        .replace(/\[TOTAL_TASKS\]/g, metrics.totalTasks)
-        .replace(/\[COMPLETION_RATE\]/g, metrics.complianceRate)
-        .replace(/\[CRITICAL_COUNT\]/g, metrics.criticalTasks)
-        .replace(/\[HIGH_COUNT\]/g, metrics.highTasks)
-        .replace(/\[MEDIUM_COUNT\]/g, metrics.mediumTasks)
-        .replace(/\[LOW_COUNT\]/g, metrics.lowTasks)
-        .replace(/\[CRITICAL_PERCENT\]/g, ((metrics.criticalTasks / metrics.totalTasks) * 100).toFixed(1))
-        .replace(/\[HIGH_PERCENT\]/g, ((metrics.highTasks / metrics.totalTasks) * 100).toFixed(1))
-        .replace(/\[MEDIUM_PERCENT\]/g, ((metrics.mediumTasks / metrics.totalTasks) * 100).toFixed(1))
-        .replace(/\[LOW_PERCENT\]/g, ((metrics.lowTasks / metrics.totalTasks) * 100).toFixed(1))
-        .replace(/\[PRINT_DATE\]/g, now.toLocaleString());
-      
+        .replace(/\[PROJECT_NAME\]/g, projectName)
+        .replace(/\[REPORT_DATE\]/g, escapeHtml(reportDate))
+        .replace(/\[ORGANIZATION_NAME\]/g, organization)
+        .replace(/\[COMPLIANCE_RATE\]/g, String(metrics.complianceRate))
+        .replace(/\[HEALTH_SCORE\]/g, String(metrics.healthScore))
+        .replace(/\[RISK_SCORE\]/g, String(metrics.riskScore))
+        .replace(/\[VELOCITY\]/g, String(weeklyVelocity))
+        .replace(/\[COMPLETED_TASKS\]/g, String(metrics.completedTasks))
+        .replace(/\[TOTAL_TASKS\]/g, String(total))
+        .replace(/\[COMPLETION_RATE\]/g, String(metrics.complianceRate))
+        .replace(/\[CRITICAL_COUNT\]/g, String(metrics.criticalTasks))
+        .replace(/\[HIGH_COUNT\]/g, String(metrics.highTasks))
+        .replace(/\[MEDIUM_COUNT\]/g, String(metrics.mediumTasks))
+        .replace(/\[LOW_COUNT\]/g, String(metrics.lowTasks))
+        .replace(/\[CRITICAL_PERCENT\]/g, pct(metrics.criticalTasks, total))
+        .replace(/\[HIGH_PERCENT\]/g, pct(metrics.highTasks, total))
+        .replace(/\[MEDIUM_PERCENT\]/g, pct(metrics.mediumTasks, total))
+        .replace(/\[LOW_PERCENT\]/g, pct(metrics.lowTasks, total))
+        .replace(/\[PRINT_DATE\]/g, escapeHtml(now.toLocaleString()));
+
       // Add critical tasks to report
       const criticalTasks = tasks
         .filter(t => {
           if (t.completed) return false;
           if (!t.due_on) return false;
-          const daysOverdue = Math.floor((now - new Date(t.due_on)) / (1000 * 60 * 60 * 24));
+          const due = new Date(t.due_on);
+          if (!Number.isFinite(due.getTime())) return false;
+          const daysOverdue = Math.floor((now - due) / (1000 * 60 * 60 * 24));
           return daysOverdue >= 30;
         })
         .slice(0, 5);
-      
+
       if (criticalTasks.length > 0) {
         const criticalTasksHtml = criticalTasks
           .map(t => {
             const daysOverdue = Math.floor((now - new Date(t.due_on)) / (1000 * 60 * 60 * 24));
+            const assigneeName = t.assignee && t.assignee.name ? t.assignee.name : 'Unassigned';
             return `
               <tr>
-                <td>${t.name}</td>
+                <td>${escapeHtml(t.name)}</td>
                 <td>${daysOverdue}</td>
-                <td>${t.assignee?.name || 'Unassigned'}</td>
+                <td>${escapeHtml(assigneeName)}</td>
                 <td><span class="badge badge-critical">CRITICAL</span></td>
               </tr>
             `;
           })
           .join('');
-        
+
         html = html.replace(
           /<tr>\s*<td>\[TASK_1_NAME\]<\/td>/,
           criticalTasksHtml
@@ -455,12 +509,17 @@ class AutomatedDailyReportGenerator {
     try {
       this.logger.info(`[${executionId}] Converting HTML to PDF...`);
       
-      // For now, save as HTML (PDF conversion would require puppeteer/wkhtmltopdf)
-      const reportDir = path.join(__dirname, 'reports', projectId);
-      if (!fs.existsSync(reportDir)) {
-        fs.mkdirSync(reportDir, { recursive: true });
+      // For now, save as HTML (PDF conversion would require puppeteer/wkhtmltopdf).
+      // Sanitize the projectId so a caller cannot traverse out of the
+      // reports directory via "../" segments.
+      const safeProjectId = safePathSegment(projectId);
+      const reportsRoot = path.resolve(__dirname, 'reports');
+      const reportDir = path.resolve(reportsRoot, safeProjectId);
+      if (!reportDir.startsWith(reportsRoot + path.sep) && reportDir !== reportsRoot) {
+        throw new Error(`Refusing to write report outside reports directory: ${reportDir}`);
       }
-      
+      fs.mkdirSync(reportDir, { recursive: true });
+
       const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
       const reportPath = path.join(reportDir, `compliance-report-${timestamp}.html`);
       

--- a/daily-compliance-report-system.js
+++ b/daily-compliance-report-system.js
@@ -23,6 +23,35 @@ const axios = require('axios');
 const fs = require('fs');
 const path = require('path');
 
+// HTML-escape every operator-controlled value before it hits the
+// report template. Without this, a task title or project name
+// containing HTML would corrupt the generated report and enable
+// injection into the emailed body.
+function escapeHtml(value) {
+  if (value === null || value === undefined) return '';
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// Safe percentage helper to avoid NaN when the denominator is zero
+// (which happens for empty projects).
+function pct(numerator, denominator, digits = 1) {
+  if (!denominator || denominator <= 0) return (0).toFixed(digits);
+  return ((numerator / denominator) * 100).toFixed(digits);
+}
+
+// Clamp a filesystem path segment so a caller-supplied projectId
+// cannot traverse out of the reports directory.
+function safePathSegment(value, fallback = 'unknown') {
+  const raw = String(value == null ? '' : value);
+  const cleaned = raw.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 128);
+  return cleaned || fallback;
+}
+
 class DailyComplianceReportSystem {
   constructor(config) {
     this.config = config;
@@ -145,17 +174,30 @@ class DailyComplianceReportSystem {
     const reportDate = new Date();
     const reportId = `compliance-report-${project.id}-${reportDate.toISOString().split('T')[0]}`;
 
-    // Calculate additional metrics
-    const criticalTasks = tasks.filter(t => this.calculateDaysOverdue(t) > 30);
-    const highRiskTasks = tasks.filter(t => this.calculateDaysOverdue(t) > 14 && this.calculateDaysOverdue(t) <= 30);
-    const mediumRiskTasks = tasks.filter(t => this.calculateDaysOverdue(t) > 7 && this.calculateDaysOverdue(t) <= 14);
+    // Precompute daysOverdue once per task to avoid re-parsing the
+    // due date in every filter, sort and percentage call.
+    const annotatedTasks = tasks.map(t => ({
+      task: t,
+      daysOverdue: this.calculateDaysOverdue(t),
+    }));
 
-    // Generate risk matrix
+    const criticalTasks = annotatedTasks.filter(x => x.daysOverdue > 30).map(x => x.task);
+    const highRiskTasks = annotatedTasks.filter(x => x.daysOverdue > 14 && x.daysOverdue <= 30).map(x => x.task);
+    const mediumRiskTasks = annotatedTasks.filter(x => x.daysOverdue > 7 && x.daysOverdue <= 14).map(x => x.task);
+    // "Low" means "overdue 1-7 days", not "every remaining task".
+    // The old `tasks.length - critical - high - medium` formula
+    // silently included completed and not-yet-due tasks, so the four
+    // buckets did not add up to the overdue total elsewhere in the
+    // report.
+    const lowRiskTasks = annotatedTasks
+      .filter(x => x.daysOverdue > 0 && x.daysOverdue <= 7)
+      .map(x => x.task);
+
     const riskMatrix = {
       critical: criticalTasks.length,
       high: highRiskTasks.length,
       medium: mediumRiskTasks.length,
-      low: tasks.length - criticalTasks.length - highRiskTasks.length - mediumRiskTasks.length,
+      low: lowRiskTasks.length,
     };
 
     // Get historical data for trend analysis
@@ -206,7 +248,7 @@ class DailyComplianceReportSystem {
       riskMatrix: {
         critical: {
           count: riskMatrix.critical,
-          percentage: ((riskMatrix.critical / tasks.length) * 100).toFixed(1),
+          percentage: pct(riskMatrix.critical, tasks.length),
           tasks: criticalTasks.slice(0, 5).map(t => ({
             id: t.id,
             title: t.title,
@@ -216,7 +258,7 @@ class DailyComplianceReportSystem {
         },
         high: {
           count: riskMatrix.high,
-          percentage: ((riskMatrix.high / tasks.length) * 100).toFixed(1),
+          percentage: pct(riskMatrix.high, tasks.length),
           tasks: highRiskTasks.slice(0, 5).map(t => ({
             id: t.id,
             title: t.title,
@@ -226,7 +268,7 @@ class DailyComplianceReportSystem {
         },
         medium: {
           count: riskMatrix.medium,
-          percentage: ((riskMatrix.medium / tasks.length) * 100).toFixed(1),
+          percentage: pct(riskMatrix.medium, tasks.length),
           tasks: mediumRiskTasks.slice(0, 3).map(t => ({
             id: t.id,
             title: t.title,
@@ -236,7 +278,7 @@ class DailyComplianceReportSystem {
         },
         low: {
           count: riskMatrix.low,
-          percentage: ((riskMatrix.low / tasks.length) * 100).toFixed(1),
+          percentage: pct(riskMatrix.low, tasks.length),
         },
       },
 
@@ -408,17 +450,19 @@ class DailyComplianceReportSystem {
   identifyTopIssues(tasks, metrics) {
     const issues = [];
 
-    // Identify most overdue tasks
+    // Precompute daysOverdue so the sort comparator and loop below
+    // don't each re-parse the due date per task.
     const mostOverdue = tasks
       .filter(t => t.status !== 'completed')
-      .sort((a, b) => this.calculateDaysOverdue(b) - this.calculateDaysOverdue(a))
+      .map(t => ({ task: t, daysOverdue: this.calculateDaysOverdue(t) }))
+      .sort((a, b) => b.daysOverdue - a.daysOverdue)
       .slice(0, 5);
 
-    for (const task of mostOverdue) {
+    for (const { task, daysOverdue } of mostOverdue) {
       issues.push({
         issue: `Task overdue: ${task.title}`,
-        daysOverdue: this.calculateDaysOverdue(task),
-        priority: this.calculateDaysOverdue(task) > 30 ? 'CRITICAL' : 'HIGH',
+        daysOverdue,
+        priority: daysOverdue > 30 ? 'CRITICAL' : 'HIGH',
         assignee: task.assignee_id,
       });
     }
@@ -557,22 +601,28 @@ class DailyComplianceReportSystem {
       }
     }
 
-    // Calculate percentages and sort by performance
+    // Calculate percentages and sort by performance. Keep a numeric
+    // copy of the rate for the sort so two members with e.g. 9.9%
+    // vs 10.1% don't get compared lexicographically via their
+    // toFixed-derived strings.
     const performance = [];
     for (const member in teamMembers) {
       const tm = teamMembers[member];
-      const completionRate = ((tm.completed / tm.total) * 100).toFixed(1);
+      const rateNum = tm.total > 0 ? (tm.completed / tm.total) * 100 : 0;
       performance.push({
         member,
         total: tm.total,
         completed: tm.completed,
         inProgress: tm.inProgress,
         overdue: tm.overdue,
-        completionRate,
+        completionRate: rateNum.toFixed(1),
+        _rate: rateNum,
       });
     }
 
-    return performance.sort((a, b) => b.completionRate - a.completionRate);
+    return performance
+      .sort((a, b) => b._rate - a._rate)
+      .map(({ _rate, ...row }) => row);
   }
 
   /**
@@ -688,12 +738,15 @@ class DailyComplianceReportSystem {
     const span = this.tracer.startSpan('save_report');
 
     try {
-      const reportsDir = path.join(process.cwd(), 'reports', projectId);
-      
-      // Create directory if it doesn't exist
-      if (!fs.existsSync(reportsDir)) {
-        fs.mkdirSync(reportsDir, { recursive: true });
+      // Sanitize projectId so an external caller cannot escape the
+      // reports root via "../" segments.
+      const safeProjectId = safePathSegment(projectId);
+      const reportsRoot = path.resolve(process.cwd(), 'reports');
+      const reportsDir = path.resolve(reportsRoot, safeProjectId);
+      if (!reportsDir.startsWith(reportsRoot + path.sep) && reportsDir !== reportsRoot) {
+        throw new Error(`Refusing to write report outside reports directory: ${reportsDir}`);
       }
+      fs.mkdirSync(reportsDir, { recursive: true });
 
       const fileName = `compliance-report-${report.reportDate.toISOString().split('T')[0]}.json`;
       const filePath = path.join(reportsDir, fileName);
@@ -722,12 +775,28 @@ class DailyComplianceReportSystem {
    * Generate HTML report
    */
   generateHTMLReport(report) {
+    // Every operator-controlled string is escaped before it lands in
+    // the template. Asana project names, task titles, recommendation
+    // text and next-step actions are all externally editable, so any
+    // one of them could inject markup or a <script> that survives
+    // the email client if left raw.
+    const summary = report.executiveSummary || {};
+    const metrics = report.metrics || {};
+    const risk = report.riskMatrix || {
+      critical: { count: 0, percentage: '0.0' },
+      high: { count: 0, percentage: '0.0' },
+      medium: { count: 0, percentage: '0.0' },
+      low: { count: 0, percentage: '0.0' },
+    };
+    const trend = report.trend || {};
+    const status = String(summary.overallStatus || 'UNKNOWN').toLowerCase();
+    const safeStatusClass = status.replace(/[^a-z-]/g, '');
     return `
 <!DOCTYPE html>
 <html>
 <head>
   <meta charset="UTF-8">
-  <title>${report.executiveSummary.title}</title>
+  <title>${escapeHtml(summary.title)}</title>
   <style>
     body {
       font-family: Arial, sans-serif;
@@ -803,29 +872,29 @@ class DailyComplianceReportSystem {
 </head>
 <body>
   <div class="header">
-    <h1>${report.executiveSummary.title}</h1>
-    <p>Generated: ${report.executiveSummary.date}</p>
-    <p>Project: ${report.projectName}</p>
+    <h1>${escapeHtml(summary.title)}</h1>
+    <p>Generated: ${escapeHtml(summary.date)}</p>
+    <p>Project: ${escapeHtml(report.projectName)}</p>
   </div>
 
   <div class="section">
     <h2>Executive Summary</h2>
-    <p>Overall Status: <strong class="status-${report.executiveSummary.overallStatus.toLowerCase()}">${report.executiveSummary.overallStatus}</strong></p>
-    
+    <p>Overall Status: <strong class="status-${safeStatusClass}">${escapeHtml(summary.overallStatus)}</strong></p>
+
     <div class="metric">
-      <div class="metric-value">${report.metrics.complianceRate}%</div>
+      <div class="metric-value">${escapeHtml(metrics.complianceRate)}%</div>
       <div class="metric-label">Compliance Rate</div>
     </div>
     <div class="metric">
-      <div class="metric-value">${report.metrics.healthScore}</div>
+      <div class="metric-value">${escapeHtml(metrics.healthScore)}</div>
       <div class="metric-label">Health Score</div>
     </div>
     <div class="metric">
-      <div class="metric-value">${report.metrics.riskScore}%</div>
+      <div class="metric-value">${escapeHtml(metrics.riskScore)}%</div>
       <div class="metric-label">Risk Score</div>
     </div>
     <div class="metric">
-      <div class="metric-value">${report.metrics.completedTasks}/${report.metrics.totalTasks}</div>
+      <div class="metric-value">${escapeHtml(metrics.completedTasks)}/${escapeHtml(metrics.totalTasks)}</div>
       <div class="metric-label">Tasks Completed</div>
     </div>
   </div>
@@ -840,44 +909,47 @@ class DailyComplianceReportSystem {
       </tr>
       <tr class="risk-critical">
         <td>Critical (30+ days)</td>
-        <td>${report.riskMatrix.critical.count}</td>
-        <td>${report.riskMatrix.critical.percentage}%</td>
+        <td>${escapeHtml(risk.critical.count)}</td>
+        <td>${escapeHtml(risk.critical.percentage)}%</td>
       </tr>
       <tr class="risk-high">
         <td>High (14-29 days)</td>
-        <td>${report.riskMatrix.high.count}</td>
-        <td>${report.riskMatrix.high.percentage}%</td>
+        <td>${escapeHtml(risk.high.count)}</td>
+        <td>${escapeHtml(risk.high.percentage)}%</td>
       </tr>
       <tr class="risk-medium">
         <td>Medium (7-13 days)</td>
-        <td>${report.riskMatrix.medium.count}</td>
-        <td>${report.riskMatrix.medium.percentage}%</td>
+        <td>${escapeHtml(risk.medium.count)}</td>
+        <td>${escapeHtml(risk.medium.percentage)}%</td>
       </tr>
       <tr class="risk-low">
         <td>Low (0-6 days)</td>
-        <td>${report.riskMatrix.low.count}</td>
-        <td>${report.riskMatrix.low.percentage}%</td>
+        <td>${escapeHtml(risk.low.count)}</td>
+        <td>${escapeHtml(risk.low.percentage)}%</td>
       </tr>
     </table>
   </div>
 
   <div class="section">
     <h2>Trend Analysis</h2>
-    <p>Direction: <strong>${report.trend.direction}</strong></p>
-    <p>Change: ${report.trend.changePercentage}% (Previous: ${report.trend.previousRate}%, Current: ${report.trend.currentRate}%)</p>
-    <p>30-Day Forecast: ${report.trend.forecast30Days}%</p>
-    <p>Analysis: ${report.trend.analysis}</p>
+    <p>Direction: <strong>${escapeHtml(trend.direction)}</strong></p>
+    <p>Change: ${escapeHtml(trend.changePercentage)}% (Previous: ${escapeHtml(trend.previousRate)}%, Current: ${escapeHtml(trend.currentRate)}%)</p>
+    <p>30-Day Forecast: ${escapeHtml(trend.forecast30Days)}%</p>
+    <p>Analysis: ${escapeHtml(trend.analysis)}</p>
   </div>
 
   <div class="section">
     <h2>Recommendations</h2>
-    ${report.recommendations.map(rec => `
-      <div class="recommendation ${rec.priority.toLowerCase()}">
-        <strong>[${rec.priority}] ${rec.category}</strong><br>
-        ${rec.recommendation}<br>
-        <em>Action: ${rec.action}</em>
+    ${(report.recommendations || []).map(rec => {
+      const priority = String(rec.priority || '').toLowerCase().replace(/[^a-z]/g, '');
+      return `
+      <div class="recommendation ${priority}">
+        <strong>[${escapeHtml(rec.priority)}] ${escapeHtml(rec.category)}</strong><br>
+        ${escapeHtml(rec.recommendation)}<br>
+        <em>Action: ${escapeHtml(rec.action)}</em>
       </div>
-    `).join('')}
+    `;
+    }).join('')}
   </div>
 
   <div class="section">
@@ -888,11 +960,11 @@ class DailyComplianceReportSystem {
         <th>Priority</th>
         <th>Details</th>
       </tr>
-      ${report.topIssues.map(issue => `
+      ${(report.topIssues || []).map(issue => `
         <tr>
-          <td>${issue.issue}</td>
-          <td>${issue.priority}</td>
-          <td>${issue.daysOverdue ? issue.daysOverdue + ' days overdue' : issue.count ? issue.count + ' items' : ''}</td>
+          <td>${escapeHtml(issue.issue)}</td>
+          <td>${escapeHtml(issue.priority)}</td>
+          <td>${escapeHtml(issue.daysOverdue ? issue.daysOverdue + ' days overdue' : issue.count ? issue.count + ' items' : '')}</td>
         </tr>
       `).join('')}
     </table>
@@ -900,17 +972,17 @@ class DailyComplianceReportSystem {
 
   <div class="section">
     <h2>Next Steps</h2>
-    ${report.nextSteps.map(step => `
-      <h3>${step.timeframe}</h3>
+    ${(report.nextSteps || []).map(step => `
+      <h3>${escapeHtml(step.timeframe)}</h3>
       <ul>
-        ${step.actions.map(action => `<li>${action}</li>`).join('')}
+        ${(step.actions || []).map(action => `<li>${escapeHtml(action)}</li>`).join('')}
       </ul>
     `).join('')}
   </div>
 
   <div class="section" style="text-align: center; color: #666; font-size: 12px;">
     <p>This report was automatically generated by ASANA Brain Compliance Intelligence System</p>
-    <p>Generated: ${new Date().toISOString()}</p>
+    <p>Generated: ${escapeHtml(new Date().toISOString())}</p>
   </div>
 </body>
 </html>
@@ -1068,11 +1140,26 @@ class DailyComplianceReportSystem {
    */
   async sendAsanaReport(report) {
     try {
-      // Create a task in Asana with the report
+      // Asana's createTask accepts `notes` / `html_notes`, not
+      // `description` — passing `description` silently drops the
+      // body. Keep the notes compact so the payload always fits
+      // inside Asana's field limit; the full JSON is attached
+      // separately via email.
+      const summary = report.executiveSummary || {};
+      const metrics = report.metrics || {};
+      const notes = [
+        `Daily Compliance Report — ${report.projectName}`,
+        `Generated: ${report.generatedAt && report.generatedAt.toISOString ? report.generatedAt.toISOString() : ''}`,
+        `Overall status: ${summary.overallStatus}`,
+        `Compliance rate: ${metrics.complianceRate}%`,
+        `Health score: ${metrics.healthScore}`,
+        `Risk score: ${metrics.riskScore}%`,
+      ].join('\n');
+
       const task = await this.asanaClient.createTask({
         projects: [report.projectId],
         name: `Daily Compliance Report - ${report.reportDate.toLocaleDateString()}`,
-        description: JSON.stringify(report, null, 2),
+        notes,
         custom_fields: {
           'Report Type': 'Daily Compliance',
           'Compliance Rate': report.metrics.complianceRate,

--- a/tests/dailyReportFixes.test.ts
+++ b/tests/dailyReportFixes.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Targeted regression tests for bug fixes in the new daily compliance
+ * report modules (automated-daily-report-generator.js,
+ * asana-brain-daily-report-executor.js, daily-compliance-report-system.js).
+ *
+ * The original production code shipped with three systemic bugs:
+ *   1. NaN percentages when a project had zero tasks
+ *      (division-by-zero in risk-matrix percentage calculations).
+ *   2. Risk-matrix "low" bucket silently included completed and
+ *      not-yet-due tasks, so the four buckets did not sum to the
+ *      overdue total reported elsewhere.
+ *   3. HTML reports concatenated Asana-controlled strings (project
+ *      name, task title, assignee) directly into the template with
+ *      no escaping — an HTML-injection vector when the report was
+ *      emailed or served.
+ *
+ * These tests lock in the fixed behaviour without asserting on
+ * internal implementation details beyond the public surface used by
+ * callers.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+import Module from 'module';
+
+const require = createRequire(import.meta.url);
+
+// The report modules pull in node-cron / nodemailer / axios at
+// `require` time. Those packages are production deps that are not
+// installed in the test environment, so we short-circuit the Node
+// module resolver with safe stubs before requiring the modules under
+// test. This keeps the suite hermetic and lets the tests focus on
+// the pure computation surface (metrics, risk matrix, HTML escaping).
+const nodemailerStub = {
+  createTransport: () => ({
+    verify: async () => true,
+    sendMail: async () => ({ accepted: [] }),
+  }),
+};
+const cronStub = { schedule: () => ({ stop: () => {} }) };
+const axiosStub = { post: async () => ({ data: {} }) };
+
+const stubs: Record<string, unknown> = {
+  'node-cron': cronStub,
+  nodemailer: nodemailerStub,
+  axios: axiosStub,
+};
+
+const originalResolve = (Module as unknown as { _resolveFilename: (...args: unknown[]) => string })._resolveFilename;
+(Module as unknown as { _resolveFilename: (...args: unknown[]) => string })._resolveFilename = function patched(request: string, ...rest: unknown[]): string {
+  if (Object.prototype.hasOwnProperty.call(stubs, request)) return request;
+  return originalResolve.call(this, request, ...rest);
+};
+const originalLoad = (Module as unknown as { _load: (...args: unknown[]) => unknown })._load;
+(Module as unknown as { _load: (...args: unknown[]) => unknown })._load = function patched(request: string, ...rest: unknown[]): unknown {
+  if (Object.prototype.hasOwnProperty.call(stubs, request)) return stubs[request];
+  return originalLoad.call(this, request, ...rest);
+};
+
+const AutomatedDailyReportGenerator = require('../automated-daily-report-generator.js');
+const AsanaBrainDailyReportExecutor = require('../asana-brain-daily-report-executor.js');
+const DailyComplianceReportSystem = require('../daily-compliance-report-system.js');
+
+function silentDeps() {
+  const span = { finish: () => {}, setTag: () => {} };
+  return {
+    logger: {
+      info: () => {}, warn: () => {}, error: () => {}, debug: () => {},
+    },
+    tracer: { startSpan: () => span },
+    metrics: { increment: () => {}, histogram: () => {} },
+    asanaClient: {
+      getProject: async () => ({ id: 'p1', name: 'Proj' }),
+      getProjectTasks: async () => [],
+      getTasks: async () => [],
+      createTask: async () => ({ id: 't1' }),
+    },
+    dashboardService: {
+      generateComplianceMetrics: async () => ({
+        totalTasks: 0, completedTasks: 0, inProgressTasks: 0,
+        overdueTasks: 0, atRiskTasks: 0, criticalTasks: 0,
+        complianceRate: 0, riskScore: 0, healthScore: 100,
+        velocity: 0, forecast: 0,
+      }),
+      updateWidget: async () => ({}),
+    },
+  };
+}
+
+describe('AutomatedDailyReportGenerator.calculateMetrics', () => {
+  const gen = new AutomatedDailyReportGenerator(silentDeps());
+
+  it('returns zero metrics and no NaN when there are no tasks', () => {
+    const m = gen.calculateMetrics([]);
+    expect(m.totalTasks).toBe(0);
+    expect(m.complianceRate).toBe(0);
+    expect(m.riskScore).toBe(0);
+    expect(Number.isNaN(m.healthScore)).toBe(false);
+  });
+
+  it('does not push non-overdue open tasks into the low bucket', () => {
+    const future = new Date(Date.now() + 30 * 24 * 3600 * 1000).toISOString();
+    const tasks = [
+      { completed: false, due_on: future }, // future due date
+      { completed: false }, // no due date
+      { completed: true }, // completed
+    ];
+    const m = gen.calculateMetrics(tasks);
+    expect(m.overdueTasks).toBe(0);
+    expect(m.lowTasks).toBe(0);
+    expect(m.criticalTasks).toBe(0);
+    expect(m.highTasks).toBe(0);
+    expect(m.mediumTasks).toBe(0);
+    // Four buckets must sum to overdueTasks exactly.
+    expect(m.criticalTasks + m.highTasks + m.mediumTasks + m.lowTasks)
+      .toBe(m.overdueTasks);
+  });
+
+  it('buckets overdue tasks correctly by days-overdue', () => {
+    const now = Date.now();
+    const daysAgo = (n: number) => new Date(now - n * 24 * 3600 * 1000).toISOString();
+    const tasks = [
+      { completed: false, due_on: daysAgo(40) }, // critical
+      { completed: false, due_on: daysAgo(20) }, // high
+      { completed: false, due_on: daysAgo(10) }, // medium
+      { completed: false, due_on: daysAgo(3) },  // low
+      { completed: true, due_on: daysAgo(50) },  // ignored
+    ];
+    const m = gen.calculateMetrics(tasks);
+    expect(m.overdueTasks).toBe(4);
+    expect(m.criticalTasks).toBe(1);
+    expect(m.highTasks).toBe(1);
+    expect(m.mediumTasks).toBe(1);
+    expect(m.lowTasks).toBe(1);
+  });
+});
+
+describe('AutomatedDailyReportGenerator.generateHTMLReport', () => {
+  const gen = new AutomatedDailyReportGenerator(silentDeps());
+  // Minimal template to exercise the placeholder replacement path.
+  gen.templates = {
+    base: [
+      'Project: [PROJECT_NAME]',
+      'Critical%: [CRITICAL_PERCENT]',
+      'High%: [HIGH_PERCENT]',
+      'Medium%: [MEDIUM_PERCENT]',
+      'Low%: [LOW_PERCENT]',
+    ].join('\n'),
+    financial: '',
+    dataProtection: '',
+  };
+
+  it('never emits NaN percentages when totalTasks is zero', () => {
+    const html = gen.generateHTMLReport(
+      { name: 'Empty Project' },
+      [],
+      gen.calculateMetrics([]),
+      {},
+    );
+    expect(html).not.toContain('NaN');
+    expect(html).toContain('Critical%: 0.0');
+    expect(html).toContain('Low%: 0.0');
+  });
+
+  it('escapes HTML in project name to prevent injection', () => {
+    const html = gen.generateHTMLReport(
+      { name: '<script>alert(1)</script>' },
+      [],
+      gen.calculateMetrics([]),
+      {},
+    );
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+});
+
+describe('AsanaBrainDailyReportExecutor risk matrix', () => {
+  it('computes percentages without NaN on an empty project', async () => {
+    const exec = new AsanaBrainDailyReportExecutor(silentDeps());
+    const report = await exec.generateComplianceReport(
+      { id: 'p', name: 'P' },
+      [],
+      {
+        totalTasks: 0, completedTasks: 0, inProgressTasks: 0,
+        overdueTasks: 0, atRiskTasks: 0, criticalTasks: 0,
+        complianceRate: 0, riskScore: 0, healthScore: 100, velocity: 0,
+      },
+    );
+    for (const k of ['critical', 'high', 'medium', 'low'] as const) {
+      expect(report.riskMatrix[k].percentage).toBe('0.0');
+    }
+  });
+
+  it('low bucket excludes completed and not-yet-due tasks', async () => {
+    const exec = new AsanaBrainDailyReportExecutor(silentDeps());
+    const now = Date.now();
+    const daysAgo = (n: number) =>
+      new Date(now - n * 24 * 3600 * 1000).toISOString();
+    const future = new Date(now + 10 * 24 * 3600 * 1000).toISOString();
+    const tasks = [
+      { id: 1, due_date: daysAgo(3), status: 'open', title: 't1' },    // low
+      { id: 2, due_date: daysAgo(40), status: 'open', title: 't2' },   // critical
+      { id: 3, due_date: future, status: 'open', title: 't3' },         // not due
+      { id: 4, due_date: daysAgo(100), status: 'completed', title: 't4' }, // completed
+    ];
+    const report = await exec.generateComplianceReport(
+      { id: 'p', name: 'P' },
+      tasks,
+      {
+        totalTasks: tasks.length, completedTasks: 1, inProgressTasks: 0,
+        overdueTasks: 2, atRiskTasks: 0, criticalTasks: 1,
+        complianceRate: 25, riskScore: 50, healthScore: 50, velocity: 0,
+      },
+    );
+    expect(report.riskMatrix.critical.count).toBe(1);
+    expect(report.riskMatrix.low.count).toBe(1);
+    // Must not count the completed or the not-yet-due task
+    expect(report.riskMatrix.low.count + report.riskMatrix.medium.count
+      + report.riskMatrix.high.count + report.riskMatrix.critical.count)
+      .toBe(2);
+  });
+});
+
+describe('AsanaBrainDailyReportExecutor.generateHTMLReport', () => {
+  const exec = new AsanaBrainDailyReportExecutor(silentDeps());
+
+  it('HTML-escapes externally-sourced values', () => {
+    const html = exec.generateHTMLReport({
+      projectName: 'Proj',
+      executiveSummary: {
+        title: '<img src=x onerror=alert(1)>',
+        date: '2026-01-01',
+        overallStatus: 'GOOD',
+      },
+      metrics: { complianceRate: '90.0', healthScore: '95.0', riskScore: '5.0', completedTasks: 9, totalTasks: 10 },
+      riskMatrix: {
+        critical: { count: 0, percentage: '0.0' },
+        high: { count: 0, percentage: '0.0' },
+        medium: { count: 0, percentage: '0.0' },
+        low: { count: 0, percentage: '0.0' },
+      },
+    });
+    expect(html).not.toContain('<img src=x onerror=alert(1)>');
+    expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
+  });
+});
+
+describe('DailyComplianceReportSystem risk matrix', () => {
+  const sys = new DailyComplianceReportSystem(silentDeps());
+
+  it('low bucket excludes completed and not-yet-due tasks', async () => {
+    const now = Date.now();
+    const daysAgo = (n: number) =>
+      new Date(now - n * 24 * 3600 * 1000).toISOString();
+    const future = new Date(now + 10 * 24 * 3600 * 1000).toISOString();
+    const tasks = [
+      { id: 1, due_date: daysAgo(2), status: 'open', title: 't1' },
+      { id: 2, due_date: future, status: 'open', title: 't2' },
+      { id: 3, due_date: daysAgo(100), status: 'completed', title: 't3' },
+    ];
+    const report = await sys.generateComplianceReport(
+      { id: 'p', name: 'P' },
+      tasks,
+      {
+        totalTasks: tasks.length, completedTasks: 1, inProgressTasks: 0,
+        overdueTasks: 1, atRiskTasks: 0, criticalTasks: 0,
+        complianceRate: 33, riskScore: 33, healthScore: 66, velocity: 0,
+        forecast: 50,
+      },
+    );
+    expect(report.riskMatrix.low.count).toBe(1);
+    expect(report.riskMatrix.critical.count).toBe(0);
+  });
+
+  it('produces non-NaN percentages on empty projects', async () => {
+    const report = await sys.generateComplianceReport(
+      { id: 'p', name: 'P' },
+      [],
+      {
+        totalTasks: 0, completedTasks: 0, inProgressTasks: 0,
+        overdueTasks: 0, atRiskTasks: 0, criticalTasks: 0,
+        complianceRate: 0, riskScore: 0, healthScore: 100, velocity: 0,
+        forecast: 0,
+      },
+    );
+    for (const k of ['critical', 'high', 'medium', 'low'] as const) {
+      expect(report.riskMatrix[k].percentage).toBe('0.0');
+    }
+  });
+});
+
+describe('DailyComplianceReportSystem.generateHTMLReport', () => {
+  const sys = new DailyComplianceReportSystem(silentDeps());
+
+  it('HTML-escapes project name, status and nested values', () => {
+    const html = sys.generateHTMLReport({
+      projectName: '<b>X</b>',
+      executiveSummary: {
+        title: 'T',
+        date: 'd',
+        overallStatus: 'GOOD"onclick=alert(1)',
+      },
+      metrics: { complianceRate: '90.0', healthScore: '95.0', riskScore: '5.0', completedTasks: 9, totalTasks: 10 },
+      riskMatrix: {
+        critical: { count: 0, percentage: '0.0' },
+        high: { count: 0, percentage: '0.0' },
+        medium: { count: 0, percentage: '0.0' },
+        low: { count: 0, percentage: '0.0' },
+      },
+      trend: { direction: 'STABLE', changePercentage: '0.0', previousRate: '0.0', currentRate: '0.0', forecast30Days: '0.0', analysis: 'ok' },
+      recommendations: [{ priority: 'HIGH', category: '<script>x</script>', recommendation: 'r', action: 'a' }],
+      topIssues: [{ issue: '<i>x</i>', priority: 'HIGH', daysOverdue: 1 }],
+      nextSteps: [{ timeframe: 't', actions: ['<u>a</u>'] }],
+    });
+    // raw tags must NOT appear
+    expect(html).not.toContain('<b>X</b>');
+    expect(html).not.toContain('<script>x</script>');
+    expect(html).not.toContain('<i>x</i>');
+    expect(html).not.toContain('<u>a</u>');
+    // escaped forms must appear
+    expect(html).toContain('&lt;b&gt;X&lt;/b&gt;');
+    expect(html).toContain('&lt;script&gt;x&lt;/script&gt;');
+  });
+});


### PR DESCRIPTION
## Summary

Deep review of the three new daily compliance report modules shipped in recent commits (`automated-daily-report-generator.js`, `asana-brain-daily-report-executor.js`, `daily-compliance-report-system.js`). Three systemic bugs and several hardening gaps are fixed together so the MLRO and auditor-facing reports are accurate and safe to distribute.

### Bugs fixed

1. **HTML injection / stored XSS in generated reports.** Every operator-controlled string (Asana project name, task title, assignee, recommendation text, next-step actions) was concatenated raw into the HTML template. A task title containing `<script>` or an `onerror=` attribute would survive into the emailed report. Fixed with a per-file `escapeHtml` helper applied at every interpolation point, plus a character-class whitelist on the `status-<name>` CSS class built from `overallStatus`.

2. **NaN percentages on empty projects.** Risk-matrix percentages and the `[CRITICAL_PERCENT]` / `[HIGH_PERCENT]` / `[MEDIUM_PERCENT]` / `[LOW_PERCENT]` placeholders divided by `tasks.length` with no zero guard, so a new project with no tasks rendered `NaN%` in every bucket. Fixed with a `pct(num, denom, digits)` helper that returns `(0).toFixed(digits)` when the denominator is zero.

3. **Risk-matrix "low" bucket silently included completed + not-due tasks.** Two of three modules used `low = total − critical − high − medium`, so the four buckets no longer summed to the overdue count reported elsewhere and completed/upcoming tasks were labelled "low risk". The third module sent every open, not-yet-due task into the low bucket. Fixed across all three so "low" means "overdue by 1–7 days" only. Precomputed `daysOverdue` once per task instead of recalculating it in every filter / sort comparator / percentage loop (N² → N).

### Additional hardening

- **Scheduler drift + unhandled rejection** in `AutomatedDailyReportGenerator.startScheduler`. The fixed `setInterval(24h)` would drift across DST transitions; the async callback's rejection was not captured. Rewrote the scheduler to recompute 08:00 UTC on each run, wire the promise through `.catch`/`.finally`, and keep rescheduling even after a failed run while `isRunning` is true. Also aligns behavior with the "8:00 AM UTC" docstring (the old `setHours(8,...)` used server-local time).
- **Path traversal guard** on every report writer. `projectId` is now sanitized (whitelist `[A-Za-z0-9._-]`, 128-char cap) and the resolved destination is verified to stay under `${root}/reports/` before `mkdir`/`writeFileSync`.
- **`loadExecutionHistory` shape validation.** Parsed JSON is checked with `Array.isArray` before assignment so a hand-edited history file cannot crash later `.push` / `.filter` calls.
- **Asana `createTask` field name.** The API accepts `notes` / `html_notes`, not `description` — passing `description` silently dropped the report body. Switched to a compact, plain-text `notes` payload that always fits inside Asana's field limit.
- **`analyzeTeamPerformance` sort.** Now sorts on the numeric completion rate rather than on a `.toFixed(1)`-derived string, so e.g. 9.9% vs 10.1% is compared numerically.

### Tests

Added `tests/dailyReportFixes.test.ts` (11 tests) locking in the fixed behaviour for all three modules: empty-project percentage handling, risk-matrix bucket composition, and HTML escaping on project name + nested report values. All **4345** existing tests continue to pass.

## Test plan

- [x] `npx vitest run tests/dailyReportFixes.test.ts` — 11/11 passing
- [x] `npx vitest run` — 4345/4345 passing (no regressions)
- [ ] Manual spot-check of an end-to-end daily report render against a real Asana project
- [ ] Verify the Netlify build still succeeds on this branch

## Remaining risks / needs verification

- **Dependency gap.** `asana-brain-daily-report-executor.js` and `daily-compliance-report-system.js` `require('node-cron' | 'nodemailer' | 'axios')` but none of the three are declared in `package.json`. The modules would fail to load in any environment without those packages installed out-of-band. Out of scope for a pure bug-fix PR; flagged for a separate decision about whether to add them as runtime deps or make the imports lazy.
- **Report retention.** Generated HTML/JSON reports accumulate under `reports/${projectId}/` forever. No regulatory retention conflict (FDL No.10/2025 Art.24 requires ≥10y), but disk fill is a concern; a separate janitor task is recommended.
- **Cache invalidation** for the shared Shipments Asana project GID (app-core.js change from c46ae74). If the project is deleted in Asana, the localStorage-cached GID stays and syncs will fail. Not part of this PR.

## Regulatory basis

- **FDL No.10/2025 Art.24** — daily compliance reports form part of the 10-year audit record; accurate bucket totals and non-corrupted HTML are required for auditor review.
- **LBMA RGG v9** — MLRO distribution channel (email) must not be a vector for HTML injection from operator-controlled fields.

https://claude.ai/code/session_01R9Y37tUnmBhH1uF2i3toB8