### PR TITLE
fix: RMW race sweep — watchlist + customer-profile lost concurrent updates (FDL Art.24, Cabinet Res 134/2025 Art.19)

### DIFF
--- a/netlify/functions/customer-profile.mts
+++ b/netlify/functions/customer-profile.mts
@@ -181,6 +181,31 @@ interface ProfileStore {
   get(id: string): Promise<CustomerProfileV2 | null>;
   set(id: string, profile: CustomerProfileV2): Promise<void>;
   tombstone(id: string, payload: { reason: string; tombstonedAt: string }): Promise<void>;
+  /**
+   * Atomic compare-and-swap update. Reads the current profile (or
+   * null if absent), hands it to `transform`, and writes the result
+   * back under a CAS precondition — retrying on conflict so two
+   * concurrent patches cannot silently overwrite each other's
+   * field changes. `transform` returning null aborts the update
+   * (for 404 on missing profile).
+   *
+   * Implementations that can't do real CAS (in-memory test stubs,
+   * older SDKs) may degrade to a plain get → transform → set; the
+   * production blob-backed impl uses Netlify Blobs
+   * `onlyIfMatch`.
+   *
+   * Returns:
+   *   { ok: true, profile } — update landed
+   *   { ok: false, notFound: true } — transform returned null
+   *   { ok: false, contention: true } — all CAS attempts lost
+   */
+  casUpdate?(
+    id: string,
+    transform: (existing: CustomerProfileV2 | null) => CustomerProfileV2 | null,
+  ): Promise<
+    | { ok: true; profile: CustomerProfileV2 }
+    | { ok: false; notFound?: boolean; contention?: boolean }
+  >;
 }
 
 function makeNetlifyBlobStore(): ProfileStore {
@@ -214,6 +239,57 @@ function makeNetlifyBlobStore(): ProfileStore {
         });
       }
       await store.delete(`profile/${id}.json`);
+    },
+    async casUpdate(id, transform) {
+      const MAX_ATTEMPTS = 5;
+      const key = `profile/${id}.json`;
+      for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+        // Read with etag. Fall back to a plain get if
+        // getWithMetadata is unavailable (older SDK).
+        let existing: CustomerProfileV2 | null = null;
+        let etag: string | null = null;
+        try {
+          const withMeta: unknown =
+            typeof (store as unknown as { getWithMetadata?: unknown }).getWithMetadata === 'function'
+              ? await (store as unknown as {
+                  getWithMetadata: (k: string, o: unknown) => Promise<{ data: unknown; etag?: string }>;
+                }).getWithMetadata(key, { type: 'json' })
+              : null;
+          if (withMeta && typeof withMeta === 'object' && 'data' in (withMeta as Record<string, unknown>)) {
+            const tuple = withMeta as { data: CustomerProfileV2 | null; etag?: string };
+            existing = tuple.data ?? null;
+            etag = tuple.etag ?? null;
+          } else {
+            existing = (await store.get(key, { type: 'json' })) as CustomerProfileV2 | null;
+          }
+        } catch {
+          existing = (await store.get(key, { type: 'json' })) as CustomerProfileV2 | null;
+        }
+
+        const next = transform(existing);
+        if (next === null) return { ok: false, notFound: true };
+
+        try {
+          const opts = etag ? { onlyIfMatch: etag } : { onlyIfNew: true };
+          const res: unknown = await (store as unknown as {
+            setJSON: (k: string, v: unknown, o?: unknown) => Promise<unknown>;
+          }).setJSON(key, next, opts);
+          const landed =
+            res == null
+              ? true
+              : typeof res === 'object' && 'modified' in (res as Record<string, unknown>)
+                ? (res as { modified: boolean }).modified === true
+                : res !== false;
+          if (landed) return { ok: true, profile: next };
+          // else CAS conflict — loop and re-read.
+        } catch {
+          // SDK without CAS support — fall back to plain write and
+          // treat as landed. Best-effort.
+          await store.setJSON(key, next);
+          return { ok: true, profile: next };
+        }
+      }
+      return { ok: false, contention: true };
     },
   };
 }
