### PR TITLE
fix: Make report scaffolding modules loadable without optional deps (Cabinet Res 134/2025 Art.19)

### DIFF
--- a/asana-brain-daily-report-executor.js
+++ b/asana-brain-daily-report-executor.js
@@ -19,9 +19,34 @@
  * Date: May 1, 2026
  */
 
-const cron = require('node-cron');
-const nodemailer = require('nodemailer');
-const axios = require('axios');
+// Lazy loaders for optional runtime deps — see the twin comment in
+// daily-compliance-report-system.js for the rationale. These three
+// packages are not declared in package.json, so resolving them at
+// require-time crashes any consumer without them installed.
+let _cron;
+function getCron() {
+  if (_cron) return _cron;
+  try { _cron = require('node-cron'); } catch (err) {
+    throw new Error('node-cron is required for scheduleDaily(). Install with `npm install node-cron`.');
+  }
+  return _cron;
+}
+let _nodemailer;
+function getNodemailer() {
+  if (_nodemailer) return _nodemailer;
+  try { _nodemailer = require('nodemailer'); } catch (err) {
+    throw new Error('nodemailer is required for email distribution. Install with `npm install nodemailer`.');
+  }
+  return _nodemailer;
+}
+let _axios;
+function getAxios() {
+  if (_axios) return _axios;
+  try { _axios = require('axios'); } catch (err) {
+    throw new Error('axios is required for Slack webhook distribution. Install with `npm install axios`.');
+  }
+  return _axios;
+}
 const fs = require('fs');
 const path = require('path');
 
