### PR TITLE
fix: security — rate-limit CAS conflict detected as success, attackers could race past cap (FDL Art.20-21, Cabinet Res 134/2025 Art.19)

### DIFF
--- a/netlify/functions/middleware/rate-limit.mts
+++ b/netlify/functions/middleware/rate-limit.mts
@@ -78,7 +78,20 @@ async function setEntryCas(key: string, entry: RateLimitEntry, etag: string | nu
     // already wrote a newer value, the write fails and we retry.
     const opts: any = etag ? { onlyIfMatch: etag } : { onlyIfNew: true };
     const ok: any = await (store as any).setJSON(key, entry, opts);
-    // Older SDKs return void on success and throw on conflict.
+    // Modern @netlify/blobs returns `{ modified: boolean, etag?: string }`
+    // and signals a CAS conflict with `modified: false` rather than a
+    // thrown error. The previous `ok !== false` check treated that
+    // object as a successful write, silently defeating the CAS retry
+    // loop — under concurrency two lambdas reading the same etag both
+    // saw "wrote = true" and we persisted only one of their writes, so
+    // rate-limit counters under-counted and attackers could exceed
+    // the documented rate. Older SDKs returned plain `undefined` on
+    // success; we treat that as success for back-compat but require an
+    // explicit non-false `modified` for the modern shape.
+    if (ok == null) return true; // legacy SDK: no return value = success
+    if (typeof ok === 'object' && 'modified' in ok) {
+      return ok.modified === true;
+    }
     return ok !== false;
   } catch {
     memoryStore.set(key, entry);

--- a/tests/rateLimitCasConflict.test.ts
+++ b/tests/rateLimitCasConflict.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Regression tests for the CAS-conflict detection in the persistent
+ * rate-limit middleware (netlify/functions/middleware/rate-limit.mts).
+ *
+ * Previous bug: @netlify/blobs `setJSON(..., { onlyIfMatch })` returns
+ * `{ modified: false }` when the CAS precondition fails, instead of
+ * throwing. The middleware's helper checked `ok !== false`, which
+ * treats the `{ modified: false }` object as truthy and hence as a
+ * successful write. The CAS retry loop therefore exited on the first
+ * attempt even when the write did not persist — so two lambdas
+ * racing to update the same rate-limit counter could each decide
+ * they had written `count=5`, and only one of the two `count++`
+ * increments actually landed. Attackers could exceed the documented
+ * rate.
+ *
+ * The fix inspects `ok?.modified` and only returns success when the
+ * SDK reports `modified: true` (or when a legacy SDK returns
+ * `undefined`). These tests exercise both branches without touching
+ * the real Netlify Blobs service.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+interface StubStore {
+  getWithMetadata: (key: string, opts: unknown) => Promise<unknown>;
+  setJSON: (key: string, value: unknown, opts: unknown) => Promise<unknown>;
+}
+
+let stubStore: StubStore;
+vi.mock('@netlify/blobs', () => ({
+  getStore: () => stubStore,
+}));
+
+async function callCheckRateLimit(clientIp = '1.2.3.4') {
+  // Import fresh each call so the module-level `memoryStore` in the
+  // middleware starts empty for every test.
+  const mod = await import(
+    '../netlify/functions/middleware/rate-limit.mts?t=' + Date.now()
+  );
+  const req = new Request('https://example.test/x', { method: 'POST' });
+  return mod.checkRateLimit(req, {
+    clientIp, namespace: 'test-ns', max: 10, windowMs: 60_000,
+  });
+}
+
+beforeEach(() => {
+  // Default stub — in-memory, no CAS conflicts.
+  const data = new Map<string, { entry: unknown; etag: string }>();
+  let etagCounter = 0;
+  stubStore = {
+    async getWithMetadata(key) {
+      const v = data.get(key);
+      if (!v) return null;
+      return { data: v.entry, etag: v.etag };
+    },
+    async setJSON(key, value, opts: any) {
+      // Mimic the modern SDK: enforce onlyIfMatch; return
+      // { modified: true/false, etag }.
+      const existing = data.get(key);
+      if (opts?.onlyIfMatch) {
+        if (!existing || existing.etag !== opts.onlyIfMatch) {
+          return { modified: false };
+        }
+      }
+      if (opts?.onlyIfNew) {
+        if (existing) return { modified: false };
+      }
+      const etag = 'etag-' + ++etagCounter;
+      data.set(key, { entry: value, etag });
+      return { modified: true, etag };
+    },
+  };
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('rate-limit — CAS success path', () => {
+  it('passes requests under the limit', async () => {
+    const r1 = await callCheckRateLimit();
+    expect(r1).toBeNull();
+    const r2 = await callCheckRateLimit();
+    expect(r2).toBeNull();
+  });
+});
+
+describe('rate-limit — CAS conflict is detected and retried', () => {
+  it('detects `{ modified: false }` as conflict and retries', async () => {
+    // Arrange: wrap setJSON so the FIRST attempt returns modified:false
+    // (simulating a concurrent writer). The retry should succeed.
+    const data = new Map<string, { entry: unknown; etag: string }>();
+    let callCount = 0;
+    stubStore = {
+      async getWithMetadata(key) {
+        const v = data.get(key);
+        if (!v) return null;
+        return { data: v.entry, etag: v.etag };
+      },
+      async setJSON(key, value) {
+        callCount++;
+        if (callCount === 1) {
+          // CAS conflict on first attempt.
+          return { modified: false };
+        }
+        data.set(key, { entry: value, etag: 'etag-ok' });
+        return { modified: true, etag: 'etag-ok' };
+      },
+    };
+
+    const res = await callCheckRateLimit('9.9.9.9');
+    expect(res).toBeNull(); // eventually allowed
+    expect(callCount).toBeGreaterThan(1); // proved the retry ran
+  });
+
+  it('fails closed with 429 when CAS loses four times in a row', async () => {
+    let callCount = 0;
+    stubStore = {
+      async getWithMetadata() {
+        return { data: null, etag: null };
+      },
+      async setJSON() {
+        callCount++;
+        return { modified: false }; // always conflict
+      },
+    };
+
+    const res = await callCheckRateLimit('8.8.8.8');
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(429);
+    // Must have attempted the configured 4 retries before giving up.
+    expect(callCount).toBe(4);
+  });
+});
+
+describe('rate-limit — legacy SDK compatibility (void return)', () => {
+  it('treats `undefined` from setJSON as success', async () => {
+    const data = new Map<string, { entry: unknown; etag: string }>();
+    stubStore = {
+      async getWithMetadata(key) {
+        const v = data.get(key);
+        return v ? { data: v.entry, etag: v.etag } : null;
+      },
+      async setJSON(key, value) {
+        data.set(key, { entry: value, etag: 'legacy' });
+        return undefined;
+      },
+    };
+    const res = await callCheckRateLimit('7.7.7.7');
+    expect(res).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Security fix in live shared middleware. **Rate-limit CAS conflicts were treated as successful writes**, silently defeating the documented concurrency defence.

`netlify/functions/middleware/rate-limit.mts` is the persistent per-IP / per-tenant limiter used by every authenticated endpoint (Asana proxy, AI proxy, approvals, webhooks, orchestrator…). It uses `@netlify/blobs` `setJSON(..., { onlyIfMatch })` inside a 4-attempt retry loop so two concurrent lambdas can't both increment from the same snapshot and silently persist only one of the two writes.

### The bug

Modern `@netlify/blobs` (shipped in this repo) returns `{ modified: boolean, etag?: string }` from `setJSON` and signals a CAS conflict with `modified: false` — **not** a thrown error. The success check was:

```ts
const ok = await store.setJSON(key, entry, opts);
return ok !== false;
```

`{ modified: false } !== false` → `true`, so CAS conflicts were treated as successful writes. The outer retry loop exited on the first attempt, the counter value never persisted, and two concurrent requests each "incremented to count=5" while the store held at most one of those writes.

**Effect:** under concurrency the counter under-counts. An attacker spraying requests across Netlify-Lambda instances could exceed the documented caps (100/15min general, 5/15min auth, 10/15min sensitive) by roughly the number of concurrent instances. The `// prevents the racy count++ / setJSON pattern` comment no longer matched runtime.

### Fix

Inspect the return shape explicitly:
- `ok == null` → legacy SDK returning void = success (back-compat).
- Object with `modified` field → success iff `modified === true`; anything else is a CAS conflict and the outer loop must retry.
- Any other shape → fall back to `ok !== false` so we never regress on unknown SDK versions.

### Tests

`tests/rateLimitCasConflict.test.ts` (4 tests) with a fake Blobs store that scripts CAS outcomes:

- Happy path — `modified: true` → allowed.
- First attempt `modified: false`, second succeeds → asserts `setJSON` called >1 time (proves retry ran).
- All 4 attempts `modified: false` → fails closed with **429**, `setJSON` called exactly 4 times.
- Legacy SDK returning `undefined` → treated as success.

Verified that reverting the fix leaves only the first and last tests passing — the two conflict-detection tests fail, directly proving the bug.

- [x] `npx vitest run tests/rateLimitCasConflict.test.ts` — 4/4 passing
- [x] `npx vitest run` — **4387/4387** passing (4383 → 4387)

## Regulatory basis

- **FDL No.10/2025 Art.20-21** — CO duty of care; documented rate caps must hold end-to-end.
- **Cabinet Res 134/2025 Art.19** — rate-limit rejections are the audit signal that catches credential-stuffing and enumeration; undercounting breaks that chain.

https://claude.ai/code/session_01R9Y37tUnmBhH1uF2i3toB8