### PR TITLE
fix: Asana skill-handler — stop losing MLRO replies on non-2xx, cap poison-pill retries (FDL Art.20-21, Cabinet Res 134/2025 Art.19)

### DIFF
--- a/netlify/functions/asana-comment-skill-handler.mts
+++ b/netlify/functions/asana-comment-skill-handler.mts
@@ -34,6 +34,12 @@ const JOBS_STORE = 'asana-skill-jobs';
 const AUDIT_STORE = 'asana-skill-audit';
 const ASANA_API_BASE = 'https://app.asana.com/api/1.0';
 
+// Poison-pill defence: after this many failed attempts, the job is
+// moved to a dead-letter slot and stops being retried every minute.
+// Five gives a ~5-minute window of natural retries for transient
+// Asana outages before we declare the job permanently poisoned.
+const MAX_ATTEMPTS = 5;
+
 interface SkillJob {
   jobId: string;
   storyGid?: string;
@@ -41,6 +47,11 @@ interface SkillJob {
   userGid?: string;
   userName?: string;
   enqueuedAtIso: string;
+  // attempts is undefined on freshly-enqueued jobs. The handler
+  // increments it every time a retryable error is recorded.
+  attempts?: number;
+  lastAttemptIso?: string;
+  lastErrorMessage?: string;
 }
 
 async function writeAudit(payload: Record<string, unknown>): Promise<void> {
@@ -68,11 +79,24 @@ async function asanaGet<T>(path: string, token: string): Promise<T | undefined> 
   return json.data;
 }
 
+interface AsanaPostResult<T> {
+  ok: boolean;
+  status: number;
+  data?: T;
+  errorSnippet?: string;
+}
+
+// Returns an ok/status envelope so callers can distinguish a real
+// transport/API failure (which should trigger a retry + audit entry)
+// from a successful post. The previous helper returned `undefined`
+// on any non-2xx, which the drain loop silently treated as success
+// and then deleted the job — losing the MLRO's reply on any 4xx/5xx
+// or network glitch.
 async function asanaPost<T>(
   path: string,
   token: string,
   body: unknown
-): Promise<T | undefined> {
+): Promise<AsanaPostResult<T>> {
   const res = await fetch(`${ASANA_API_BASE}${path}`, {
     method: 'POST',
     headers: {
@@ -82,9 +106,51 @@ async function asanaPost<T>(
     },
     body: JSON.stringify({ data: body }),
   });
-  if (!res.ok) return undefined;
+  if (!res.ok) {
+    let snippet: string | undefined;
+    try {
+      // Truncate to 240 chars so a chatty Asana error body cannot
+      // blow out the audit store.
+      snippet = (await res.text()).slice(0, 240);
+    } catch { /* snippet is best-effort */ }
+    return { ok: false, status: res.status, errorSnippet: snippet };
+  }
   const json = (await res.json()) as { data?: T };
-  return json.data;
+  return { ok: true, status: res.status, data: json.data };
+}
+
+async function requeueOrDeadLetter(
+  jobsStore: ReturnType<typeof getStore>,
+  key: string,
+  job: SkillJob,
+  errorMessage: string,
+): Promise<'retried' | 'dead_lettered'> {
+  const attempts = (job.attempts ?? 0) + 1;
+  const updated: SkillJob = {
+    ...job,
+    attempts,
+    lastAttemptIso: new Date().toISOString(),
+    lastErrorMessage: errorMessage.slice(0, 240),
+  };
+  if (attempts >= MAX_ATTEMPTS) {
+    // Move to dead-letter; the next cron tick will no longer see it
+    // under the `pending/` prefix that the drain loop lists.
+    const deadKey = `dead-letter/${job.jobId}.json`;
+    await jobsStore.setJSON(deadKey, updated);
+    await jobsStore.delete(key);
+    await writeAudit({
+      event: 'skill_job_dead_lettered',
+      jobId: job.jobId,
+      attempts,
+      lastError: updated.lastErrorMessage,
+      deadKey,
+    });
+    return 'dead_lettered';
+  }
+  // Re-save the job under its existing pending key so the attempts
+  // counter is preserved for the next tick.
+  await jobsStore.setJSON(key, updated);
+  return 'retried';
 }
 
 export default async (): Promise<Response> => {
@@ -112,6 +178,8 @@ export default async (): Promise<Response> => {
   let replied = 0;
   let unknown = 0;
   let errors = 0;
+  let retried = 0;
+  let deadLettered = 0;
 
   // Dynamic import so the cron cold-start stays cheap.
   const routerModule = await import('../../src/services/asanaCommentSkillRouter');
@@ -141,15 +209,26 @@ export default async (): Promise<Response> => {
       if (!routed.ok) {
         // Unknown skill or insufficient args — post a reply
         // explaining the error so the MLRO can fix their
-        // command.
+        // command. If the reply post fails, retry the whole
+        // job so the MLRO is not silently left without feedback.
         if (job.parentTaskGid) {
-          await asanaPost(
+          const postRes = await asanaPost(
             `/tasks/${encodeURIComponent(job.parentTaskGid)}/stories`,
             token,
             {
               text: `Skill error: ${routed.error}\n\nFDL Art.29 — do not share this reply with the subject.`,
             }
           );
+          if (!postRes.ok) {
+            const outcome = await requeueOrDeadLetter(
+              jobsStore, key, job,
+              `unknown-skill reply post failed: ${postRes.status} ${postRes.errorSnippet ?? ''}`,
+            );
+            if (outcome === 'dead_lettered') deadLettered++;
+            else retried++;
+            errors++;
+            continue;
+          }
           unknown++;
         }
         await jobsStore.delete(key);
@@ -157,29 +236,46 @@ export default async (): Promise<Response> => {
         continue;
       }
 
-      // Execute the stub and post the reply.
+      // Execute the stub and post the reply. If Asana rejects the
+      // post, the job is preserved with an incremented attempts
+      // counter — after MAX_ATTEMPTS it is moved to the dead-letter
+      // slot instead of retried forever, which previously pegged
+      // the shared Asana rate limit on any poison-pill job.
       if (routed.invocation && job.parentTaskGid) {
         const execResult = routerModule.buildStubExecution(routed.invocation);
-        await asanaPost(
+        const postRes = await asanaPost(
           `/tasks/${encodeURIComponent(job.parentTaskGid)}/stories`,
           token,
           { text: execResult.reply }
         );
+        if (!postRes.ok) {
+          const outcome = await requeueOrDeadLetter(
+            jobsStore, key, job,
+            `skill reply post failed: ${postRes.status} ${postRes.errorSnippet ?? ''}`,
+          );
+          if (outcome === 'dead_lettered') deadLettered++;
+          else retried++;
+          errors++;
+          continue;
+        }
         replied++;
       }
 
       await jobsStore.delete(key);
       drained++;
     } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const outcome = await requeueOrDeadLetter(jobsStore, key, job, message);
+      if (outcome === 'dead_lettered') deadLettered++;
+      else retried++;
       errors++;
       await writeAudit({
         event: 'skill_job_error',
         jobId: job.jobId,
-        error: err instanceof Error ? err.message : String(err),
+        error: message,
+        attempts: (job.attempts ?? 0) + 1,
+        outcome,
       });
-      // Leave the job in the queue for the next cron tick. If
-      // it fails ≥5 times we'd move it to a dead-letter store,
-      // but that's a future tightening.
     }
   }
 
@@ -189,6 +285,8 @@ export default async (): Promise<Response> => {
     replied,
     unknown,
     errors,
+    retried,
+    deadLettered,
   });
 
   return Response.json({
@@ -197,6 +295,8 @@ export default async (): Promise<Response> => {
     replied,
     unknown,
     errors,
+    retried,
+    deadLettered,
   });
 };
 

--- a/tests/asanaCommentSkillHandlerRetry.test.ts
+++ b/tests/asanaCommentSkillHandlerRetry.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Regression tests for asana-comment-skill-handler.mts retry +
+ * dead-letter semantics.
+ *
+ * The handler is the cron that drains the MLRO slash-command queue
+ * and posts replies back to Asana. Two pre-existing production bugs:
+ *
+ *   1. When `asanaPost` returned a non-2xx response it resolved to
+ *      `undefined`, which the drain loop silently treated as success
+ *      and then DELETED the job. The MLRO's reply was lost on any
+ *      4xx/5xx or network glitch.
+ *
+ *   2. A job that threw inside the drain loop was left in the
+ *      `pending/` queue forever. A single poison-pill job would peg
+ *      the shared Asana rate limit every minute, indefinitely.
+ *
+ * The fixed handler:
+ *   - exposes a typed `AsanaPostResult<T>` envelope from asanaPost
+ *     so non-ok responses are distinguishable from successes;
+ *   - increments an `attempts` counter on every failure and moves
+ *     the job to a `dead-letter/<jobId>.json` slot once attempts
+ *     reach MAX_ATTEMPTS (5), so a broken job costs at most five
+ *     cron ticks of noise.
+ *
+ * These tests drive the handler through a fake `@netlify/blobs`
+ * store and a stubbed `fetch` so we never hit the real API.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Fake @netlify/blobs store
+// ---------------------------------------------------------------------------
+
+interface FakeBlob {
+  data: Map<string, unknown>;
+  listings: string[];
+}
+
+const stores = new Map<string, FakeBlob>();
+
+function getFakeStore(name: string): FakeBlob {
+  let s = stores.get(name);
+  if (!s) {
+    s = { data: new Map(), listings: [] };
+    stores.set(name, s);
+  }
+  return s;
+}
+
+vi.mock('@netlify/blobs', () => ({
+  getStore: (name: string) => {
+    const s = getFakeStore(name);
+    return {
+      list: async ({ prefix }: { prefix: string }) => ({
+        blobs: [...s.data.keys()]
+          .filter((k) => k.startsWith(prefix))
+          .map((k) => ({ key: k })),
+      }),
+      get: async (key: string, _opts: unknown) => s.data.get(key) ?? null,
+      setJSON: async (key: string, value: unknown) => {
+        s.data.set(key, value);
+        s.listings.push(key);
+      },
+      delete: async (key: string) => {
+        s.data.delete(key);
+      },
+    };
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Stubbed fetch — responses are queued per URL+method.
+// ---------------------------------------------------------------------------
+
+type FakeResponse = { status: number; body: unknown };
+const fetchQueue: FakeResponse[] = [];
+const fetchCalls: Array<{ url: string; method: string; body?: string }> = [];
+
+beforeEach(() => {
+  stores.clear();
+  fetchQueue.length = 0;
+  fetchCalls.length = 0;
+  vi.stubGlobal('fetch', async (url: string, init: RequestInit = {}) => {
+    fetchCalls.push({
+      url,
+      method: init.method ?? 'GET',
+      body: init.body as string | undefined,
+    });
+    const res = fetchQueue.shift() ?? { status: 500, body: { error: 'queue-empty' } };
+    return {
+      ok: res.status >= 200 && res.status < 300,
+      status: res.status,
+      async json() { return res.body; },
+      async text() { return typeof res.body === 'string' ? res.body : JSON.stringify(res.body); },
+    };
+  });
+  process.env.ASANA_API_TOKEN = 'test-token';
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.ASANA_API_TOKEN;
+});
+
+async function runHandler() {
+  // Re-import fresh so the module picks up the new fetch stub.
+  const mod = await import('../netlify/functions/asana-comment-skill-handler.mts?t=' + Date.now());
+  return (mod as unknown as { default: () => Promise<Response> }).default();
+}
+
+function enqueuePendingJob(jobId: string, overrides: Record<string, unknown> = {}) {
+  const jobs = getFakeStore('asana-skill-jobs');
+  jobs.data.set(`pending/${jobId}.json`, {
+    jobId,
+    storyGid: `story-${jobId}`,
+    parentTaskGid: `task-${jobId}`,
+    enqueuedAtIso: new Date().toISOString(),
+    ...overrides,
+  });
+}
+
+describe('asana-comment-skill-handler — non-2xx reply preserves the job', () => {
+  it('does NOT delete a job when Asana returns 500 on the reply post', async () => {
+    enqueuePendingJob('j1');
+    // First call: GET story → 200 with a real slash-command body.
+    fetchQueue.push({ status: 200, body: { data: { text: '/screen ACME LLC' } } });
+    // Second call: POST reply → 500.
+    fetchQueue.push({ status: 500, body: 'asana is down' });
+
+    const res = await runHandler();
+    const body = (await res.json()) as Record<string, number>;
+
+    expect(body.replied).toBe(0);
+    expect(body.errors).toBe(1);
+    // Job is STILL in pending (not deleted) so it will retry.
+    const jobs = getFakeStore('asana-skill-jobs');
+    expect(jobs.data.has('pending/j1.json')).toBe(true);
+    const kept = jobs.data.get('pending/j1.json') as { attempts?: number };
+    expect(kept.attempts).toBe(1);
+  });
+});
+
+describe('asana-comment-skill-handler — poison-pill dead-letter', () => {
+  it('moves a job to dead-letter/ after MAX_ATTEMPTS (5) failures', async () => {
+    // Seed the job with attempts = 4 so one more failure trips the
+    // MAX_ATTEMPTS threshold.
+    enqueuePendingJob('poison', { attempts: 4 });
+    // GET story → 200, POST → 500.
+    fetchQueue.push({ status: 200, body: { data: { text: '/screen X' } } });
+    fetchQueue.push({ status: 500, body: 'still down' });
+
+    const res = await runHandler();
+    const body = (await res.json()) as Record<string, number>;
+
+    const jobs = getFakeStore('asana-skill-jobs');
+    expect(jobs.data.has('pending/poison.json')).toBe(false);
+    expect(jobs.data.has('dead-letter/poison.json')).toBe(true);
+    expect(body.deadLettered).toBe(1);
+    const dl = jobs.data.get('dead-letter/poison.json') as { attempts: number };
+    expect(dl.attempts).toBe(5);
+  });
+
+  it('keeps retrying for attempts < MAX_ATTEMPTS', async () => {
+    enqueuePendingJob('retry', { attempts: 2 });
+    fetchQueue.push({ status: 200, body: { data: { text: '/screen X' } } });
+    fetchQueue.push({ status: 500, body: 'still down' });
+
+    const res = await runHandler();
+    const body = (await res.json()) as Record<string, number>;
+
+    const jobs = getFakeStore('asana-skill-jobs');
+    expect(jobs.data.has('dead-letter/retry.json')).toBe(false);
+    expect(body.retried).toBe(1);
+    const job = jobs.data.get('pending/retry.json') as { attempts: number; lastErrorMessage?: string };
+    expect(job.attempts).toBe(3);
+    expect(job.lastErrorMessage).toContain('500');
+  });
+});
+
+describe('asana-comment-skill-handler — happy path still deletes the job', () => {
+  it('deletes the pending job after a successful reply post', async () => {
+    enqueuePendingJob('ok');
+    fetchQueue.push({ status: 200, body: { data: { text: '/screen ACME LLC' } } });
+    fetchQueue.push({ status: 200, body: { data: { gid: 'story-reply-1' } } });
+
+    const res = await runHandler();
+    const body = (await res.json()) as Record<string, number>;
+
+    expect(body.replied).toBe(1);
+    expect(body.errors).toBe(0);
+    const jobs = getFakeStore('asana-skill-jobs');
+    expect(jobs.data.has('pending/ok.json')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Round-5 fix — **live production code path** this time, not scaffolding. Two real bugs in `netlify/functions/asana-comment-skill-handler.mts` (the cron that drains the MLRO slash-command queue every minute):

### Bug 1 — MLRO replies silently lost on any non-2xx

`asanaPost` returned `undefined` on any non-2xx response; the drain loop treated `undefined` identically to success. A 429 (rate-limited), 500 (outage), or 4xx auth glitch → the handler DELETED the job and the MLRO got no reply, no signal. Fixed with a typed `AsanaPostResult<T>` envelope (`ok`, `status`, `data`, truncated `errorSnippet`). The loop now distinguishes failure from success and preserves the job on failure.

### Bug 2 — Poison-pill jobs retry every minute forever

Jobs that threw inside the drain loop were left in `pending/` indefinitely. A single malformed story or persistent Asana auth error would fire the same fetch+post chain every cron tick, pegging the shared Asana rate-limit quota. The old comment acknowledged this as "a future tightening"; this PR is that tightening.

Fixed by tracking an `attempts` counter per `SkillJob`. Any failure path (thrown exception, non-2xx on happy-path reply, non-2xx on unknown-skill reply) calls a shared `requeueOrDeadLetter(jobsStore, key, job, errorMessage)` helper that:
- increments `attempts`, stamps `lastAttemptIso` + `lastErrorMessage` (truncated to 240 chars);
- if `attempts < MAX_ATTEMPTS (5)`, re-saves under the existing `pending/` key for the next tick;
- once `attempts ≥ 5`, moves to `dead-letter/<jobId>.json` and deletes from `pending/` so the drain loop stops seeing it.

Five attempts ≈ 5-minute natural-retry window for transient Asana outages.

### Response surface
JSON response and audit entry both now include `retried` and `deadLettered` counters alongside the existing `drained`, `replied`, `unknown`, `errors` counts.

## Tests

Added `tests/asanaCommentSkillHandlerRetry.test.ts` (4 tests) using a fake `@netlify/blobs` store and a stubbed fetch queue:
- Non-2xx reply post does NOT delete the job; attempts increments to 1.
- Job with `attempts=4` + failed post crosses the threshold → lands in `dead-letter/`, removed from `pending/`.
- Job with `attempts=2` + failed post → `pending/` with `attempts=3` and error message captured.
- Happy path still deletes after successful reply.

- [x] `npx vitest run tests/asanaCommentSkillHandlerRetry.test.ts` — 4/4 passing
- [x] `npx vitest run` — **4373/4373** passing (4369 → 4373)

## Regulatory basis

- **FDL No.10/2025 Art.20-21** — MLRO duty of care; silently dropped replies break the audit chain.
- **FDL No.10/2025 Art.29** — dead-lettering is the right failure mode; a noisy retry loop could surface subject identifiers in unexpected channels.
- **Cabinet Res 134/2025 Art.19** — `retried`/`deadLettered` metrics persisted to `asana-skill-audit` store on every tick for auditable internal review.

https://claude.ai/code/session_01R9Y37tUnmBhH1uF2i3toB8