### PR TITLE
fix: Asana skill-handler — complete the non-2xx-silent-drop fix on the GET path (FDL Art.20-21, Cabinet Res 134/2025 Art.19)

### DIFF
--- a/netlify/functions/asana-comment-skill-handler.mts
+++ b/netlify/functions/asana-comment-skill-handler.mts
@@ -67,16 +67,42 @@ async function writeAudit(payload: Record<string, unknown>): Promise<void> {
   }
 }
 
-async function asanaGet<T>(path: string, token: string): Promise<T | undefined> {
+interface AsanaGetResult<T> {
+  ok: boolean;
+  status: number;
+  data?: T;
+  errorSnippet?: string;
+  // `notFound` is true on 404. The drain loop treats that as "the
+  // story genuinely no longer exists" (MLRO deleted the comment,
+  // the task was removed, etc.) and drops the job. Any other !ok
+  // status (429/5xx/auth glitch) must NOT drop the job — the
+  // previous implementation returned plain `undefined` on every
+  // non-2xx, which made transient outages look identical to
+  // permanent deletion and silently lost MLRO commands.
+  notFound?: boolean;
+}
+
+async function asanaGet<T>(path: string, token: string): Promise<AsanaGetResult<T>> {
   const res = await fetch(`${ASANA_API_BASE}${path}`, {
     headers: {
       Authorization: `Bearer ${token}`,
       Accept: 'application/json',
     },
   });
-  if (!res.ok) return undefined;
+  if (!res.ok) {
+    let snippet: string | undefined;
+    try {
+      snippet = (await res.text()).slice(0, 240);
+    } catch { /* best-effort */ }
+    return {
+      ok: false,
+      status: res.status,
+      notFound: res.status === 404,
+      errorSnippet: snippet,
+    };
+  }
   const json = (await res.json()) as { data?: T };
-  return json.data;
+  return { ok: true, status: res.status, data: json.data };
 }
 
 interface AsanaPostResult<T> {
@@ -187,11 +213,35 @@ export default async (): Promise<Response> => {
   for (const { key, job } of jobs) {
     try {
       // Fetch the story body from Asana.
-      const story = await asanaGet<{ text?: string; created_by?: { name?: string } }>(
+      const storyRes = await asanaGet<{ text?: string; created_by?: { name?: string } }>(
         `/stories/${encodeURIComponent(job.storyGid!)}?opt_fields=text,created_by.name,resource_subtype`,
         token
       );
+      if (!storyRes.ok) {
+        if (storyRes.notFound) {
+          // 404 = story genuinely gone (comment deleted, task
+          // removed). Safe to drop the job permanently.
+          await jobsStore.delete(key);
+          drained++;
+          continue;
+        }
+        // Any other non-2xx (429, 5xx, auth glitch) is transient —
+        // bump attempts and retry on the next tick so a bad minute
+        // at Asana does not silently lose MLRO commands.
+        const outcome = await requeueOrDeadLetter(
+          jobsStore, key, job,
+          `story GET failed: ${storyRes.status} ${storyRes.errorSnippet ?? ''}`,
+        );
+        if (outcome === 'dead_lettered') deadLettered++;
+        else retried++;
+        errors++;
+        continue;
+      }
+      const story = storyRes.data;
       if (!story?.text) {
+        // Story exists but has no text (rare Asana shape — e.g. a
+        // system-generated story with `html_text` only). Nothing to
+        // route; drop the job.
         await jobsStore.delete(key);
         drained++;
         continue;

--- a/tests/asanaCommentSkillHandlerRetry.test.ts
+++ b/tests/asanaCommentSkillHandlerRetry.test.ts
@@ -192,3 +192,52 @@ describe('asana-comment-skill-handler — happy path still deletes the job', () 
     expect(jobs.data.has('pending/ok.json')).toBe(false);
   });
 });
+
+describe('asana-comment-skill-handler — transient GET failure preserves the job', () => {
+  it('retries (not drops) when the story GET returns 500', async () => {
+    enqueuePendingJob('get-500');
+    // First call: GET story → 500. No POST queued because we never
+    // reach it.
+    fetchQueue.push({ status: 500, body: 'asana is down' });
+
+    const res = await runHandler();
+    const body = (await res.json()) as Record<string, number>;
+
+    expect(body.drained).toBe(0);
+    expect(body.errors).toBe(1);
+    expect(body.retried).toBe(1);
+    const jobs = getFakeStore('asana-skill-jobs');
+    // Job must still be in pending/, not silently deleted.
+    expect(jobs.data.has('pending/get-500.json')).toBe(true);
+    const kept = jobs.data.get('pending/get-500.json') as { attempts?: number; lastErrorMessage?: string };
+    expect(kept.attempts).toBe(1);
+    expect(kept.lastErrorMessage).toContain('500');
+  });
+
+  it('retries on 429 (rate limit) as well', async () => {
+    enqueuePendingJob('get-429');
+    fetchQueue.push({ status: 429, body: 'slow down' });
+
+    await runHandler();
+
+    const jobs = getFakeStore('asana-skill-jobs');
+    expect(jobs.data.has('pending/get-429.json')).toBe(true);
+    expect(jobs.data.has('dead-letter/get-429.json')).toBe(false);
+  });
+
+  it('drops the job on 404 (story genuinely gone)', async () => {
+    enqueuePendingJob('get-404');
+    fetchQueue.push({ status: 404, body: { errors: [{ message: 'not found' }] } });
+
+    const res = await runHandler();
+    const body = (await res.json()) as Record<string, number>;
+
+    expect(body.drained).toBe(1);
+    expect(body.errors).toBe(0);
+    expect(body.retried).toBe(0);
+    const jobs = getFakeStore('asana-skill-jobs');
+    // 404 = permanent deletion, not retry.
+    expect(jobs.data.has('pending/get-404.json')).toBe(false);
+    expect(jobs.data.has('dead-letter/get-404.json')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Round 6 — completes the fix started in #225. Same bug class was still present on the GET path of `asana-comment-skill-handler.mts`.

`asanaGet` returned plain `undefined` on every non-2xx response, and the drain loop treated that identically to "story has no text" → deleted the job. So a 429, 500, or auth glitch during the story fetch had the same effect as the MLRO deleting their own comment: the slash command was silently discarded.

## Fix

`asanaGet` now returns an `AsanaGetResult<T>` envelope (`ok`, `status`, `data`, `notFound`, `errorSnippet`). The drain loop now:

- **404** → drops the job (story genuinely gone; comment or task deleted).
- **429 / 5xx / other non-2xx** → routes through `requeueOrDeadLetter()` so the job is preserved with `attempts++`, and eventually moves to `dead-letter/<jobId>.json` after MAX_ATTEMPTS (5) ticks — same retry contract the POST path uses.
- **200 with no `text` field** → still drops (system-generated stories with `html_text` only).

## Tests

Extended `tests/asanaCommentSkillHandlerRetry.test.ts` with 3 new tests (7 total):
- 500 on story GET → job stays in `pending/` with `attempts=1` and `lastErrorMessage` captured.
- 429 on story GET → same outcome.
- 404 on story GET → job is dropped (permanent deletion).

- [x] `npx vitest run tests/asanaCommentSkillHandlerRetry.test.ts` — 7/7 passing
- [x] `npx vitest run` — **4376/4376** passing (4373 → 4376)

## Regulatory basis

- **FDL No.10/2025 Art.20-21** — an MLRO slash command dropped because Asana had a bad minute is the same audit-chain gap as a reply that never landed.
- **Cabinet Res 134/2025 Art.19** — dead-letter entries + the `retried`/`deadLettered` counters give the MLRO and auditor a first-class view of every command that was parked, not just the ones that succeeded.

https://claude.ai/code/session_01R9Y37tUnmBhH1uF2i3toB8