@@ -62,17 +87,20 @@ class AsanaBrainDailyReportExecutor {
     this.asanaClient = config.asanaClient;
     this.dashboardService = config.dashboardService;
     this.notificationService = config.notificationService;
-    this.emailTransporter = this.initializeEmailTransporter();
+    // Email transporter is created on first use so merely requiring
+    // this file never crashes when nodemailer is absent.
+    this.emailTransporter = null;
     this.reportSchedules = new Map();
     this.executionHistory = [];
     this.status = 'INITIALIZED';
   }
 
   /**
-   * Initialize email transporter
+   * Initialize email transporter. Retained for back-compat; prefer
+   * `getEmailTransporter()` which memoises.
    */
   initializeEmailTransporter() {
-    return nodemailer.createTransport({
+    return getNodemailer().createTransport({
       host: this.config.emailConfig?.host || 'smtp.gmail.com',
       port: this.config.emailConfig?.port || 587,
       secure: this.config.emailConfig?.secure || false,
@@ -81,6 +109,13 @@ class AsanaBrainDailyReportExecutor {
         pass: this.config.emailConfig?.password,
       },
     });
+  }
+
+  getEmailTransporter() {
+    if (!this.emailTransporter) {
+      this.emailTransporter = this.initializeEmailTransporter();
+    }
+    return this.emailTransporter;
   }
 
   /**
@@ -93,7 +128,7 @@ class AsanaBrainDailyReportExecutor {
       this.logger.info('Initializing ASANA Brain Daily Report Executor');
 
       // Verify email configuration
-      const emailValid = await this.emailTransporter.verify();
+      const emailValid = await this.getEmailTransporter().verify();
       if (!emailValid) {
         this.logger.warn('Email configuration may be invalid');
       }
@@ -180,7 +215,7 @@ class AsanaBrainDailyReportExecutor {
       }
 
       // Schedule at 8:00 AM daily
-      const schedule = cron.schedule('0 8 * * *', async () => {
+      const schedule = getCron().schedule('0 8 * * *', async () => {
         await this.executeReport(projectId, recipients);
       });
 
@@ -643,7 +678,7 @@ class AsanaBrainDailyReportExecutor {
         ],
       };
 
-      await this.emailTransporter.sendMail(mailOptions);
+      await this.getEmailTransporter().sendMail(mailOptions);
 
       this.logger.info('Email report sent', { recipients: recipients.length });
       return { success: true, recipients: recipients.length };
@@ -678,7 +713,7 @@ class AsanaBrainDailyReportExecutor {
       };
 
       for (const channel of slackChannels) {
-        await axios.post(channel, message);
+        await getAxios().post(channel, message);
       }
 
       this.logger.info('Slack report sent', { channels: slackChannels.length });

--- a/asana-brain-intelligence.js
+++ b/asana-brain-intelligence.js
@@ -4,7 +4,8 @@
  * autonomous risk management, and real-time threat detection
  */
 
-const axios = require('axios');
+// `axios` was imported here but never used; removed so that
+// requiring this module does not fail when axios is absent.
 
 class ASANABrainIntelligence {
   constructor(asanaClient, db) {

--- a/daily-compliance-report-system.js
+++ b/daily-compliance-report-system.js
@@ -17,9 +17,37 @@
  * Date: May 1, 2026
  */
 
-const cron = require('node-cron');
-const nodemailer = require('nodemailer');
-const axios = require('axios');
+// Lazy loaders for optional runtime deps. These packages are NOT
+// declared in package.json because the module is scaffolding code
+// that the SPA bundle does not need. Loading them eagerly at
+// module-require time would crash every consumer that does not have
+// them installed (including the test harness). Instead we only
+// resolve them when the specific method that needs them is called,
+// and raise a clear error with install guidance if they are missing.
+let _cron;
+function getCron() {
+  if (_cron) return _cron;
+  try { _cron = require('node-cron'); } catch (err) {
+    throw new Error('node-cron is required for scheduleDaily(). Install with `npm install node-cron`.');
+  }
+  return _cron;
+}
+let _nodemailer;
+function getNodemailer() {
+  if (_nodemailer) return _nodemailer;
+  try { _nodemailer = require('nodemailer'); } catch (err) {
+    throw new Error('nodemailer is required for email distribution. Install with `npm install nodemailer`.');
+  }
+  return _nodemailer;
+}
+let _axios;
+function getAxios() {
+  if (_axios) return _axios;
+  try { _axios = require('axios'); } catch (err) {
+    throw new Error('axios is required for Slack webhook distribution. Install with `npm install axios`.');
+  }
+  return _axios;
+}
 const fs = require('fs');
 const path = require('path');
 
@@ -62,15 +90,19 @@ class DailyComplianceReportSystem {
     this.dashboardService = config.dashboardService;
     this.notificationService = config.notificationService;
     this.storageService = config.storageService;
-    this.emailTransporter = this.initializeEmailTransporter();
+    // Transporter is created on first use (see getEmailTransporter)
+    // so that importing this module never fails when nodemailer is
+    // absent — the dep is only needed when email distribution runs.
+    this.emailTransporter = null;
     this.reportSchedules = new Map();
   }
 
   /**
-   * Initialize email transporter for sending reports
+   * Initialize email transporter for sending reports. Retained for
+   * back-compat; prefer `getEmailTransporter()` which memoises.
    */
   initializeEmailTransporter() {
-    return nodemailer.createTransport({
+    return getNodemailer().createTransport({
       host: this.config.emailConfig?.host || 'smtp.gmail.com',
       port: this.config.emailConfig?.port || 587,
       secure: this.config.emailConfig?.secure || false,
@@ -79,6 +111,13 @@ class DailyComplianceReportSystem {
         pass: this.config.emailConfig?.password,
       },
     });
+  }
+
+  getEmailTransporter() {
+    if (!this.emailTransporter) {
+      this.emailTransporter = this.initializeEmailTransporter();
+    }
+    return this.emailTransporter;
   }
 
   /**
@@ -95,7 +134,7 @@ class DailyComplianceReportSystem {
       }
 
       // Schedule report generation at 8:00 AM daily
-      const schedule = cron.schedule('0 8 * * *', async () => {
+      const schedule = getCron().schedule('0 8 * * *', async () => {
         await this.generateAndDistributeReport(projectId, recipients);
       });
 
@@ -1049,7 +1088,7 @@ class DailyComplianceReportSystem {
         ],
       };
 
-      await this.emailTransporter.sendMail(mailOptions);
+      await this.getEmailTransporter().sendMail(mailOptions);
 
       this.logger.info('Email report sent', { recipients, count: recipients.length });
       return { success: true, recipients: recipients.length };
@@ -1106,7 +1145,7 @@ class DailyComplianceReportSystem {
       };
 
       for (const channel of slackChannels) {
-        await axios.post(channel, message);
+        await getAxios().post(channel, message);
       }
 
       this.logger.info('Slack report sent', { channels: slackChannels.length });

--- a/daily-compliance-reporter.js
+++ b/daily-compliance-reporter.js
@@ -3,8 +3,18 @@
  * Generates and distributes automatic daily compliance reports
  */
 
-const cron = require('node-cron');
-const nodemailer = require('nodemailer');
+// Lazy loader for node-cron so requiring this module does not crash
+// in environments where the dep is not installed. nodemailer is
+// referenced only in a commented-out example below, so no loader is
+// needed for it.
+let _cron;
+function getCron() {
+  if (_cron) return _cron;
+  try { _cron = require('node-cron'); } catch (err) {
+    throw new Error('node-cron is required for scheduleDaily(). Install with `npm install node-cron`.');
+  }
+  return _cron;
+}
 
 class DailyComplianceReporter {
   constructor(asanaBrain, db, config = {}) {
@@ -44,7 +54,7 @@ class DailyComplianceReporter {
     // Cron: Run at specified time every day (0 minute, hour, *, *, *)
     const cronExpression = `${minute} ${hour} * * *`;
 
-    this.cronJob = cron.schedule(cronExpression, async () => {
+    this.cronJob = getCron().schedule(cronExpression, async () => {
       console.log('[Daily Reporter] 📅 Generating daily compliance report...');
       await this.generateAndDistributeReport();
     });

--- a/hawkeye-str-analysis-engine.js
+++ b/hawkeye-str-analysis-engine.js
@@ -4,7 +4,8 @@
  * Auto-creates Asana tasks for findings
  */
 
-const axios = require('axios');
+// `axios` was imported here but never used; removed so requiring
+// this module does not fail when axios is absent.
 
 class STRAnalysisEngine {
   constructor(asanaClient, llmClient, config = {}) {

--- a/phase1-asana-sync-engine.js
+++ b/phase1-asana-sync-engine.js
@@ -5,10 +5,33 @@
  * TARGET: < 1 second latency for all sync operations
  */
 
-const logger = require('./logger-service');
-const tracer = require('./tracer-service');
-const metrics = require('./metrics-service');
-const axios = require('axios');
+// Four external deps previously loaded eagerly: three local
+// (`./logger-service`, `./tracer-service`, `./metrics-service`) that
+// do not exist in this repo, and `axios` which is not declared in
+// package.json. Each one is attempted once; if the module is absent
+// we substitute a stub whose every property getter throws with a
+// clear install hint. This keeps `require()` of the module safe
+// (e.g. for inventory and health checks) while still failing loudly
+// the moment any caller actually tries to use the sync engine.
+function _unavailable(name, hint) {
+  return new Proxy(function stubFn() {
+    throw new Error(`'${name}' is not available. ${hint}`);
+  }, {
+    get() {
+      throw new Error(`'${name}' is not available. ${hint}`);
+    },
+    apply() {
+      throw new Error(`'${name}' is not available. ${hint}`);
+    },
+  });
+}
+function _tryRequire(name, hint) {
+  try { return require(name); } catch (err) { return _unavailable(name, hint); }
+}
+const logger = _tryRequire('./logger-service', 'Provide a logger-service.js shim.');
+const tracer = _tryRequire('./tracer-service', 'Provide a tracer-service.js shim.');
+const metrics = _tryRequire('./metrics-service', 'Provide a metrics-service.js shim.');
+const axios = _tryRequire('axios', 'Install with `npm install axios`.');
 
 class AsanaSyncEngine {
   constructor(config = {}) {

--- a/tests/reportModuleLoadability.test.ts
+++ b/tests/reportModuleLoadability.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Regression tests proving that the compliance report scaffolding
+ * modules can be `require()`d cleanly even when their optional runtime
+ * deps (`node-cron`, `nodemailer`, `axios`) are not installed.
+ *
+ * Motivation: three earlier review rounds flagged that these six
+ * modules pulled in deps that are not declared in `package.json`, so
+ * merely requiring any of them from a consumer, a smoke-test, or a
+ * dependency-inventory scan would crash. The fix wraps the required
+ * bindings in lazy resolvers (or, for `phase1-asana-sync-engine.js`,
+ * a Proxy-backed stub) so the module can always be loaded. Actual
+ * method calls that genuinely need a dep now throw a clear
+ * "install with npm" error instead of crashing at import time.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createRequire } from 'module';
+import Module from 'module';
+
+const req = createRequire(import.meta.url);
+
+const TARGETS = [
+  '../daily-compliance-report-system.js',
+  '../asana-brain-daily-report-executor.js',
+  '../daily-compliance-reporter.js',
+  '../asana-brain-intelligence.js',
+  '../hawkeye-str-analysis-engine.js',
+  '../phase1-asana-sync-engine.js',
+] as const;
+
+const MISSING = new Set(['node-cron', 'nodemailer', 'axios']);
+
+type Resolver = (this: unknown, request: string, ...rest: unknown[]) => string;
+let origResolve: Resolver;
+
+beforeAll(() => {
+  // Patch the Node resolver to make the three optional deps look
+  // uninstalled. This simulates the production environment where the
+  // SPA's package.json does not include them.
+  origResolve = (Module as unknown as { _resolveFilename: Resolver })._resolveFilename;
+  (Module as unknown as { _resolveFilename: Resolver })._resolveFilename = function patched(request, ...rest) {
+    if (MISSING.has(request)) {
+      const err = new Error(`Cannot find module '${request}'`) as Error & { code?: string };
+      err.code = 'MODULE_NOT_FOUND';
+      throw err;
+    }
+    return origResolve.call(this, request, ...rest);
+  };
+});
+
+afterAll(() => {
+  (Module as unknown as { _resolveFilename: Resolver })._resolveFilename = origResolve;
+});
+
+describe('Report scaffolding modules load without optional runtime deps', () => {
+  for (const target of TARGETS) {
+    it(`require('${target}') succeeds without node-cron/nodemailer/axios`, () => {
+      // Clear any cached copy so the patched resolver actually runs.
+      const resolved = req.resolve(target);
+      delete (req.cache as Record<string, unknown>)[resolved];
+      let loaded: unknown;
+      expect(() => {
+        loaded = req(target);
+      }).not.toThrow();
+      expect(loaded).toBeDefined();
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Resolves the dependency-gap carry-over flagged in PRs #221, #222, and #223. Six compliance report scaffolding modules previously required `node-cron`, `nodemailer`, `axios` and three non-existent local services (`./logger-service`, `./tracer-service`, `./metrics-service`) at load time, none declared in `package.json`. Any `require()` of any of them — consumer code, smoke test, inventory scan, or CI health check — crashed immediately with `MODULE_NOT_FOUND`.

This PR makes all six safe to import while still failing loudly (with a clear install hint) the moment a caller actually uses a feature that needs the missing dep.

## Pattern

- **`daily-compliance-report-system.js`, `asana-brain-daily-report-executor.js`, `daily-compliance-reporter.js`** — top-level requires replaced with `getCron()` / `getNodemailer()` / `getAxios()` helpers that memoise the first successful `require` and throw a descriptive error otherwise. Email transporter construction moved from the class constructor into a lazy `getEmailTransporter()` so instantiation no longer depends on `nodemailer`. All call sites (`cron.schedule`, `nodemailer.createTransport`, `axios.post`, `emailTransporter.sendMail`) route through the helpers.
- **`asana-brain-intelligence.js`, `hawkeye-str-analysis-engine.js`** — `axios` was imported but never used. Removed the dead import.
- **`phase1-asana-sync-engine.js`** — four missing deps. Each resolved through a `_tryRequire(name, hint)` helper that falls back to a Proxy stub whose every property access/invocation throws with the install hint. Module loads cleanly; any real call still fails with a meaningful message.

## Tests

Added `tests/reportModuleLoadability.test.ts` (6 tests). Patches `Module._resolveFilename` to make the three optional deps look uninstalled, then asserts every file can be `require()`d without throwing.

- [x] `npx vitest run tests/reportModuleLoadability.test.ts` — 6/6 passing
- [x] `npx vitest run` — **4369/4369** passing (4363 → 4369, 0 regressions)

## What this does NOT do

- Does not execute any `scheduleDaily`, email, or Slack path without deps — those still throw.
- Does not add `node-cron`/`nodemailer`/`axios` to `package.json`. The modules remain scaffolding not imported by the live SPA bundle, so adding the packages would bloat the Netlify bundle for no runtime benefit.

## Regulatory basis

- **Cabinet Res 134/2025 Art.19** — internal controls and the audit chain rely on being able to load any compliance module for inventory and health scans without crashing the host process. Unloadable modules are indistinguishable from deleted modules to an auditor, which muddies the traceability matrix.

https://claude.ai/code/session_01R9Y37tUnmBhH1uF2i3toB8