### PR TITLE
fix: security — close path-normalisation bypass in live Asana proxy (FDL Art.20-21, ISO 27001 A.8.10)

### DIFF
--- a/netlify/functions/asana-proxy.mts
+++ b/netlify/functions/asana-proxy.mts
@@ -32,6 +32,10 @@ import { authenticate } from './middleware/auth.mts';
 import { checkRateLimit } from './middleware/rate-limit.mts';
 
 const ASANA_BASE_URL = 'https://app.asana.com/api/1.0';
+// Pathname of ASANA_BASE_URL, cached. Used by the normalisation-bypass
+// defence below to confirm that the URL parser did not collapse any
+// "../" segments after the allowlist check passed.
+const ASANA_BASE_PATH = new URL(ASANA_BASE_URL).pathname;
 const MAX_BODY_BYTES = 256 * 1024;
 const FETCH_TIMEOUT_MS = 30_000;
 
@@ -128,6 +132,25 @@ export default async (req: Request, context: Context): Promise<Response> => {
     return badRequest(`Path ${path} not in allowlist.`);
   }
 
+  // Defence in depth against path-normalisation bypass.
+  //
+  // The allowlist regexes use `[^/]+` segments, which happily match
+  // `..` or its URL-encoded form `%2e%2e`. The WHATWG URL parser
+  // collapses those segments when building the upstream URL, so e.g.
+  // `/tasks/..` slips past `/^\/tasks\/[^/]+$/` and then normalises
+  // to the API root `/api/1.0/` — an endpoint that was never
+  // allowlisted. Refuse any literal `..` sequence and any `%2e%2e`
+  // encoding before we hand the string to `new URL()`.
+  const lowered = path.toLowerCase();
+  if (
+    path.includes('..') ||
+    lowered.includes('%2e%2e') ||
+    lowered.includes('%2e.') ||
+    lowered.includes('.%2e')
+  ) {
+    return badRequest('Path must not contain parent-directory references.');
+  }
+
   // Build the upstream URL. We use new URL() so any caller-supplied
   // query smuggling via `path` is normalised.
   let target: URL;
