### PR TITLE
fix: four-eyes race — approver votes silently lost under concurrency (FDL Art.20-21, Cabinet Res 134/2025 Art.19)

### DIFF
--- a/netlify/functions/approvals.mts
+++ b/netlify/functions/approvals.mts
@@ -243,6 +243,13 @@ interface RecordDecisionResult {
   cooldownPendingUntilIso?: string;
   /** True when the record changed and should be persisted. */
   shouldPersist: boolean;
+  /**
+   * Set when the record was meant to be persisted but every CAS
+   * attempt lost to a concurrent writer. The HTTP layer surfaces
+   * this as 503 so the client knows their vote did not land and
+   * must be retried — never as a silent success.
+   */
+  casExhausted?: boolean;
 }
 
 interface ApplyDecisionOptions {
@@ -346,25 +353,108 @@ async function recordDecision(
   nowMs: number = Date.now(),
 ): Promise<RecordDecisionResult> {
   const approvalStore = getStore(APPROVAL_STORE);
-  const existing = (await approvalStore.get(eventId, { type: "json" })) as ApprovalEntry | null;
-  const rec: ApprovalEntry = existing ?? {
-    eventId,
-    approvals: [],
-    rejections: [],
-    status: "pending",
-  };
-
-  const result = applyDecisionToRecord(rec, actor, verdict, note, {
+  const options: ApplyDecisionOptions = {
     soloMode: isSoloMlroModeEnabled(),
     soloCooldownHours: getSoloMlroCooldownHours(),
     nowMs,
-  });
+  };
 
-  if (result.shouldPersist) {
-    await approvalStore.setJSON(eventId, result.rec);
+  // Read-modify-write is done inside a CAS retry loop. Without this,
+  // two concurrent votes on the same eventId both read the same
+  // {approvals: []} snapshot, each compute their own new record, and
+  // the second `setJSON` silently overwrites the first — one of the
+  // votes (approval OR rejection) is lost. That is a four-eyes
+  // integrity bug: an approver's "approve" can be erased by a racing
+  // "reject", or vice versa. CAS via onlyIfMatch forces the second
+  // writer to re-read the fresh record and re-apply their vote on
+  // top of it, so both votes land.
+  //
+  // Cap at MAX_CAS_ATTEMPTS so a pathological contender cannot spin
+  // forever; after that we fail closed with a 500 in the caller.
+  const MAX_CAS_ATTEMPTS = 5;
+  let lastResult: RecordDecisionResult | null = null;
+
+  for (let attempt = 0; attempt < MAX_CAS_ATTEMPTS; attempt++) {
+    // Prefer getWithMetadata so we get an etag for the conditional
+    // write. If the SDK surface doesn't expose it (older Netlify
+    // Blobs versions), fall back to a plain get and a non-conditional
+    // setJSON — which is the previous behaviour, so we never regress.
+    let existing: ApprovalEntry | null = null;
+    let etag: string | null = null;
+    try {
+      // Widen: SDK signature varies across versions.
+      const withMeta: any =
+        typeof (approvalStore as any).getWithMetadata === 'function'
+          ? await (approvalStore as any).getWithMetadata(eventId, { type: 'json' })
+          : null;
+      if (withMeta) {
+        existing = (withMeta.data ?? null) as ApprovalEntry | null;
+        etag = (withMeta.etag ?? null) as string | null;
+      } else {
+        existing = (await approvalStore.get(eventId, {
+          type: 'json',
+        })) as ApprovalEntry | null;
+      }
+    } catch {
+      existing = (await approvalStore.get(eventId, {
+        type: 'json',
+      })) as ApprovalEntry | null;
+    }
+
+    // Deep-clone so applyDecisionToRecord's in-place mutation never
+    // leaks into the next CAS retry's starting state.
+    const startingRec: ApprovalEntry =
+      existing !== null
+        ? (JSON.parse(JSON.stringify(existing)) as ApprovalEntry)
+        : { eventId, approvals: [], rejections: [], status: 'pending' };
+
+    const result = applyDecisionToRecord(startingRec, actor, verdict, note, options);
+    lastResult = result;
+
+    if (!result.shouldPersist) {
+      // No-op vote (idempotent, terminal record, solo-cooldown reject,
+      // or other non-persisting branch). Return the fresh record
+      // without racing a write.
+      return result;
+    }
+
+    // Attempt a conditional write. If it lands, we're done. On a
+    // conflict (another writer got there first) we loop and re-read.
+    try {
+      const writeOpts: any = etag
+        ? { onlyIfMatch: etag }
+        : { onlyIfNew: true };
+      const writeResult: any =
+        typeof (approvalStore as any).setJSON === 'function'
+          ? await (approvalStore as any).setJSON(eventId, result.rec, writeOpts)
+          : undefined;
+
+      const landed =
+        writeResult == null
+          ? true // legacy SDK that returned void on success
+          : typeof writeResult === 'object' && 'modified' in writeResult
+            ? writeResult.modified === true
+            : writeResult !== false;
+      if (landed) return result;
+      // else: conflict, retry
+    } catch (err) {
+      // Unknown SDK variant or transport failure. Fall back to a
+      // plain setJSON once to preserve the pre-existing behaviour
+      // (best-effort persistence rather than silently dropping the
+      // vote on CAS-unsupported stores).
+      console.warn(
+        `[approvals] CAS write failed, falling back to plain setJSON: ${(err as Error).message}`,
+      );
+      await approvalStore.setJSON(eventId, result.rec);
+      return result;
+    }
   }
 
-  return result;
+  // All CAS attempts lost the race. Surface `casExhausted: true` so
+  // the HTTP layer returns 503 and the client retries, rather than
+  // pretending the vote landed.
+  if (lastResult) return { ...lastResult, shouldPersist: false, casExhausted: true };
+  throw new Error('approvals CAS exhausted without computing a decision');
 }
 
 // ---------------------------------------------------------------------------
@@ -437,7 +527,29 @@ export default async (req: Request, context: Context) => {
         isApprove ? "approve" : "reject",
         note,
       );
-      const { rec, cooldownPendingUntilIso } = result;
+      const { rec, cooldownPendingUntilIso, casExhausted } = result;
+
+      // CAS exhausted — a concurrent writer won every retry. Surface
+      // 503 so the client retries; never pretend the vote landed.
+      // This is the defence against the four-eyes read-modify-write
+      // race: under high contention we refuse the request rather
+      // than silently drop the caller's vote.
+      if (casExhausted) {
+        console.warn(
+          `[approvals] CAS exhausted eventId=${eventId} actor=${auth.username} verdict=${
+            isApprove ? "approve" : "reject"
+          }`,
+        );
+        return jsonResponse(
+          {
+            ok: false,
+            error: "approval_write_contention",
+            message:
+              "Another approver wrote concurrently; your vote was not recorded. Please retry.",
+          },
+          { status: 503, headers: { "Retry-After": "1" } },
+        );
+      }
 
       // Solo-MLRO cooldown rejection — surface the wait time so the
       // MLRO knows when to come back. HTTP 409 (Conflict) is the

--- a/tests/approvalsRaceCondition.test.ts
+++ b/tests/approvalsRaceCondition.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Regression tests for the four-eyes read-modify-write race in
+ * netlify/functions/approvals.mts.
+ *
+ * The bug: `recordDecision` previously read the current ApprovalEntry,
+ * computed the new record via `applyDecisionToRecord`, and then
+ * unconditionally `setJSON`'d the result. Two concurrent votes on
+ * the same eventId both read the same `{approvals: []}` snapshot and
+ * each wrote their own new record; the second writer silently
+ * overwrote the first. One of the two votes (approval OR rejection)
+ * was lost, which in a four-eyes regulatory flow is a correctness
+ * bug: an approver's "approve" could be erased by a racing "reject"
+ * (or vice versa), and the UI would never know.
+ *
+ * The fix wraps the read-modify-write in a CAS retry loop using the
+ * Netlify Blobs `onlyIfMatch` / `onlyIfNew` semantics. Under
+ * contention the second writer re-reads the fresh record and
+ * re-applies their vote on top. After MAX_CAS_ATTEMPTS of lost
+ * races the caller surfaces `casExhausted: true` so the HTTP layer
+ * responds with 503 — never a silent success.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Fake Netlify Blobs implementation scriptable per-test.
+interface FakeEntry { value: unknown; etag: string }
+let fakeData: Map<string, FakeEntry>;
+let fakeCounter = 0;
+let beforeFirstWrite: (() => Promise<void>) | null = null;
+let setJsonCalls = 0;
+let getCalls = 0;
+
+vi.mock('@netlify/blobs', () => ({
+  getStore: () => ({
+    async getWithMetadata(key: string) {
+      getCalls++;
+      const v = fakeData.get(key);
+      return v ? { data: v.value, etag: v.etag } : null;
+    },
+    async get(key: string) {
+      const v = fakeData.get(key);
+      return v ? v.value : null;
+    },
+    async setJSON(key: string, value: unknown, opts: any) {
+      setJsonCalls++;
+      // beforeFirstWrite hook: simulate another writer winning the
+      // race just before our first CAS attempt lands.
+      if (beforeFirstWrite && setJsonCalls === 1) {
+        const hook = beforeFirstWrite;
+        beforeFirstWrite = null;
+        await hook();
+      }
+      const existing = fakeData.get(key);
+      if (opts?.onlyIfMatch) {
+        if (!existing || existing.etag !== opts.onlyIfMatch) {
+          return { modified: false };
+        }
+      }
+      if (opts?.onlyIfNew) {
+        if (existing) return { modified: false };
+      }
+      const etag = 'etag-' + ++fakeCounter;
+      fakeData.set(key, { value, etag });
+      return { modified: true, etag };
+    },
+  }),
+}));
+
+// Auth stub — always returns alice. We bypass the real bearer
+// extraction, rate limiter, etc., so the tests focus on the race.
+vi.mock('../netlify/functions/middleware/auth.mts', () => ({
+  authenticateApprover: () => ({ ok: true, username: 'alice' }),
+}));
+vi.mock('../netlify/functions/middleware/rate-limit.mts', () => ({
+  checkRateLimit: async () => null,
+}));
+
+beforeEach(() => {
+  fakeData = new Map();
+  fakeCounter = 0;
+  setJsonCalls = 0;
+  getCalls = 0;
+  beforeFirstWrite = null;
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+async function freshModule() {
+  return await import('../netlify/functions/approvals.mts?t=' + Date.now());
+}
+
+describe('approvals — CAS retry on concurrent writers', () => {
+  it('retries and preserves a prior approver when a race happens', async () => {
+    const mod = await freshModule();
+    // Seed: bob already approved. That snapshot has etag=etag-1.
+    fakeData.set('evt1', {
+      value: {
+        eventId: 'evt1',
+        approvals: [{ actor: 'bob', at: '2026-04-17T10:00:00.000Z' }],
+        rejections: [],
+        status: 'pending',
+      },
+      etag: 'etag-1',
+    });
+    fakeCounter = 1;
+
+    // Install the pre-first-write hook: between alice reading
+    // {approvals:[bob]} and alice writing {approvals:[bob,alice]},
+    // a third party (charlie) squeezes in a concurrent approval and
+    // updates the etag. Alice's first CAS attempt therefore fails,
+    // and the retry must re-read + re-apply on top of charlie's
+    // fresh record.
+    beforeFirstWrite = async () => {
+      fakeData.set('evt1', {
+        value: {
+          eventId: 'evt1',
+          approvals: [
+            { actor: 'bob', at: '2026-04-17T10:00:00.000Z' },
+            { actor: 'charlie', at: '2026-04-17T11:00:00.000Z' },
+          ],
+          rejections: [],
+          status: 'pending',
+        },
+        etag: 'etag-99', // the concurrent writer's new etag
+      });
+    };
+
+    // Alice votes approve.
+    const req = new Request('https://example.test/api/approvals/approve', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ eventId: 'evt1' }),
+    });
+    const res = await (mod.default as any)(req, { ip: '127.0.0.1' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // Alice's vote landed AND bob + charlie's prior votes are
+    // preserved (the fix: we re-read on CAS conflict instead of
+    // blindly overwriting).
+    const finalRec = body.record;
+    const actors = finalRec.approvals.map((a: { actor: string }) => a.actor);
+    expect(actors).toContain('bob');
+    expect(actors).toContain('charlie');
+    expect(actors).toContain('alice');
+    expect(finalRec.status).toBe('approved'); // >= REQUIRED_APPROVERS
+    // setJSON was attempted twice (one conflict + one success).
+    expect(setJsonCalls).toBe(2);
+  });
+
+  it('returns 503 when every CAS attempt loses', async () => {
+    const mod = await freshModule();
+    fakeData.set('evt2', {
+      value: {
+        eventId: 'evt2',
+        approvals: [],
+        rejections: [],
+        status: 'pending',
+      },
+      etag: 'etag-seed',
+    });
+
+    // Every setJSON attempt reports a CAS conflict (modified:false).
+    // This is a stronger contender than our test can usually script,
+    // but we substitute a fakeData that shifts etag on every read.
+    let etagRev = 100;
+    const realGet = (mod as any); // force fresh import
+    // Replace the stub to always bump the etag between get and set.
+    fakeData = new Map();
+    const rewrite = () => {
+      fakeData.set('evt2', {
+        value: { eventId: 'evt2', approvals: [], rejections: [], status: 'pending' },
+        etag: 'etag-' + (++etagRev),
+      });
+    };
+    rewrite();
+    beforeFirstWrite = async () => {
+      // Rewrite before the write lands — and again on every retry.
+      rewrite();
+    };
+    // We can only install ONE beforeFirstWrite, so instead patch the
+    // fake store via getStore() closure. Easiest: monkey-patch
+    // fakeData directly inside the setJSON by shifting etag. We do
+    // that via the getWithMetadata hook by always returning a
+    // reshuffled etag.
+    const originalGet = fakeData.get.bind(fakeData);
+    (fakeData as any).get = (key: string) => {
+      const v = originalGet(key);
+      if (v) rewrite();
+      return v;
+    };
+
+    const req = new Request('https://example.test/api/approvals/approve', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ eventId: 'evt2' }),
+    });
+    const res = await (mod.default as any)(req, { ip: '127.0.0.1' });
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBe('approval_write_contention');
+  });
+
+  it('still allows single-vote success on no contention', async () => {
+    const mod = await freshModule();
+    fakeData.set('evt3', {
+      value: {
+        eventId: 'evt3',
+        approvals: [],
+        rejections: [],
+        status: 'pending',
+      },
+      etag: 'etag-only',
+    });
+
+    const req = new Request('https://example.test/api/approvals/approve', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer cccccccccccccccccccccccccccccccccccccccccc',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ eventId: 'evt3' }),
+    });
+    const res = await (mod.default as any)(req, { ip: '127.0.0.1' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.record.approvals.length).toBe(1);
+    expect(body.record.approvals[0].actor).toBe('alice');
+    expect(setJsonCalls).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

**Regulatory four-eyes integrity bug** in live code. `netlify/functions/approvals.mts` did a classic read-modify-write on `approvalStore` without any CAS — under concurrent POSTs against the same `eventId`, approver votes could be silently lost.

### The bug

```ts
const existing = await approvalStore.get(eventId, ...);
const rec = existing ?? { approvals: [], ... };
applyDecisionToRecord(rec, actor, verdict, ...);
await approvalStore.setJSON(eventId, rec); // unconditional!
```

Two approvers both read `{approvals: []}`, each compute their own new record, the second `setJSON` silently overwrote the first.

**Symptom matrix:**
- Alice + Bob both approve concurrently → only one name persists. Quorum never reached, both humans think they voted yes.
- Alice approves, Bob rejects concurrently → whichever write lands last wins. An approve can erase a reject or vice versa. No audit trail of the lost vote.

Regulatory violation: FDL Art.20-21 (CO duty of care), Cabinet Res 134/2025 Art.19 (auditable internal review).

### Fix

CAS retry loop using `getWithMetadata` + `setJSON({ onlyIfMatch })`:

1. Read record + etag.
2. Deep-clone snapshot so `applyDecisionToRecord`'s in-place mutation doesn't poison the next retry.
3. Compute new record.
4. Conditional write; if `modified: false`, re-read + re-apply.
5. After 5 losses: `casExhausted: true` → HTTP 503 with `error: "approval_write_contention"` and `Retry-After: 1`. Never a silent success.

Also preserves back-compat for legacy SDKs (void-return = success) and CAS-unsupported stores (fall back to plain `setJSON`).

### Tests

`tests/approvalsRaceCondition.test.ts` (3 tests):

- **Race preserved:** charlie squeezes a vote between alice's read and write → alice's first CAS fails → retry re-reads fresh `{approvals:[bob,charlie]}` → alice's vote lands on top → final record has all three and reaches `approved`. `setJSON` called exactly twice.
- **CAS exhausted:** every attempt loses → 503 with `approval_write_contention`.
- **Baseline:** single-vote no-contention → 200, `setJSON` called once.

Verified that reverting the fix leaves only the baseline test passing — the two concurrency tests fail directly, proving the bug.

- [x] `npx vitest run tests/approvalsRaceCondition.test.ts` — 3/3 passing
- [x] `npx vitest run` — **4390/4390** passing (4387 → 4390)

## Regulatory basis

- **FDL No.10/2025 Art.20-21** — CO duty of care; every four-eyes vote must be recorded, silent loss under concurrency is a hard correctness violation.
- **Cabinet Res 134/2025 Art.19** — auditable internal review; CAS exhaustion now generates a 503 log line AND a client-visible error, so every contested vote is traceable in both the audit chain and the operator-facing UI.

https://claude.ai/code/session_01R9Y37tUnmBhH1uF2i3toB8