@@ -322,29 +398,89 @@ export async function handleUpdate(
   req: UpdateRequest,
   deps: HandlerDeps
 ): Promise<{ status: number; body: unknown }> {
-  const existing = await deps.store.get(req.id);
-  if (!existing) return { status: 404, body: { ok: false, error: 'not_found', id: req.id } };
+  // Build the merged profile inside the transform so it is
+  // recomputed on every CAS retry — picking up any fields another
+  // writer added since we first read the record. Two concurrent
+  // patches to the same customer no longer silently overwrite
+  // each other's field changes (FDL Art.24 audit-chain integrity).
+  let validationReport: ReturnType<typeof validateCustomerProfile> | null = null;
 
-  // Merge the patch, but ALWAYS preserve id + createdAt +
-  // schemaVersion (these are write-once).
-  const merged: CustomerProfileV2 = {
-    ...existing,
-    ...req.patch,
-    id: existing.id,
-    schemaVersion: 2,
-    createdAt: existing.createdAt,
-    lastReviewedAt: deps.nowIso,
-    lastReviewerUserId: deps.userId,
+  const transform = (
+    existing: CustomerProfileV2 | null,
+  ): CustomerProfileV2 | null => {
+    if (!existing) return null;
+    const merged: CustomerProfileV2 = {
+      ...existing,
+      ...req.patch,
+      id: existing.id,
+      schemaVersion: 2,
+      createdAt: existing.createdAt,
+      lastReviewedAt: deps.nowIso,
+      lastReviewerUserId: deps.userId,
+    };
+    // Validation uses the latest merged record — if the
+    // concurrent writer added a field that conflicts with our
+    // patch, the second-round validation will catch it instead
+    // of silently losing state.
+    validationReport = validateCustomerProfile(merged);
+    if (!validationReport.ok) {
+      // Abort the CAS loop by returning null — the handler below
+      // surfaces 422 with the failed report.
+      return null;
+    }
+    return merged;
   };
-  const report = validateCustomerProfile(merged);
-  if (!report.ok) {
+
+  if (typeof deps.store.casUpdate === 'function') {
+    const result = await deps.store.casUpdate(req.id, transform);
+    if (!result.ok) {
+      if (validationReport && !validationReport.ok) {
+        return {
+          status: 422,
+          body: { ok: false, error: 'validation_failed', report: validationReport },
+        };
+      }
+      if (result.contention) {
+        return {
+          status: 503,
+          body: {
+            ok: false,
+            error: 'profile_write_contention',
+            message: 'Another update landed concurrently; please retry.',
+          },
+        };
+      }
+      return { status: 404, body: { ok: false, error: 'not_found', id: req.id } };
+    }
     return {
-      status: 422,
-      body: { ok: false, error: 'validation_failed', report },
+      status: 200,
+      body: {
+        ok: true,
+        profile: result.profile,
+        warnings: validationReport?.warningCount ?? 0,
+      },
     };
   }
+
+  // Fallback for stores without CAS (test stubs). Same semantics
+  // as before — no concurrency protection, but unchanged behaviour.
+  const existing = await deps.store.get(req.id);
+  if (!existing) return { status: 404, body: { ok: false, error: 'not_found', id: req.id } };
+  const merged = transform(existing);
+  if (!merged) {
+    if (validationReport && !validationReport.ok) {
+      return {
+        status: 422,
+        body: { ok: false, error: 'validation_failed', report: validationReport },
+      };
+    }
+    return { status: 404, body: { ok: false, error: 'not_found', id: req.id } };
+  }
   await deps.store.set(merged.id, merged);
-  return { status: 200, body: { ok: true, profile: merged, warnings: report.warningCount } };
+  return {
+    status: 200,
+    body: { ok: true, profile: merged, warnings: validationReport?.warningCount ?? 0 },
+  };
 }
 
 export async function handleDelete(

--- a/netlify/functions/watchlist.mts
+++ b/netlify/functions/watchlist.mts
@@ -91,6 +91,36 @@ async function loadFromStore(): Promise<SerialisedWatchlist> {
   return memoryStore ?? { version: 1, entries: [] };
 }
 
+// Read the watchlist along with its etag so the HTTP handler can do a
+// CAS write. Falls back to a plain load (no etag) when the SDK does
+// not expose getWithMetadata.
+async function loadFromStoreWithMetadata(): Promise<{
+  data: SerialisedWatchlist;
+  etag: string | null;
+}> {
+  try {
+    const store = getStore(BLOB_STORE_NAME);
+    const withMeta: unknown =
+      typeof (store as unknown as { getWithMetadata?: unknown }).getWithMetadata === 'function'
+        ? await (store as unknown as {
+            getWithMetadata: (key: string, opts: unknown) => Promise<{ data: unknown; etag?: string }>;
+          }).getWithMetadata(BLOB_KEY, { type: 'json' })
+        : null;
+    if (withMeta && typeof withMeta === 'object' && 'data' in (withMeta as Record<string, unknown>)) {
+      const tuple = withMeta as { data: SerialisedWatchlist | null; etag?: string };
+      const raw = tuple.data;
+      const etag = tuple.etag ?? null;
+      if (raw && typeof raw === 'object' && 'version' in raw && Array.isArray(raw.entries)) {
+        return { data: raw, etag };
+      }
+      return { data: { version: 1, entries: [] }, etag };
+    }
+  } catch {
+    /* fall through */
+  }
+  return { data: await loadFromStore(), etag: null };
+}
+
 async function saveToStore(data: SerialisedWatchlist): Promise<void> {
   try {
     const store = getStore(BLOB_STORE_NAME);
@@ -98,6 +128,32 @@ async function saveToStore(data: SerialisedWatchlist): Promise<void> {
   } catch {
     // Dev / local / Blobs unavailable — persist to process memory
     memoryStore = data;
+  }
+}
+
+// Conditional write. Returns true iff the CAS precondition held and
+// the blob was actually modified. Decodes all three Netlify Blobs
+// SDK return shapes (modern `{ modified: boolean }`, legacy void,
+// or `false`). On transport failure, falls back to the memory
+// store and returns true so local-dev callers never lose writes.
+async function saveToStoreCas(
+  data: SerialisedWatchlist,
+  etag: string | null,
+): Promise<boolean> {
+  try {
+    const store = getStore(BLOB_STORE_NAME);
+    const opts = etag ? { onlyIfMatch: etag } : { onlyIfNew: true };
+    const res: unknown = await (store as unknown as {
+      setJSON: (key: string, value: unknown, opts?: unknown) => Promise<unknown>;
+    }).setJSON(BLOB_KEY, data, opts);
+    if (res == null) return true;
+    if (typeof res === 'object' && 'modified' in (res as Record<string, unknown>)) {
+      return (res as { modified: boolean }).modified === true;
+    }
+    return res !== false;
+  } catch {
+    memoryStore = data;
+    return true;
   }
 }
 
@@ -257,40 +313,69 @@ export default async (req: Request, context: Context): Promise<Response> => {
     }
     const body = validation.body;
 
-    // Load current state
-    const current = await loadFromStore();
-    const wl = deserialiseWatchlist(current);
-
-    // Dispatch on action
+    // Dispatch on action. `add` and `remove` are read-modify-write
+    // on the same single-key blob, so they MUST use CAS — without
+    // it, two concurrent adds for different subjects both read the
+    // same snapshot and the second setJSON silently overwrites the
+    // first entry, silently dropping a watchlist subject (FDL
+    // Art.24 audit-chain gap). `replace` overwrites the whole blob
+    // unconditionally, which is the caller's intent, so no CAS.
+    const MAX_CAS_ATTEMPTS = 5;
     try {
-      if (body.action === 'add') {
-        // Reject duplicates with 409 Conflict
-        if (wl.entries.has(body.id)) {
-          return jsonResponse(
-            { ok: false, error: `subject "${body.id}" already exists in watchlist` },
-            { status: 409 }
-          );
-        }
-        const entry = addToWatchlist(wl, {
-          id: body.id,
-          subjectName: body.subjectName,
-          riskTier: body.riskTier,
-          metadata: body.metadata,
-        });
-        await saveToStore(serialiseWatchlist(wl));
-        return jsonResponse({ ok: true, action: 'add', entry, size: watchlistSize(wl) });
-      }
+      if (body.action === 'add' || body.action === 'remove') {
+        for (let attempt = 0; attempt < MAX_CAS_ATTEMPTS; attempt++) {
+          const { data: current, etag } = await loadFromStoreWithMetadata();
+          const wl = deserialiseWatchlist(current);
 
-      if (body.action === 'remove') {
-        const removed = removeFromWatchlist(wl, body.id);
-        if (!removed) {
-          return jsonResponse(
-            { ok: false, error: `subject "${body.id}" not found in watchlist` },
-            { status: 404 }
-          );
+          if (body.action === 'add') {
+            if (wl.entries.has(body.id)) {
+              return jsonResponse(
+                { ok: false, error: `subject "${body.id}" already exists in watchlist` },
+                { status: 409 }
+              );
+            }
+            const entry = addToWatchlist(wl, {
+              id: body.id,
+              subjectName: body.subjectName,
+              riskTier: body.riskTier,
+              metadata: body.metadata,
+            });
+            const landed = await saveToStoreCas(serialiseWatchlist(wl), etag);
+            if (landed) {
+              return jsonResponse({
+                ok: true, action: 'add', entry, size: watchlistSize(wl),
+              });
+            }
+            // else: CAS conflict — loop and re-read.
+            continue;
+          }
+
+          // body.action === 'remove'
+          const removed = removeFromWatchlist(wl, body.id);
+          if (!removed) {
+            return jsonResponse(
+              { ok: false, error: `subject "${body.id}" not found in watchlist` },
+              { status: 404 }
+            );
+          }
+          const landed = await saveToStoreCas(serialiseWatchlist(wl), etag);
+          if (landed) {
+            return jsonResponse({
+              ok: true, action: 'remove', id: body.id, size: watchlistSize(wl),
+            });
+          }
+          continue;
         }
-        await saveToStore(serialiseWatchlist(wl));
-        return jsonResponse({ ok: true, action: 'remove', id: body.id, size: watchlistSize(wl) });
+        // All CAS attempts lost. Fail with 503 so the client
+        // retries; never silently drop the caller's mutation.
+        return jsonResponse(
+          {
+            ok: false,
+            error: 'watchlist_write_contention',
+            message: 'Another writer modified the watchlist concurrently; please retry.',
+          },
+          { status: 503, headers: { 'Retry-After': '1' } }
+        );
       }
 
       if (body.action === 'replace') {

--- a/tests/customerProfileUpdateRace.test.ts
+++ b/tests/customerProfileUpdateRace.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Regression tests for the read-modify-write race on
+ * `handleUpdate` in netlify/functions/customer-profile.mts.
+ *
+ * Without CAS, two concurrent PATCHes against the same customer
+ * both read the same snapshot, each compute their own merged
+ * record, and the second setJSON silently overwrites the first
+ * patcher's field changes. Lost field updates on a customer
+ * profile are an FDL Art.24 audit-chain gap — the regulatory
+ * record will not reflect what the two MLROs actually typed.
+ *
+ * The fix threads a `casUpdate(id, transform)` method through
+ * `ProfileStore`. `handleUpdate` uses it when available; the
+ * transform is re-invoked on every CAS retry so the merge happens
+ * on top of the freshest record, not a stale snapshot. These
+ * tests drive `handleUpdate` through a fake store that simulates
+ * a concurrent writer landing between our read and our write.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { CustomerProfileV2 } from '../src/domain/customerProfile';
+import {
+  handleUpdate,
+  type HandlerDeps,
+  type ProfileStore,
+} from '../netlify/functions/customer-profile.mts';
+
+function makeValidProfile(id = 'cust-race'): CustomerProfileV2 {
+  return {
+    schemaVersion: 2,
+    id,
+    legalName: 'RACE TRADING L.L.C',
+    customerType: 'legal',
+    country: 'AE',
+    jurisdiction: 'Dubai',
+    licenseNumber: 'DET-RACE',
+    licenseIssuer: 'Dubai DET',
+    licenseIssueDate: '01/01/2024',
+    licenseExpiryDate: '01/01/2030',
+    licenseStatus: 'active',
+    businessModel: 'Jewellery wholesale trading in UAE',
+    activity: 'Jewellery Trading',
+    sector: 'jewellery-retail',
+    expectedMonthlyVolumeAed: 100_000,
+    expectedTransactionCountPerMonth: 10,
+    riskRating: 'medium',
+    riskRatingAssignedAt: '01/01/2026',
+    riskRatingExpiresAt: '01/07/2026',
+    pepStatus: 'clear',
+    sanctionsStatus: 'clear',
+    sourceOfFundsStatus: 'verified',
+    sourceOfFundsEvidence: [
+      {
+        kind: 'bank-statement',
+        issuer: 'Emirates NBD',
+        issuedAt: '01/01/2026',
+        verifiedAt: '02/01/2026',
+        reference: 'ENBD-RACE',
+      },
+    ],
+    beneficialOwners: [
+      {
+        fullName: 'Owner Person',
+        nationality: 'AE',
+        ownershipPercentage: 100,
+        isPep: false,
+        verifiedAt: '01/01/2026',
+      },
+    ],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    lastReviewedAt: '2026-01-01T00:00:00.000Z',
+    lastReviewerUserId: 'init',
+  } as CustomerProfileV2;
+}
+
+// A CAS-aware in-memory store that lets each test script a
+// "concurrent writer" hook that fires between our read and our
+// write, exactly once.
+function makeCasMemoryStore(seed: CustomerProfileV2, concurrentWriter?: (profile: CustomerProfileV2) => CustomerProfileV2) {
+  const state = new Map<string, { profile: CustomerProfileV2; etag: string }>();
+  state.set(seed.id, { profile: seed, etag: 'etag-0' });
+  let etagRev = 0;
+  let writerFired = false;
+  let casAttempts = 0;
+  const store: ProfileStore = {
+    async list() { return Array.from(state.keys()).map((id) => `profile/${id}.json`); },
+    async get(id) { return state.get(id)?.profile ?? null; },
+    async set(id, p) { state.set(id, { profile: p, etag: 'etag-' + ++etagRev }); },
+    async tombstone() { /* not exercised */ },
+    async casUpdate(id, transform) {
+      for (let attempt = 0; attempt < 5; attempt++) {
+        casAttempts++;
+        const cur = state.get(id);
+        const existing = cur?.profile ?? null;
+        const etag = cur?.etag ?? null;
+
+        // Fire the concurrent-writer hook exactly once, between
+        // our read and our write on the FIRST attempt.
+        if (!writerFired && concurrentWriter && existing) {
+          writerFired = true;
+          const bumped = concurrentWriter(existing);
+          state.set(id, { profile: bumped, etag: 'etag-' + ++etagRev });
+        }
+
+        const next = transform(existing);
+        if (next === null) return { ok: false, notFound: true };
+
+        const latest = state.get(id);
+        if (etag && latest && latest.etag !== etag) {
+          // CAS conflict — retry.
+          continue;
+        }
+        state.set(id, { profile: next, etag: 'etag-' + ++etagRev });
+        return { ok: true, profile: next };
+      }
+      return { ok: false, contention: true };
+    },
+  };
+  return { store, state, get casAttempts() { return casAttempts; } };
+}
+
+function deps(store: ProfileStore): HandlerDeps {
+  return {
+    store,
+    nowIso: '2026-04-17T12:00:00.000Z',
+    userId: 'tester',
+  };
+}
+
+describe('handleUpdate — CAS retry preserves a concurrent patch', () => {
+  it('retries and merges on top of a concurrent writer', async () => {
+    const initial = makeValidProfile('cust-1');
+    const { store, state, casAttempts: _ } = makeCasMemoryStore(initial, (cur) => ({
+      // Concurrent writer changes riskRating and adds a review stamp.
+      ...cur,
+      riskRating: 'high',
+      lastReviewerUserId: 'concurrent-mlro',
+    }));
+
+    // Our patch changes pepStatus.
+    const result = await handleUpdate(
+      { id: 'cust-1', patch: { pepStatus: 'screened' } as Partial<CustomerProfileV2> },
+      deps(store),
+    );
+    expect(result.status).toBe(200);
+
+    // The concurrent writer's riskRating='high' must be preserved,
+    // AND our pepStatus='screened' must land.
+    const final = state.get('cust-1')!.profile;
+    expect(final.riskRating).toBe('high');
+    expect(final.pepStatus).toBe('screened');
+    // Our user stamp overwrites — we are the winner of the final
+    // vote, which is expected since we re-merged on top.
+    expect(final.lastReviewerUserId).toBe('tester');
+  });
+
+  it('surfaces 404 when the record does not exist', async () => {
+    const { store } = makeCasMemoryStore(makeValidProfile('other'));
+    const result = await handleUpdate(
+      { id: 'missing', patch: { pepStatus: 'screened' } as Partial<CustomerProfileV2> },
+      deps(store),
+    );
+    expect(result.status).toBe(404);
+  });
+
+  it('surfaces 422 when validation fails (even via the CAS path)', async () => {
+    const initial = makeValidProfile('cust-422');
+    const { store } = makeCasMemoryStore(initial);
+    // invalid patch — licenseExpiryDate in the wrong format.
+    const result = await handleUpdate(
+      { id: 'cust-422', patch: { licenseExpiryDate: 'not-a-date' } as Partial<CustomerProfileV2> },
+      deps(store),
+    );
+    expect(result.status).toBe(422);
+    const body = result.body as { ok: boolean; error: string };
+    expect(body.error).toBe('validation_failed');
+  });
+});
+
+describe('handleUpdate — fallback path (no casUpdate on the store)', () => {
+  it('works without casUpdate (pre-existing behaviour preserved)', async () => {
+    const initial = makeValidProfile('cust-legacy');
+    const state = new Map<string, CustomerProfileV2>([[initial.id, initial]]);
+    const legacyStore: ProfileStore = {
+      async list() { return Array.from(state.keys()).map((id) => `profile/${id}.json`); },
+      async get(id) { return state.get(id) ?? null; },
+      async set(id, p) { state.set(id, p); },
+      async tombstone() {},
+      // NOTE: no casUpdate
+    };
+    const result = await handleUpdate(
+      { id: 'cust-legacy', patch: { pepStatus: 'screened' } as Partial<CustomerProfileV2> },
+      deps(legacyStore),
+    );
+    expect(result.status).toBe(200);
+    expect(state.get('cust-legacy')!.pepStatus).toBe('screened');
+  });
+});

--- a/tests/watchlistRaceCondition.test.ts
+++ b/tests/watchlistRaceCondition.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Regression tests for the read-modify-write race in watchlist.mts
+ * POST add/remove.
+ *
+ * Without CAS, two concurrent `add` calls for different subjects
+ * both read the same `{entries: []}` snapshot, each push their own
+ * entry, and the second setJSON silently overwrites the first
+ * subject. This is an FDL Art.24 audit-chain gap: watchlist
+ * membership is regulatory data; a silently dropped entry is a
+ * compliance failure.
+ *
+ * These tests drive the function through a fake Netlify Blobs
+ * store that scripts CAS etag evolution deterministically.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+interface FakeEntry { value: unknown; etag: string }
+let watchlistData: Map<string, FakeEntry>;
+let etagCounter = 0;
+let setJsonCalls = 0;
+let beforeFirstWrite: (() => void) | null = null;
+
+vi.mock('@netlify/blobs', () => ({
+  getStore: () => ({
+    async get(key: string) {
+      return watchlistData.get(key)?.value ?? null;
+    },
+    async getWithMetadata(key: string) {
+      const v = watchlistData.get(key);
+      if (!v) return null;
+      return { data: v.value, etag: v.etag };
+    },
+    async setJSON(key: string, value: unknown, opts: any) {
+      setJsonCalls++;
+      if (beforeFirstWrite && setJsonCalls === 1) {
+        const hook = beforeFirstWrite;
+        beforeFirstWrite = null;
+        hook();
+      }
+      const existing = watchlistData.get(key);
+      if (opts?.onlyIfMatch) {
+        if (!existing || existing.etag !== opts.onlyIfMatch) {
+          return { modified: false };
+        }
+      }
+      if (opts?.onlyIfNew) {
+        if (existing) return { modified: false };
+      }
+      const etag = 'etag-' + ++etagCounter;
+      watchlistData.set(key, { value, etag });
+      return { modified: true, etag };
+    },
+    async delete(key: string) { watchlistData.delete(key); },
+    async list() { return { blobs: [] }; },
+  }),
+}));
+
+// Bypass auth + rate-limit — we are testing the CAS path only.
+vi.mock('../netlify/functions/middleware/auth.mts', () => ({
+  authenticate: () => ({ ok: true, userId: 'test-user' }),
+}));
+vi.mock('../netlify/functions/middleware/rate-limit.mts', () => ({
+  checkRateLimit: async () => null,
+}));
+
+beforeEach(() => {
+  watchlistData = new Map();
+  etagCounter = 0;
+  setJsonCalls = 0;
+  beforeFirstWrite = null;
+});
+
+afterEach(() => { vi.resetModules(); });
+
+async function freshModule() {
+  return await import('../netlify/functions/watchlist.mts?t=' + Date.now());
+}
+
+async function postAction(body: unknown): Promise<Response> {
+  const mod = await freshModule();
+  const req = new Request('https://example.test/api/watchlist', {
+    method: 'POST',
+    headers: {
+      Authorization: 'Bearer ' + 'a'.repeat(40),
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  return (mod.default as any)(req, { ip: '127.0.0.1' });
+}
+
+describe('watchlist — concurrent add retains all subjects', () => {
+  it('preserves a concurrent writer when our CAS conflicts', async () => {
+    // Seed: one entry (alice) at etag-1.
+    watchlistData.set('current', {
+      value: {
+        version: 1,
+        entries: [{ id: 'alice', subjectName: 'Alice', riskTier: 'high' }],
+      },
+      etag: 'etag-1',
+    });
+    etagCounter = 1;
+
+    // Between our read of `{alice}` at etag-1 and our setJSON,
+    // another writer adds charlie and bumps etag to etag-99.
+    beforeFirstWrite = () => {
+      watchlistData.set('current', {
+        value: {
+          version: 1,
+          entries: [
+            { id: 'alice', subjectName: 'Alice', riskTier: 'high' },
+            { id: 'charlie', subjectName: 'Charlie', riskTier: 'medium' },
+          ],
+        },
+        etag: 'etag-99',
+      });
+    };
+
+    // We add bob.
+    const res = await postAction({
+      action: 'add', id: 'bob', subjectName: 'Bob', riskTier: 'low',
+    });
+    expect(res.status).toBe(200);
+
+    const finalEntries = (watchlistData.get('current')!.value as any).entries;
+    const ids = finalEntries.map((e: { id: string }) => e.id).sort();
+    expect(ids).toEqual(['alice', 'bob', 'charlie']); // all three survive
+    expect(setJsonCalls).toBe(2); // one conflict + one success
+  });
+
+  it('returns 503 when every CAS attempt loses', async () => {
+    watchlistData.set('current', {
+      value: { version: 1, entries: [] },
+      etag: 'etag-seed',
+    });
+    // Every read returns a fresh etag so every CAS attempt fails.
+    let rev = 0;
+    vi.mocked({} as any); // noop
+    const origGet = watchlistData.get.bind(watchlistData);
+    (watchlistData as any).get = (k: string) => {
+      const v = origGet(k);
+      if (v) {
+        v.etag = 'etag-' + ++rev;
+        watchlistData.set(k, v);
+      }
+      return v;
+    };
+
+    const res = await postAction({
+      action: 'add', id: 'x', subjectName: 'X', riskTier: 'low',
+    });
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBe('watchlist_write_contention');
+  });
+
+  it('single-writer happy path still works', async () => {
+    const res = await postAction({
+      action: 'add', id: 'only', subjectName: 'Only', riskTier: 'low',
+    });
+    expect(res.status).toBe(200);
+    const entries = (watchlistData.get('current')!.value as any).entries;
+    expect(entries).toHaveLength(1);
+    expect(entries[0].id).toBe('only');
+  });
+});
+
+describe('watchlist — concurrent remove preserves a concurrent add', () => {
+  it('re-applies remove on top of a concurrent writer', async () => {
+    // Seed: alice and bob, etag-1.
+    watchlistData.set('current', {
+      value: {
+        version: 1,
+        entries: [
+          { id: 'alice', subjectName: 'Alice', riskTier: 'high' },
+          { id: 'bob', subjectName: 'Bob', riskTier: 'medium' },
+        ],
+      },
+      etag: 'etag-1',
+    });
+    etagCounter = 1;
+
+    // Before our remove lands, a concurrent writer adds charlie.
+    beforeFirstWrite = () => {
+      watchlistData.set('current', {
+        value: {
+          version: 1,
+          entries: [
+            { id: 'alice', subjectName: 'Alice', riskTier: 'high' },
+            { id: 'bob', subjectName: 'Bob', riskTier: 'medium' },
+            { id: 'charlie', subjectName: 'Charlie', riskTier: 'low' },
+          ],
+        },
+        etag: 'etag-99',
+      });
+    };
+
+    // We remove alice.
+    const res = await postAction({ action: 'remove', id: 'alice' });
+    expect(res.status).toBe(200);
+
+    const finalEntries = (watchlistData.get('current')!.value as any).entries;
+    const ids = finalEntries.map((e: { id: string }) => e.id).sort();
+    expect(ids).toEqual(['bob', 'charlie']); // alice removed, charlie preserved
+  });
+});


### PR DESCRIPTION
## Summary

Continuation of the RMW-without-CAS sweep (rounds 5-10 fixed: skill handler, Asana proxy, rate-limit, approvals, auth lockout). Audited the four remaining candidates from the evaluation:

| File | Verdict |
|---|---|
| `watchlist.mts` | **RMW confirmed — fixed** |
| `customer-profile.mts` | **RMW confirmed — fixed** |
| `regulatory-horizon-cron.mts` (seen-list) | Daily singleton cron; low severity; deferred |
| `auth.mts` (session store) | Write-once on login; no RMW |

### `watchlist.mts`

`POST /api/watchlist {action: 'add' | 'remove'}` did a classic RMW on the single `screening-watchlist/current` blob. Two concurrent `add`s for different subjects both read `{entries: []}`, pushed their entry, and the second `setJSON` silently overwrote the first. Adding Alice + Bob concurrently = only one of them survives. **FDL Art.24 audit-chain gap.**

Fix: new `loadFromStoreWithMetadata` + `saveToStoreCas` helpers; POST handler wraps add/remove in a 5-attempt CAS retry; returns **503** `watchlist_write_contention` if all attempts lose.

### `customer-profile.mts`

`handleUpdate` did read → merge → write with no CAS. MLRO A changes `riskRating` while MLRO B changes `pepStatus` → second write wins, first change silently disappears. **FDL Art.24 audit-chain gap on KYC/CDD data.**

Fix: `ProfileStore` gains an OPTIONAL `casUpdate(id, transform)` method. Production blob adapter implements it via `getWithMetadata` + `setJSON({onlyIfMatch})` with 5-attempt retry. `handleUpdate` runs merge+validate inside a transform closure so it is recomputed on every retry — picking up concurrent writers' changes. Stores without `casUpdate` fall back to pre-existing behaviour (tests unchanged).

## Tests

- `tests/watchlistRaceCondition.test.ts` (4 tests) — concurrent add preserves the other writer's entry; concurrent remove preserves a concurrent add; every-CAS-loses path → 503; single-writer baseline.
- `tests/customerProfileUpdateRace.test.ts` (4 tests) — concurrent writer changes one field between our read & write → our merge re-applies on top so BOTH changes land; 404 on missing; 422 on validation failure via CAS path; no-casUpdate fallback still works.

Verified reverting the fixes fails exactly the 4 concurrency tests.

- [x] `npx vitest run` — **4401/4401** passing (4393 → 4401)
- [x] Existing 32-test `customerProfileCrudHandlers.test.ts` still passes unchanged.

## Not fixed in this PR
- **regulatory-horizon-cron.mts seen-list** — daily 04:00 UTC singleton cron, race would produce at most a duplicate brain event, not a regulatory data loss.
- **auth.mts session store** — write-once on login, no RMW pattern to protect.

## Regulatory basis
- **FDL No.10/2025 Art.24** — record retention + audit-chain integrity.
- **Cabinet Res 134/2025 Art.19** — auditable internal review; 503 on CAS exhaustion is client-visible, so every contested write is traceable.

https://claude.ai/code/session_01R9Y37tUnmBhH1uF2i3toB8