### PR TITLE
fix: Weekly risk analysis scheduler — XSS, Monday-edge-case, scheduler drift (FDL No.10/2025 Art.24, LBMA RGG v9)

### DIFF
--- a/tests/weeklyRiskSchedulerFixes.test.ts
+++ b/tests/weeklyRiskSchedulerFixes.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Targeted regression tests for the round-3 fixes to
+ * weekly-risk-analysis-scheduler.js. Same bug classes as the earlier
+ * report modules:
+ *
+ *   1. HTML injection / stored XSS in generateWeeklyHTML — any
+ *      operator-controlled value (team member name, recommendation
+ *      action, recommendation owner) could carry markup into the
+ *      emailed report body.
+ *   2. Non-Date `rec.dueDate` crashed the whole render because the
+ *      old template called `.toISOString()` directly.
+ *   3. `getNextMonday` did not handle "today is Monday but it is
+ *      already past 08:00 UTC" — it returned today, so the caller
+ *      scheduled a negative delay and fired the report immediately
+ *      instead of a week later.
+ *   4. Fixed 7-day `setInterval` drifts across DST transitions and
+ *      leaks an unhandled rejection when the async work fails.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const WeeklyRiskAnalysisScheduler = require('../weekly-risk-analysis-scheduler.js');
+
+function silentDeps() {
+  const span = { finish: () => {}, setTag: () => {} };
+  return {
+    logger: {
+      info: () => {}, warn: () => {}, error: () => {}, debug: () => {},
+    },
+    tracer: { startSpan: () => span },
+    metrics: { increment: () => {}, histogram: () => {}, gauge: () => {} },
+  };
+}
+
+describe('WeeklyRiskAnalysisScheduler.generateWeeklyHTML', () => {
+  const sched = new WeeklyRiskAnalysisScheduler(silentDeps());
+
+  const sample = (overrides: Record<string, unknown> = {}) => ({
+    projectId: 'p1',
+    config: {},
+    weeklyData: {
+      week: 16, startDate: '2026-04-13', endDate: '2026-04-19',
+      tasksCompleted: 18, tasksCreated: 12, tasksOverdue: 4,
+      averageCompletionTime: 2.3,
+    },
+    trends: { complianceRateTrend: '+5.3%', healthScoreTrend: '+4', riskScoreTrend: '-2.8%' },
+    riskHeatmap: {},
+    teamAnalysis: [],
+    recommendations: [],
+    ...overrides,
+  });
+
+  it('escapes team-member names', async () => {
+    const html = await sched.generateWeeklyHTML('rep-1', sample({
+      teamAnalysis: [
+        { name: '<img src=x onerror=alert(1)>', tasksCompleted: 1, completionRate: 100, avgTime: 1 },
+      ],
+    }));
+    expect(html).not.toContain('<img src=x onerror=alert(1)>');
+    expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
+  });
+
+  it('escapes recommendation action text', async () => {
+    const html = await sched.generateWeeklyHTML('rep-1', sample({
+      recommendations: [
+        {
+          priority: 'HIGH',
+          action: '<script>alert(1)</script>',
+          owner: 'Lead',
+          dueDate: new Date('2026-04-20'),
+        },
+      ],
+    }));
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+
+  it('tolerates a non-Date recommendation dueDate without throwing', async () => {
+    const html = await sched.generateWeeklyHTML('rep-1', sample({
+      recommendations: [
+        { priority: 'MEDIUM', action: 'x', owner: 'y', dueDate: 'not-a-date' },
+        { priority: 'LOW', action: 'x', owner: 'y', dueDate: null },
+        { priority: 'HIGH', action: 'x', owner: 'y', dueDate: undefined },
+      ],
+    }));
+    // Render must succeed and produce a "Due: " line for each item.
+    const dueMatches = html.match(/Due:\s*</g) || [];
+    expect(dueMatches.length).toBe(3);
+  });
+
+  it('escapes weekly start/end date strings', async () => {
+    const html = await sched.generateWeeklyHTML('rep-1', sample({
+      weeklyData: {
+        week: 1,
+        startDate: '"><script>alert(1)</script>',
+        endDate: '2026-04-19',
+        tasksCompleted: 0, tasksCreated: 0, tasksOverdue: 0, averageCompletionTime: 0,
+      },
+    }));
+    expect(html).not.toContain('"><script>alert(1)</script>');
+    expect(html).toContain('&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+});
+
+describe('WeeklyRiskAnalysisScheduler.getNextMondayAt8Utc', () => {
+  const sched = new WeeklyRiskAnalysisScheduler(silentDeps());
+
+  it('returns 8:00 UTC on a Monday when called before 8:00 on that Monday', () => {
+    const mondayMorning = new Date(Date.UTC(2026, 3, 13, 5, 0, 0)); // 2026-04-13 is a Monday
+    const next = sched.getNextMondayAt8Utc(mondayMorning);
+    expect(next.getUTCDay()).toBe(1);
+    expect(next.toISOString()).toBe('2026-04-13T08:00:00.000Z');
+  });
+
+  it('skips forward to the FOLLOWING Monday when called on a Monday past 8:00 UTC', () => {
+    // 2026-04-13 is a Monday. 09:00 UTC is past 08:00 UTC on that
+    // Monday — the old getNextMonday returned today and produced a
+    // negative delay, so the report fired immediately instead of a
+    // week later.
+    const mondayLate = new Date(Date.UTC(2026, 3, 13, 9, 0, 0));
+    const next = sched.getNextMondayAt8Utc(mondayLate);
+    expect(next.getUTCDay()).toBe(1);
+    expect(next.toISOString()).toBe('2026-04-20T08:00:00.000Z');
+  });
+
+  it('returns the NEXT Monday when called on a Sunday', () => {
+    // 2026-04-12 is a Sunday.
+    const sunday = new Date(Date.UTC(2026, 3, 12, 23, 0, 0));
+    const next = sched.getNextMondayAt8Utc(sunday);
+    expect(next.getUTCDay()).toBe(1);
+    expect(next.toISOString()).toBe('2026-04-13T08:00:00.000Z');
+  });
+
+  it('returns the next Monday when called mid-week', () => {
+    // 2026-04-15 is a Wednesday.
+    const wednesday = new Date(Date.UTC(2026, 3, 15, 12, 0, 0));
+    const next = sched.getNextMondayAt8Utc(wednesday);
+    expect(next.getUTCDay()).toBe(1);
+    expect(next.toISOString()).toBe('2026-04-20T08:00:00.000Z');
+  });
+});
+
+describe('WeeklyRiskAnalysisScheduler.startScheduler', () => {
+  it('uses a setTimeout delay that lands on the next Monday 08:00 UTC', () => {
+    const sched = new WeeklyRiskAnalysisScheduler(silentDeps());
+    let capturedDelay: number | null = null;
+    const original = globalThis.setTimeout;
+    (globalThis as unknown as { setTimeout: typeof setTimeout }).setTimeout = ((_fn: () => void, delay: number) => {
+      capturedDelay = delay;
+      return { unref() {} } as unknown as ReturnType<typeof setTimeout>;
+    }) as unknown as typeof setTimeout;
+    try {
+      void sched.startScheduler();
+    } finally {
+      (globalThis as unknown as { setTimeout: typeof setTimeout }).setTimeout = original;
+    }
+    expect(capturedDelay).not.toBeNull();
+    // It must be strictly positive (we are always scheduling strictly
+    // ahead of `now`), and it must land on the next Monday 08:00 UTC
+    // as computed independently.
+    expect(capturedDelay as number).toBeGreaterThan(0);
+    const expected = sched.getNextMondayAt8Utc(new Date()).getTime() - Date.now();
+    expect(Math.abs((capturedDelay as number) - expected)).toBeLessThan(2000);
+  });
+});

--- a/weekly-risk-analysis-scheduler.js
+++ b/weekly-risk-analysis-scheduler.js
@@ -13,6 +13,29 @@
 const EventEmitter = require('events');
 const crypto = require('crypto');
 
+// Escape any operator-controlled string before interpolating it into
+// the generated HTML so an Asana task name, team member name or a
+// recommendation action cannot break out of the template.
+function escapeHtml(value) {
+  if (value === null || value === undefined) return '';
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// Coerce a value that might be a Date, ISO string, number or null
+// into a YYYY-MM-DD display string. Returns '' on invalid input so
+// the whole report render does not blow up on one bad field.
+function toIsoDay(value) {
+  if (value === null || value === undefined) return '';
+  const d = value instanceof Date ? value : new Date(value);
+  if (!Number.isFinite(d.getTime())) return '';
+  return d.toISOString().split('T')[0];
+}
+
 class WeeklyRiskAnalysisScheduler extends EventEmitter {
   constructor(config) {
     super();
@@ -79,27 +102,30 @@ class WeeklyRiskAnalysisScheduler extends EventEmitter {
     const span = this.tracer.startSpan('start_weekly_scheduler');
     try {
       this.logger.info('Starting weekly scheduler...');
-      
-      // Calculate next Monday 8:00 AM UTC
-      const now = new Date();
-      const nextMonday = this.getNextMonday(now);
-      const scheduledTime = new Date(nextMonday);
-      scheduledTime.setUTCHours(8, 0, 0, 0);
-      
-      const timeUntilExecution = scheduledTime.getTime() - now.getTime();
-      
-      this.logger.info(`⏰ Next weekly execution: ${scheduledTime.toISOString()}`);
-      
-      // Set initial timeout
-      this.schedulerTimeout = setTimeout(() => {
-        this.executeWeeklyReports();
-        
-        // Then set recurring interval (7 days)
-        this.schedulerInterval = setInterval(() => {
-          this.executeWeeklyReports();
-        }, 7 * 24 * 60 * 60 * 1000);
-      }, timeUntilExecution);
-      
+
+      // Each run recomputes "next Monday 08:00 UTC" so there is no
+      // drift across DST transitions, and the async work is wrapped
+      // through .catch/.finally so a failing run cannot leak an
+      // unhandled promise rejection or stop the schedule.
+      const scheduleNext = () => {
+        const now = new Date();
+        const next = this.getNextMondayAt8Utc(now);
+        const delay = next.getTime() - now.getTime();
+        this.logger.info(`⏰ Next weekly execution: ${next.toISOString()}`);
+        this.schedulerTimeout = setTimeout(() => {
+          Promise.resolve()
+            .then(() => this.executeWeeklyReports())
+            .catch((err) => {
+              this.logger.error('Unhandled error in scheduled weekly reports', err);
+            })
+            .finally(() => {
+              if (this.isRunning) scheduleNext();
+            });
+        }, delay);
+      };
+
+      scheduleNext();
+
       this.logger.info('✅ Weekly scheduler started');
       span.finish();
     } catch (error) {
@@ -110,13 +136,48 @@ class WeeklyRiskAnalysisScheduler extends EventEmitter {
   }
 
   /**
-   * Get next Monday date
+   * Compute the next Monday 08:00 UTC strictly AFTER `from`.
+   *
+   * The previous `getNextMonday` returned today when called on a
+   * Monday, which on a Monday past 08:00 UTC produced a negative
+   * delay and fired the report immediately instead of in a week.
+   * This version also does all arithmetic in UTC so it does not
+   * drift when the host server's local timezone changes.
+   */
+  getNextMondayAt8Utc(from) {
+    const now = from instanceof Date ? from : new Date(from);
+    // Start at today 08:00 UTC.
+    const candidate = new Date(Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate(),
+      8, 0, 0, 0,
+    ));
+    // Monday is day 1 in both local and UTC. If today is not Monday,
+    // advance to the next Monday.
+    const dow = candidate.getUTCDay();
+    if (dow !== 1) {
+      const daysUntilMonday = (1 - dow + 7) % 7 || 7;
+      candidate.setUTCDate(candidate.getUTCDate() + daysUntilMonday);
+    }
+    // If we landed on "today 08:00 UTC" but that moment has already
+    // passed, jump to next Monday (7 days ahead).
+    if (candidate.getTime() <= now.getTime()) {
+      candidate.setUTCDate(candidate.getUTCDate() + 7);
+    }
+    return candidate;
+  }
+
+  /**
+   * Back-compat alias. Calendar-only (no time), so callers that
+   * relied on the date semantics of the old helper still work. Prefer
+   * `getNextMondayAt8Utc` for anything new.
    */
   getNextMonday(date) {
-    const d = new Date(date);
-    const day = d.getDay();
-    const diff = d.getDate() - day + (day === 0 ? -6 : 1); // Adjust when day is Sunday
-    return new Date(d.setDate(diff));
+    const next = this.getNextMondayAt8Utc(date);
+    // Strip the time portion so the return shape matches the old
+    // semantics (a Date at midnight local).
+    return new Date(next.getUTCFullYear(), next.getUTCMonth(), next.getUTCDate());
   }
 
   /**
@@ -447,37 +508,37 @@ class WeeklyRiskAnalysisScheduler extends EventEmitter {
     <div class="header">
       <div class="confidential">CONFIDENTIAL</div>
       <h1>Weekly Risk Analysis Report</h1>
-      <p>Week ${weeklyData.week} | ${weeklyData.startDate} to ${weeklyData.endDate}</p>
+      <p>Week ${escapeHtml(weeklyData.week)} | ${escapeHtml(weeklyData.startDate)} to ${escapeHtml(weeklyData.endDate)}</p>
     </div>
-    
+
     <div class="section">
       <h2 class="section-title">Weekly Trends</h2>
       <div class="trends-grid">
         <div class="trend-item">
           <div class="trend-label">Compliance Rate Trend</div>
-          <div class="trend-value" style="color: #4caf50;">${trends.complianceRateTrend}</div>
+          <div class="trend-value" style="color: #4caf50;">${escapeHtml(trends.complianceRateTrend)}</div>
         </div>
         <div class="trend-item">
           <div class="trend-label">Health Score Trend</div>
-          <div class="trend-value" style="color: #4caf50;">↑ ${trends.healthScoreTrend}</div>
+          <div class="trend-value" style="color: #4caf50;">↑ ${escapeHtml(trends.healthScoreTrend)}</div>
         </div>
         <div class="trend-item">
           <div class="trend-label">Risk Score Trend</div>
-          <div class="trend-value" style="color: #4caf50;">${trends.riskScoreTrend}</div>
+          <div class="trend-value" style="color: #4caf50;">${escapeHtml(trends.riskScoreTrend)}</div>
         </div>
       </div>
     </div>
-    
+
     <div class="section">
       <h2 class="section-title">Weekly Performance</h2>
       <div>
-        <p><strong>Tasks Completed:</strong> ${weeklyData.tasksCompleted}</p>
-        <p><strong>Tasks Created:</strong> ${weeklyData.tasksCreated}</p>
-        <p><strong>Tasks Overdue:</strong> ${weeklyData.tasksOverdue}</p>
-        <p><strong>Average Completion Time:</strong> ${weeklyData.averageCompletionTime} days</p>
+        <p><strong>Tasks Completed:</strong> ${escapeHtml(weeklyData.tasksCompleted)}</p>
+        <p><strong>Tasks Created:</strong> ${escapeHtml(weeklyData.tasksCreated)}</p>
+        <p><strong>Tasks Overdue:</strong> ${escapeHtml(weeklyData.tasksOverdue)}</p>
+        <p><strong>Average Completion Time:</strong> ${escapeHtml(weeklyData.averageCompletionTime)} days</p>
       </div>
     </div>
-    
+
     <div class="section">
       <h2 class="section-title">Team Performance</h2>
       <table class="team-table">
@@ -487,33 +548,39 @@ class WeeklyRiskAnalysisScheduler extends EventEmitter {
           <th>Completion Rate</th>
           <th>Avg Time</th>
         </tr>
-        ${teamAnalysis.map(member => `
+        ${(teamAnalysis || []).map(member => `
           <tr>
-            <td>${member.name}</td>
-            <td>${member.tasksCompleted}</td>
-            <td>${member.completionRate}%</td>
-            <td>${member.avgTime} days</td>
+            <td>${escapeHtml(member.name)}</td>
+            <td>${escapeHtml(member.tasksCompleted)}</td>
+            <td>${escapeHtml(member.completionRate)}%</td>
+            <td>${escapeHtml(member.avgTime)} days</td>
           </tr>
         `).join('')}
       </table>
     </div>
-    
+
     <div class="section">
       <h2 class="section-title">Recommendations</h2>
-      ${recommendations.map(rec => `
+      ${(recommendations || []).map(rec => {
+        // Pick a background colour from a closed allowlist so a
+        // caller-supplied priority cannot be interpolated directly
+        // into the inline `background:` style.
+        const bg = rec.priority === 'HIGH' ? '#ffc107' : '#2196f3';
+        return `
         <div style="padding: 15px; margin-bottom: 10px; background: #f9f9f9; border-left: 4px solid #003366;">
-          <div style="display: inline-block; padding: 4px 10px; background: #${rec.priority === 'HIGH' ? 'ffc107' : '2196f3'}; color: #333; border-radius: 3px; font-size: 11px; font-weight: bold; margin-bottom: 8px;">
-            ${rec.priority}
+          <div style="display: inline-block; padding: 4px 10px; background: ${bg}; color: #333; border-radius: 3px; font-size: 11px; font-weight: bold; margin-bottom: 8px;">
+            ${escapeHtml(rec.priority)}
           </div>
-          <div style="font-size: 14px; margin-bottom: 5px;">${rec.action}</div>
-          <div style="font-size: 12px; color: #666;">Owner: ${rec.owner} | Due: ${rec.dueDate.toISOString().split('T')[0]}</div>
+          <div style="font-size: 14px; margin-bottom: 5px;">${escapeHtml(rec.action)}</div>
+          <div style="font-size: 12px; color: #666;">Owner: ${escapeHtml(rec.owner)} | Due: ${escapeHtml(toIsoDay(rec.dueDate))}</div>
         </div>
-      `).join('')}
+      `;
+      }).join('')}
     </div>
-    
+
     <div class="footer">
-      <p>Report ID: ${reportId}</p>
-      <p>Generated: ${new Date().toISOString()}</p>
+      <p>Report ID: ${escapeHtml(reportId)}</p>
+      <p>Generated: ${escapeHtml(new Date().toISOString())}</p>
       <p>© 2026 ASANA Brain Compliance Platform</p>
     </div>
   </div>


### PR DESCRIPTION
## Summary

Third review pass over `weekly-risk-analysis-scheduler.js` (710 lines), which landed on `main` after #222 merged. Same bug classes as the earlier modules, plus one new Monday-edge-case bug unique to this scheduler.

### Bugs fixed

1. **HTML injection / stored XSS in `generateWeeklyHTML`** — team member name, recommendation `action`/`owner`, weekly data `startDate`/`endDate`, and trend values were all concatenated raw into the email HTML body. A `startDate` of `"><script>...</script>` or a team member name with markup would land verbatim. Fixed with a module-local `escapeHtml` helper at every interpolation point. The priority-derived background colour is now picked from a closed allowlist rather than inlined from the value itself.

2. **`rec.dueDate.toISOString()` crashes on non-Date input** — the old template called `.toISOString()` directly. A caller passing a string/null/undefined crashed the whole report. A `toIsoDay` helper coerces through `new Date`, returns `''` on invalid input, and never throws.

3. **`getNextMonday` returned "today" on a Monday** *(new — specific to this module)* — `getNextMonday(now)` used local `.getDay()` and `.setDate()` arithmetic and never handled "today is Monday but the current time is already past 08:00 UTC". The caller then called `setUTCHours(8,...)` on that date and computed a **negative** `timeUntilExecution`, so `setTimeout` fired the report immediately instead of a week later. A new `getNextMondayAt8Utc(from)` computes the next strict 08:00 UTC Monday entirely in UTC arithmetic. The old `getNextMonday` is kept as a back-compat alias returning the date portion.

4. **Scheduler drift + unhandled promise rejection** — same fixed `setInterval(7 * 24h)` drift across DST and unwrapped async callback as the round-1 daily scheduler. Rewrote to recompute "next Monday 08:00 UTC" on each run, wire the promise through `.catch`/`.finally`, and keep rescheduling after a failed run while `isRunning` is true.

### Tests

Added `tests/weeklyRiskSchedulerFixes.test.ts` (9 tests) covering: HTML escaping (team member, recommendation, weekly dates), non-Date `dueDate` graceful handling, `getNextMondayAt8Utc` on Sunday / Monday-before-08:00 / Monday-after-08:00 / mid-week, and scheduler delay verification.

## Test plan

- [x] `npx vitest run tests/weeklyRiskSchedulerFixes.test.ts` — 9/9 passing
- [x] `npx vitest run` — **4363/4363** passing (0 regressions; +9)
- [ ] Netlify deploy preview builds cleanly
- [ ] `lint-and-test` CI step green

## Regulatory basis

- **FDL No.10/2025 Art.24** — weekly compliance reports form part of the 10-year audit record; non-corrupted HTML and a scheduler that fires exactly when it claims to are required for the audit chain.
- **LBMA RGG v9** — MLRO email distribution must not be a vector for HTML or style-attribute injection from operator-controlled fields.

https://claude.ai/code/session_01R9Y37tUnmBhH1uF2i3toB8