@@ -138,6 +161,14 @@ export default async (req: Request, context: Context): Promise<Response> => {
   }
   if (target.origin !== new URL(ASANA_BASE_URL).origin) {
     return badRequest('Path must not change origin.');
+  }
+  // If the URL parser changed the pathname at all (e.g. resolved a
+  // normalisation we missed above, or collapsed consecutive slashes),
+  // refuse the request rather than forward to an endpoint the
+  // allowlist never vetted.
+  const expectedPath = ASANA_BASE_PATH + path.split('?')[0].split('#')[0];
+  if (target.pathname !== expectedPath) {
+    return badRequest('Path normalisation mismatch; refusing to forward.');
   }
 
   const upstreamHeaders: Record<string, string> = {

--- a/tests/asanaProxyPathTraversal.test.ts
+++ b/tests/asanaProxyPathTraversal.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Security regression tests for the asana-proxy Netlify function.
+ *
+ * Catches the path-normalisation bypass where `/tasks/..` (or its
+ * URL-encoded form `/tasks/%2e%2e`) passed the `/^\/tasks\/[^/]+$/`
+ * allowlist regex because `..` is non-slash, but then got collapsed
+ * by `new URL()` into `/api/1.0/` — a pathname that was never
+ * allowlisted. The proxy would then happily forward the request to
+ * Asana.
+ *
+ * The fix refuses any literal `..` or `%2e%2e` sequence in the path,
+ * and also verifies that `new URL()` did not change the pathname
+ * before forwarding. These tests assert both defences, plus the
+ * happy path, without ever letting a real Asana fetch occur.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const AUTH_TOKEN = 'a'.repeat(32);
+const ASANA_TOKEN = 'b'.repeat(40);
+
+const fetchCalls: Array<{ url: string; method: string }> = [];
+
+beforeEach(() => {
+  fetchCalls.length = 0;
+  process.env.HAWKEYE_BRAIN_TOKEN = AUTH_TOKEN;
+  process.env.ASANA_API_TOKEN = ASANA_TOKEN;
+  // Any upstream fetch succeeds with an empty data envelope. If the
+  // defence is broken and we forward a rejected path, the fetchCalls
+  // array will capture it and the assertion will fail.
+  vi.stubGlobal('fetch', async (url: string | URL, init: RequestInit = {}) => {
+    fetchCalls.push({
+      url: typeof url === 'string' ? url : url.toString(),
+      method: init.method ?? 'GET',
+    });
+    return {
+      ok: true, status: 200,
+      async text() { return '{"data":{}}'; },
+    };
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.HAWKEYE_BRAIN_TOKEN;
+  delete process.env.ASANA_API_TOKEN;
+});
+
+async function callProxy(body: unknown): Promise<Response> {
+  const mod = await import('../netlify/functions/asana-proxy.mts?t=' + Date.now());
+  const handler = (mod as unknown as { default: (req: Request, ctx: unknown) => Promise<Response> }).default;
+  const req = new Request('https://example.test/api/asana/proxy', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${AUTH_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  return handler(req, { ip: '127.0.0.1' });
+}
+
+describe('asana-proxy — path normalisation bypass defences', () => {
+  it('rejects /tasks/.. before forwarding', async () => {
+    const res = await callProxy({ method: 'GET', path: '/tasks/..' });
+    expect(res.status).toBe(400);
+    expect(fetchCalls.length).toBe(0);
+    const body = (await res.json()) as { error: string };
+    expect(body.error.toLowerCase()).toContain('parent-directory');
+  });
+
+  it('rejects URL-encoded dot-dot /tasks/%2e%2e', async () => {
+    const res = await callProxy({ method: 'GET', path: '/tasks/%2e%2e' });
+    expect(res.status).toBe(400);
+    expect(fetchCalls.length).toBe(0);
+  });
+
+  it('rejects a mixed-encoding dot-dot /tasks/.%2e', async () => {
+    const res = await callProxy({ method: 'GET', path: '/tasks/.%2e' });
+    expect(res.status).toBe(400);
+    expect(fetchCalls.length).toBe(0);
+  });
+
+  it('rejects uppercase encoded /tasks/%2E%2E', async () => {
+    const res = await callProxy({ method: 'GET', path: '/tasks/%2E%2E' });
+    expect(res.status).toBe(400);
+    expect(fetchCalls.length).toBe(0);
+  });
+
+  it('still allows a legitimate task GET', async () => {
+    const res = await callProxy({ method: 'GET', path: '/tasks/1111' });
+    expect(res.status).toBe(200);
+    expect(fetchCalls.length).toBe(1);
+    expect(fetchCalls[0].url).toBe('https://app.asana.com/api/1.0/tasks/1111');
+  });
+
+  it('still allows a POST with a body', async () => {
+    const res = await callProxy({
+      method: 'POST',
+      path: '/tasks',
+      body: { data: { name: 'x', workspace: 'ws1' } },
+    });
+    expect(res.status).toBe(200);
+    expect(fetchCalls.length).toBe(1);
+    expect(fetchCalls[0].url).toBe('https://app.asana.com/api/1.0/tasks');
+    expect(fetchCalls[0].method).toBe('POST');
+  });
+
+  it('rejects a path not in the allowlist (baseline)', async () => {
+    const res = await callProxy({ method: 'GET', path: '/webhooks' });
+    expect(res.status).toBe(400);
+    expect(fetchCalls.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Security fix in live code — **path-normalisation bypass** in `netlify/functions/asana-proxy.mts`.

### The bug

Every allowlist regex uses `[^/]+` for variable segments (e.g. `/^\/tasks\/[^/]+$/`). `..` is valid for `[^/]+`, so `/tasks/..` (plus `/tasks/%2e%2e`, `/tasks/.%2e`, upper/lower-case variants) passed `isAllowedPath()`. The proxy then built the upstream URL with `new URL(ASANA_BASE_URL + path)`; the WHATWG URL parser collapsed `/api/1.0/tasks/..` into `/api/1.0/` — an endpoint never allowlisted. The proxy forwarded the request to the Asana API root **with the real `ASANA_API_TOKEN` PAT attached**.

Damage is modest today (Asana API root is not a juicy admin surface under PAT auth), but the principle matters: any future allowlist path with deeper nesting could be bypassed the same way, and the current behavior violates ISO/IEC 27001 A.8.10 "data separation" and FDL Art.20-21 "CO duty of care" by letting a compromised browser reach endpoints the CO never vetted.

### Fix — two independent defences

1. **Input-layer rejection** — refuse any `path` containing `..`, `%2e%2e`, `%2e.`, or `.%2e` (case-insensitive). Catches the bypass before the URL parser ever sees the string.
2. **Post-normalisation verification** — after `new URL(...)`, compare `target.pathname` to `ASANA_BASE_PATH + path.split('?')[0]`. If they differ, the parser collapsed something we missed (consecutive `/`, unknown encodings, future parser bugs) → refuse.

Either defence blocks today's bypass; having both is belt-and-braces.

## Tests

`tests/asanaProxyPathTraversal.test.ts` (7 tests):

- `/tasks/..` → 400, never hits fetch
- `/tasks/%2e%2e` → 400
- `/tasks/.%2e` → 400
- `/tasks/%2E%2E` → 400 (upper-case)
- `/tasks/1111` → 200, forwards to correct URL
- POST `/tasks` → 200, forwards body
- `/webhooks` (baseline, not in allowlist) → 400

Verified that reverting the fix makes exactly the four bypass tests fail, proving the tests catch the bug.

- [x] `npx vitest run tests/asanaProxyPathTraversal.test.ts` — 7/7 passing
- [x] `npx vitest run` — **4383/4383** passing (4376 → 4383)

## Regulatory basis

- **FDL No.10/2025 Art.20-21** — CO duty of care; token scope bounded by the allowlist.
- **ISO/IEC 27001 A.8.10** — data separation; no unvetted endpoint forwarding.
- **Cabinet Res 134/2025 Art.19** — auditable internal review; rejection reason emitted as 400 so auditors can trace every blocked request.

https://claude.ai/code/session_01R9Y37tUnmBhH1uF2i3toB8