### PR TITLE
fix: Round-2 hardening — XSS in dashboard report engine + null uptime guards (FDL No.10/2025 Art.24, LBMA RGG v9)

### DIFF
--- a/asana-brain-master-system.js
+++ b/asana-brain-master-system.js
@@ -300,6 +300,11 @@ class AsanaBrainMasterSystem extends EventEmitter {
   performHealthCheck() {
     const span = this.tracer.startSpan('health_check');
     try {
+      // `startTime` is null until initialize() completes. Guard so a
+      // health check that fires between constructor and the end of
+      // initialize() (or after shutdown clears it) does not crash
+      // the whole monitor loop.
+      const uptime = this.startTime ? Date.now() - this.startTime.getTime() : 0;
       const health = {
         status: 'healthy',
         timestamp: new Date(),
@@ -308,7 +313,7 @@ class AsanaBrainMasterSystem extends EventEmitter {
           features: this.features.size,
           weaponization: this.weaponization.size,
         },
-        uptime: Date.now() - this.startTime.getTime(),
+        uptime,
       };
       
       this.metrics.gauge('system.health', health.status === 'healthy' ? 1 : 0);
@@ -352,7 +357,7 @@ class AsanaBrainMasterSystem extends EventEmitter {
   reportMetrics() {
     const span = this.tracer.startSpan('report_metrics');
     try {
-      const uptime = Date.now() - this.startTime.getTime();
+      const uptime = this.startTime ? Date.now() - this.startTime.getTime() : 0;
       const uptimeHours = (uptime / (1000 * 60 * 60)).toFixed(2);
       
       this.logger.info(`System uptime: ${uptimeHours} hours`);
@@ -378,7 +383,7 @@ class AsanaBrainMasterSystem extends EventEmitter {
     try {
       const status = {
         status: this.isRunning ? 'running' : 'stopped',
-        uptime: Date.now() - this.startTime.getTime(),
+        uptime: this.startTime ? Date.now() - this.startTime.getTime() : 0,
         startTime: this.startTime,
         services: {
           total: this.services.size,

--- a/compliance-dashboard-report-engine.js
+++ b/compliance-dashboard-report-engine.js
@@ -13,6 +13,29 @@
 const EventEmitter = require('events');
 const crypto = require('crypto');
 
+// Escape any operator-controlled string before it lands in the
+// generated HTML. Without this, config.organization, recommendation
+// text, team member names and regulatory framework names can all
+// break the DOM or carry markup into the emailed report body.
+function escapeHtml(value) {
+  if (value === null || value === undefined) return '';
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// Convert a value that might be a Date, ISO string, number or null
+// into a YYYY-MM-DD display string without throwing on bad input.
+function toIsoDay(value) {
+  if (value === null || value === undefined) return '';
+  const d = value instanceof Date ? value : new Date(value);
+  if (!Number.isFinite(d.getTime())) return '';
+  return d.toISOString().split('T')[0];
+}
+
 class ComplianceDashboardReportEngine extends EventEmitter {
   constructor(config) {
     super();
@@ -185,31 +208,39 @@ class ComplianceDashboardReportEngine extends EventEmitter {
     const span = this.tracer.startSpan('start_scheduler');
     try {
       this.logger.info('Starting daily scheduler...');
-      
-      // Schedule daily execution at 8:00 AM UTC
-      const now = new Date();
-      const scheduledTime = new Date();
-      scheduledTime.setUTCHours(8, 0, 0, 0);
-      
-      // If it's already past 8:00 AM, schedule for tomorrow
-      if (now > scheduledTime) {
-        scheduledTime.setDate(scheduledTime.getDate() + 1);
-      }
-      
-      const timeUntilExecution = scheduledTime.getTime() - now.getTime();
-      
-      this.logger.info(`⏰ Next execution: ${scheduledTime.toISOString()}`);
-      
-      // Set initial timeout
-      this.schedulerTimeout = setTimeout(() => {
-        this.executeDailyReports();
-        
-        // Then set recurring interval (24 hours)
-        this.schedulerInterval = setInterval(() => {
-          this.executeDailyReports();
-        }, 24 * 60 * 60 * 1000);
-      }, timeUntilExecution);
-      
+
+      // Each run recomputes "next 08:00 UTC" so there is no drift
+      // across DST transitions. The async executeDailyReports
+      // rejection is caught locally instead of leaking as an
+      // unhandled promise rejection, and the next run is scheduled
+      // even after a failed run.
+      const scheduleNext = () => {
+        const now = new Date();
+        const next = new Date(Date.UTC(
+          now.getUTCFullYear(),
+          now.getUTCMonth(),
+          now.getUTCDate(),
+          8, 0, 0, 0,
+        ));
+        if (next.getTime() <= now.getTime()) {
+          next.setUTCDate(next.getUTCDate() + 1);
+        }
+        const delay = next.getTime() - now.getTime();
+        this.logger.info(`⏰ Next execution: ${next.toISOString()}`);
+        this.schedulerTimeout = setTimeout(() => {
+          Promise.resolve()
+            .then(() => this.executeDailyReports())
+            .catch((err) => {
+              this.logger.error('Unhandled error in scheduled daily reports', err);
+            })
+            .finally(() => {
+              if (this.isRunning) scheduleNext();
+            });
+        }, delay);
+      };
+
+      scheduleNext();
+
       this.logger.info('✅ Daily scheduler started');
       span.finish();
     } catch (error) {
@@ -483,14 +514,24 @@ class ComplianceDashboardReportEngine extends EventEmitter {
   async generateHTMLReport(reportId, data) {
     try {
       const { projectId, config, metrics, riskMatrix, recommendations, teamPerformance, regulatoryStatus } = data;
-      
+
+      // Every operator- or tenant-controlled value is escaped before
+      // interpolation. Numeric metrics are also routed through the
+      // same helper — it safely passes numbers straight through
+      // while shielding against a caller that replaces the mock
+      // `fetchComplianceMetrics` with real data containing unicode
+      // or HTML-sensitive characters.
+      const orgName = escapeHtml(config && config.organization || 'Global Finance Corp');
+      const reportDay = escapeHtml(toIsoDay(new Date()));
+      const safeReportId = escapeHtml(reportId);
+
       const html = `
 <!DOCTYPE html>
 <html>
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Daily Compliance Report - ${new Date().toISOString().split('T')[0]}</title>
+  <title>Daily Compliance Report - ${reportDay}</title>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body { 
@@ -673,69 +714,75 @@ class ComplianceDashboardReportEngine extends EventEmitter {
     <div class="header">
       <div class="confidential">CONFIDENTIAL</div>
       <h1>Daily Compliance Report</h1>
-      <p>Report Date: ${new Date().toISOString().split('T')[0]}</p>
-      <p>Organization: ${config.organization || 'Global Finance Corp'}</p>
+      <p>Report Date: ${reportDay}</p>
+      <p>Organization: ${orgName}</p>
     </div>
-    
+
     <!-- Metrics -->
     <div class="metrics-grid">
       <div class="metric-card">
         <div class="metric-label">Compliance Rate</div>
-        <div class="metric-value">${metrics.complianceRate}%</div>
+        <div class="metric-value">${escapeHtml(metrics.complianceRate)}%</div>
         <div class="metric-unit">↑ +4.2%</div>
       </div>
       <div class="metric-card">
         <div class="metric-label">Health Score</div>
-        <div class="metric-value">${metrics.healthScore}</div>
+        <div class="metric-value">${escapeHtml(metrics.healthScore)}</div>
         <div class="metric-unit">↑ +3.1</div>
       </div>
       <div class="metric-card">
         <div class="metric-label">Risk Score</div>
-        <div class="metric-value">${metrics.riskScore}%</div>
+        <div class="metric-value">${escapeHtml(metrics.riskScore)}%</div>
         <div class="metric-unit">↓ -2.1%</div>
       </div>
       <div class="metric-card">
         <div class="metric-label">Velocity</div>
-        <div class="metric-value">${metrics.velocity}</div>
+        <div class="metric-value">${escapeHtml(metrics.velocity)}</div>
         <div class="metric-unit">tasks/week</div>
       </div>
     </div>
-    
+
     <!-- Risk Matrix -->
     <div class="risk-matrix">
       <h2>Risk Matrix Analysis</h2>
       <div class="risk-items">
         <div class="risk-item risk-critical">
-          <div class="risk-count">${riskMatrix.critical.count}</div>
-          <div class="risk-label">CRITICAL (${riskMatrix.critical.percentage}%)</div>
+          <div class="risk-count">${escapeHtml(riskMatrix.critical.count)}</div>
+          <div class="risk-label">CRITICAL (${escapeHtml(riskMatrix.critical.percentage)}%)</div>
         </div>
         <div class="risk-item risk-high">
-          <div class="risk-count">${riskMatrix.high.count}</div>
-          <div class="risk-label">HIGH (${riskMatrix.high.percentage}%)</div>
+          <div class="risk-count">${escapeHtml(riskMatrix.high.count)}</div>
+          <div class="risk-label">HIGH (${escapeHtml(riskMatrix.high.percentage)}%)</div>
         </div>
         <div class="risk-item risk-medium">
-          <div class="risk-count">${riskMatrix.medium.count}</div>
-          <div class="risk-label">MEDIUM (${riskMatrix.medium.percentage}%)</div>
+          <div class="risk-count">${escapeHtml(riskMatrix.medium.count)}</div>
+          <div class="risk-label">MEDIUM (${escapeHtml(riskMatrix.medium.percentage)}%)</div>
         </div>
         <div class="risk-item risk-low">
-          <div class="risk-count">${riskMatrix.low.count}</div>
-          <div class="risk-label">LOW (${riskMatrix.low.percentage}%)</div>
+          <div class="risk-count">${escapeHtml(riskMatrix.low.count)}</div>
+          <div class="risk-label">LOW (${escapeHtml(riskMatrix.low.percentage)}%)</div>
         </div>
       </div>
     </div>
-    
+
     <!-- Recommendations -->
     <div class="recommendations">
       <h2>Recommendations</h2>
-      ${recommendations.map(rec => `
+      ${(recommendations || []).map(rec => {
+        // Constrain the priority-derived CSS class to a-z only so a
+        // caller-supplied priority cannot break out of the class
+        // attribute.
+        const priorityClass = String(rec.priority || '').toLowerCase().replace(/[^a-z]/g, '');
+        return `
         <div class="recommendation-item">
-          <div class="rec-priority rec-${rec.priority.toLowerCase()}">${rec.priority}</div>
-          <div class="rec-action">${rec.action}</div>
-          <div class="rec-owner">Owner: ${rec.owner} | Due: ${rec.dueDate.toISOString().split('T')[0]}</div>
+          <div class="rec-priority rec-${priorityClass}">${escapeHtml(rec.priority)}</div>
+          <div class="rec-action">${escapeHtml(rec.action)}</div>
+          <div class="rec-owner">Owner: ${escapeHtml(rec.owner)} | Due: ${escapeHtml(toIsoDay(rec.dueDate))}</div>
         </div>
-      `).join('')}
+      `;
+      }).join('')}
     </div>
-    
+
     <!-- Team Performance -->
     <div class="team-performance">
       <h2>Team Performance</h2>
@@ -745,40 +792,53 @@ class ComplianceDashboardReportEngine extends EventEmitter {
           <th>Completion Rate</th>
           <th>Tasks Completed</th>
         </tr>
-        ${teamPerformance.map(member => `
+        ${(teamPerformance || []).map(member => {
+          // Clamp completionRate into [0,100] and to a number for the
+          // inline `width:` style — otherwise a caller supplying
+          // "100%;background:red" would land verbatim in the style
+          // attribute.
+          const rawRate = Number(member.completionRate);
+          const safeRate = Number.isFinite(rawRate)
+            ? Math.max(0, Math.min(100, rawRate))
+            : 0;
+          return `
           <tr>
-            <td>${member.name}</td>
+            <td>${escapeHtml(member.name)}</td>
             <td>
               <div class="progress-bar">
-                <div class="progress-fill" style="width: ${member.completionRate}%">${member.completionRate}%</div>
+                <div class="progress-fill" style="width: ${safeRate}%">${escapeHtml(member.completionRate)}%</div>
               </div>
             </td>
-            <td>${member.tasksCompleted}</td>
+            <td>${escapeHtml(member.tasksCompleted)}</td>
           </tr>
-        `).join('')}
+        `;
+        }).join('')}
       </table>
     </div>
-    
+
     <!-- Regulatory Status -->
     <div class="regulatory-status">
       <h2>Regulatory Compliance Status</h2>
       <div class="status-grid">
-        ${Object.entries(regulatoryStatus).map(([framework, status]) => `
-          <div class="status-item status-${status.status.toLowerCase()}">
-            <div class="status-name">${framework.toUpperCase()}</div>
-            <div class="status-badge">${status.status}</div>
+        ${Object.entries(regulatoryStatus || {}).map(([framework, status]) => {
+          const statusClass = String(status && status.status || '').toLowerCase().replace(/[^a-z-]/g, '');
+          return `
+          <div class="status-item status-${statusClass}">
+            <div class="status-name">${escapeHtml(String(framework).toUpperCase())}</div>
+            <div class="status-badge">${escapeHtml(status && status.status)}</div>
             <div style="font-size: 11px; margin-top: 10px; color: #666;">
-              Violations: ${status.violations}
+              Violations: ${escapeHtml(status && status.violations)}
             </div>
           </div>
-        `).join('')}
+        `;
+        }).join('')}
       </div>
     </div>
-    
+
     <!-- Footer -->
     <div class="footer">
-      <p>Report ID: ${reportId}</p>
-      <p>Generated: ${new Date().toISOString()}</p>
+      <p>Report ID: ${safeReportId}</p>
+      <p>Generated: ${escapeHtml(new Date().toISOString())}</p>
       <p>CONFIDENTIAL - For authorized recipients only</p>
       <p>© 2026 ASANA Brain Compliance Platform</p>
     </div>

--- a/tests/dashboardReportEngineFixes.test.ts
+++ b/tests/dashboardReportEngineFixes.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Targeted regression tests for the round-2 fixes to the newer report
+ * modules (compliance-dashboard-report-engine.js and
+ * asana-brain-master-system.js).
+ *
+ * Focus:
+ *   1. HTML injection in generateHTMLReport — Asana-controlled
+ *      strings (organization, recommendation text, team member name,
+ *      regulatory framework/status, priority-derived CSS classes)
+ *      must be escaped before landing in the emailed HTML body.
+ *   2. Completion-rate is clamped and coerced before it is used in an
+ *      inline `style="width:…"` attribute, so a caller cannot break
+ *      out of the style context.
+ *   3. AsanaBrainMasterSystem's uptime-reading methods do not crash
+ *      when startTime is null (pre-init / post-shutdown).
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+
+const ComplianceDashboardReportEngine = require('../compliance-dashboard-report-engine.js');
+const AsanaBrainMasterSystem = require('../asana-brain-master-system.js');
+
+function silentDeps() {
+  const span = { finish: () => {}, setTag: () => {} };
+  return {
+    logger: {
+      info: () => {}, warn: () => {}, error: () => {}, debug: () => {},
+    },
+    tracer: { startSpan: () => span },
+    metrics: {
+      increment: () => {}, histogram: () => {}, gauge: () => {},
+    },
+  };
+}
+
+describe('ComplianceDashboardReportEngine.generateHTMLReport', () => {
+  const engine = new ComplianceDashboardReportEngine(silentDeps());
+
+  const sampleData = (overrides: Record<string, unknown> = {}) => ({
+    projectId: 'p1',
+    config: { organization: 'Acme Corp' },
+    metrics: { complianceRate: 90, healthScore: 80, riskScore: 10, velocity: 5 },
+    riskMatrix: {
+      critical: { count: 0, percentage: 0 },
+      high: { count: 0, percentage: 0 },
+      medium: { count: 0, percentage: 0 },
+      low: { count: 0, percentage: 0 },
+    },
+    recommendations: [],
+    teamPerformance: [],
+    regulatoryStatus: {},
+    ...overrides,
+  });
+
+  it('escapes the organization name', async () => {
+    const html = await engine.generateHTMLReport('rep-1', sampleData({
+      config: { organization: '<img src=x onerror=alert(1)>' },
+    }));
+    expect(html).not.toContain('<img src=x onerror=alert(1)>');
+    expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
+  });
+
+  it('escapes recommendation action text and sanitises the CSS class', async () => {
+    const html = await engine.generateHTMLReport('rep-1', sampleData({
+      recommendations: [
+        {
+          priority: 'HIGH"onload=alert(1)',
+          action: '<script>alert(1)</script>',
+          owner: 'A',
+          dueDate: new Date('2026-01-01'),
+        },
+      ],
+    }));
+    // Raw script tag must NOT land in the HTML; escaped form must.
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+    // The priority-derived class only has [a-z] so it cannot break
+    // out of the class attribute. We match the actual rendered
+    // class pattern `rec-<letters>` with a closing quote right
+    // after.
+    expect(html).toMatch(/class="rec-priority rec-[a-z]+"/);
+    // An unescaped double-quote from the priority must not reach the
+    // class attribute (that would be the real breakout vector).
+    expect(html).not.toMatch(/class="rec-priority rec-[^"]*"[^>]*onload/);
+  });
+
+  it('clamps team-member completionRate used in inline style attribute', async () => {
+    const html = await engine.generateHTMLReport('rep-1', sampleData({
+      teamPerformance: [
+        { name: 'Alice', completionRate: '100%;background:red', tasksCompleted: 3 },
+        { name: 'Bob', completionRate: 250, tasksCompleted: 9 },
+        { name: 'Carol', completionRate: -50, tasksCompleted: 1 },
+      ],
+    }));
+    // The real attack surface is the style attribute — asserting no
+    // style="…" contains `background:` is the correct check (the
+    // substring "background:red" as text content inside the div is
+    // harmless and merely the echoed user input).
+    expect(html).not.toMatch(/style="[^"]*background:/);
+    // Alice: NaN-like → 0, Carol: -50 → clamped to 0, Bob: 250 → 100.
+    expect(html).toContain('style="width: 0%"');
+    expect(html).toContain('style="width: 100%"');
+    const widthZeroCount = (html.match(/style="width: 0%"/g) || []).length;
+    expect(widthZeroCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it('escapes regulatory framework name and status', async () => {
+    const html = await engine.generateHTMLReport('rep-1', sampleData({
+      regulatoryStatus: {
+        '<b>sox</b>': { status: 'COMPLIANT"onclick=alert(1)', violations: 0 },
+      },
+    }));
+    // Raw <b> tag must not appear; escaped form must.
+    expect(html).not.toContain('<b>sox</b>');
+    expect(html).toContain('&lt;B&gt;SOX&lt;/B&gt;');
+    // The status-derived CSS class must stay within [a-z-] so it
+    // cannot break out of the class attribute.
+    expect(html).toMatch(/class="status-item status-[a-z-]*"/);
+    // And no element should actually carry an unescaped `onclick`
+    // attribute — which would be the real XSS breakout.
+    expect(html).not.toMatch(/<[a-z]+[^>]*\sonclick\s*=/i);
+  });
+
+  it('tolerates a non-Date recommendation dueDate without throwing', async () => {
+    const html = await engine.generateHTMLReport('rep-1', sampleData({
+      recommendations: [
+        { priority: 'LOW', action: 'x', owner: 'y', dueDate: 'not-a-date' },
+      ],
+    }));
+    expect(html).toContain('Due:'); // rendered, just with an empty day
+  });
+});
+
+describe('ComplianceDashboardReportEngine.startScheduler', () => {
+  it('computes the next fire time at 08:00 UTC without drift', () => {
+    const engine = new ComplianceDashboardReportEngine(silentDeps());
+    // Patch global setTimeout so we can capture the delay instead of
+    // actually scheduling.
+    let capturedDelay: number | null = null;
+    const originalSetTimeout = globalThis.setTimeout;
+    (globalThis as unknown as { setTimeout: typeof setTimeout }).setTimeout = ((_fn: () => void, delay: number) => {
+      capturedDelay = delay;
+      return { unref() {} } as unknown as ReturnType<typeof setTimeout>;
+    }) as unknown as typeof setTimeout;
+    try {
+      engine.startScheduler();
+    } finally {
+      (globalThis as unknown as { setTimeout: typeof setTimeout }).setTimeout = originalSetTimeout;
+    }
+    expect(capturedDelay).not.toBeNull();
+    // The captured delay must land exactly on the next 08:00 UTC mark
+    // (give or take a tiny measurement window).
+    const now = new Date();
+    const next = new Date(Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate(),
+      8, 0, 0, 0,
+    ));
+    if (next.getTime() <= now.getTime()) next.setUTCDate(next.getUTCDate() + 1);
+    const expected = next.getTime() - now.getTime();
+    // Allow a few hundred ms of slack for the test runner.
+    expect(Math.abs((capturedDelay as number) - expected)).toBeLessThan(2000);
+  });
+});
+
+describe('AsanaBrainMasterSystem uptime guards', () => {
+  it('performHealthCheck tolerates a null startTime', () => {
+    const sys = new AsanaBrainMasterSystem(silentDeps());
+    // startTime is null until initialize() completes. The old code
+    // called this.startTime.getTime() and crashed the whole monitor.
+    expect(() => sys.performHealthCheck()).not.toThrow();
+  });
+
+  it('reportMetrics tolerates a null startTime', () => {
+    const sys = new AsanaBrainMasterSystem(silentDeps());
+    expect(() => sys.reportMetrics()).not.toThrow();
+  });
+
+  it('getSystemStatus tolerates a null startTime and reports uptime 0', () => {
+    const sys = new AsanaBrainMasterSystem(silentDeps());
+    const status = sys.getSystemStatus();
+    expect(status.uptime).toBe(0);
+    expect(status.status).toBe('stopped');
+  });
+});


### PR DESCRIPTION
## Summary

Second review pass over the two new compliance modules that landed on `main` after #221 merged:
- `compliance-dashboard-report-engine.js` (1 032 lines)
- `asana-brain-master-system.js` (567 lines)

Same class of bugs as round 1, fixed with the same pattern for consistency.

### `compliance-dashboard-report-engine.js`

1. **HTML injection / stored XSS in `generateHTMLReport`** — `config.organization`, recommendation `priority`/`action`/`owner`, team member `name`, regulatory framework key, and `status.status` were all concatenated raw into the emailed HTML body. A framework key of `<b>sox</b>` or a status of `COMPLIANT"onclick=alert(1)` would land verbatim. Fixed with a module-local `escapeHtml` helper at every interpolation point. CSS class names derived from priority/status are clamped to `[a-z]` / `[a-z-]` so a caller cannot break out of the class attribute.

2. **Style-attribute break-out in progress bar** — `style="width: ${member.completionRate}%"` accepted any string. A value of `100%;background:red` would inject a new declaration. Fixed by coercing to a number and clamping into `[0,100]` before interpolation.

3. **Scheduler drift + unhandled rejection in `startScheduler`** — same DST drift and unhandled-promise-rejection pattern as round 1. Rewrote to recompute 08:00 UTC on each run, wire the promise through `.catch`/`.finally`, and keep rescheduling after a failed run while `isRunning` is true.

4. **`toIsoDay` helper for `rec.dueDate`** — the old template called `rec.dueDate.toISOString()` directly. Any caller passing a non-Date (ISO string, null) would crash the whole report render. The helper coerces through `new Date`, returns `''` on invalid input, and never throws.

### `asana-brain-master-system.js`

5. **Null `startTime` crash in monitor loops and status reads** — `performHealthCheck`, `reportMetrics`, and `getSystemStatus` all did `Date.now() - this.startTime.getTime()`. `startTime` is `null` from construction until the end of `initialize()`, so any pre-init call (or post-shutdown call) crashed with `Cannot read properties of null`. Guarded each method to return `uptime=0` when `startTime` is null.

### Tests

Added `tests/dashboardReportEngineFixes.test.ts` (9 tests) covering the XSS paths (organization name, recommendation action, team completion rate as style value, regulatory framework + status), CSS-class sanitisation, clamped progress-bar width, scheduler delay computation (asserts the next fire lands exactly on 08:00 UTC), and the three null-`startTime` guards.

## Test plan

- [x] `npx vitest run tests/dashboardReportEngineFixes.test.ts` — 9/9 passing
- [x] `npx vitest run` — **4354/4354** passing (no regressions; 9 new)
- [ ] Netlify deploy preview builds cleanly
- [ ] `lint-and-test` CI step green

## Deliberately NOT fixed in this PR

- **Missing runtime deps** (`node-cron`, `nodemailer`, `axios` in earlier report modules). Re-verified via grep that those modules are referenced only by setup `.md` docs — no live JS imports them. Adding three npm packages to the Netlify bundle to satisfy scaffolding code that nothing currently runs would add supply-chain risk with zero benefit. Next session should decide between: declare as deps, make the imports lazy, or delete the scaffolding.

## Regulatory basis

- **FDL No.10/2025 Art.24** — daily compliance reports form part of the 10-year audit record; non-corrupted HTML and crash-free monitor loops are required for the audit chain.
- **LBMA RGG v9** — MLRO email distribution must not be a vector for HTML or style-attribute injection from operator-controlled fields.

https://claude.ai/code/session_01R9Y37tUnmBhH1uF2i3toB8