### PR TITLE
feat: Asana reconcile live-reads rollout — runbook + read-only summary endpoint (FDL Art.20, Cabinet Res 134/2025 Art.19)

### DIFF
--- a/netlify/functions/asana-reconcile-summary.mts
+++ b/netlify/functions/asana-reconcile-summary.mts
@@ -1,0 +1,318 @@
+/**
+ * Asana Reconcile Summary — on-demand read-only diagnostic.
+ *
+ * GET /.netlify/functions/asana-reconcile-summary[?window=24h|1h|7d]
+ *
+ * Walks the `asana-reconcile-audit` blob store for the requested
+ * window (default 24h) and returns a per-tenant rollup of cron
+ * health and match quality. This is the endpoint the MLRO polls
+ * during the rollout of ASANA_RECONCILE_LIVE_READS_ENABLED so they
+ * can see whether the heuristic case-id matching is tracking real
+ * drift before we wire the reconciler's `actions` output to real
+ * Asana dispatches.
+ *
+ * The endpoint is READ-ONLY — it never writes to any store and
+ * never triggers a reconcile cycle. Safe to hit on demand.
+ *
+ * Auth + rate limit match every other authenticated diagnostic
+ * surface in this repo:
+ *   - `authenticate(req)` against HAWKEYE_BRAIN_TOKEN.
+ *   - 30 requests / 15 min per IP under the `asana-reconcile-summary`
+ *     namespace.
+ *
+ * Regulatory basis:
+ *   FDL No.10/2025 Art.20 — MLRO visibility of brain ↔ Asana drift.
+ *   FDL No.10/2025 Art.24 — reads the audit store only; retention
+ *     lifetime of the underlying blobs is unchanged.
+ *   Cabinet Res 134/2025 Art.19 — audit-rollup surface for internal
+ *     review of the reconcile cron.
+ */
+
+import type { Config, Context } from '@netlify/functions';
+import { getStore } from '@netlify/blobs';
+import { authenticate } from './middleware/auth.mts';
+import { checkRateLimit } from './middleware/rate-limit.mts';
+
+const AUDIT_STORE = 'asana-reconcile-audit';
+const DEFAULT_WINDOW_HOURS = 24;
+const MIN_WINDOW_HOURS = 1;
+const MAX_WINDOW_HOURS = 24 * 7;
+
+interface AuditRow {
+  event?: string;
+  recordedAt?: string;
+  tenantsProcessed?: number;
+  totalActions?: number;
+  durationMs?: number;
+  liveMode?: boolean;
+  note?: string;
+  perTenant?: Array<{
+    tenantId?: string;
+    actions?: number;
+    inAgreement?: number;
+    tolerated?: number;
+    actionKinds?: string[];
+    plansForTenant?: number;
+    asanaTasksMatched?: number;
+    asanaProjectGid?: string | null;
+    fallbackReason?: string;
+  }>;
+}
+
+interface TenantRollup {
+  tenantId: string;
+  ticksObserved: number;
+  totalActions: number;
+  totalInAgreement: number;
+  totalTolerated: number;
+  totalPlansForTenant: number;
+  totalAsanaTasksMatched: number;
+  actionKindCounts: Record<string, number>;
+  latestFallbackReason?: string;
+  latestRecordedAtIso?: string;
+  asanaProjectGid?: string | null;
+  /**
+   * Share of ticks where the cron was able to either find no drift
+   * or report concrete diagnostics (i.e. `fallbackReason` was NOT
+   * set on that tick). 100% = cron is always able to read both
+   * sides; anything lower means the tenant had at least one tick
+   * where the reader aborted with a fallback.
+   */
+  healthyReadPct: number;
+}
+
+interface SummaryResponse {
+  ok: true;
+  generatedAt: string;
+  window: {
+    fromIso: string;
+    toIso: string;
+    hours: number;
+  };
+  auditEntriesScanned: number;
+  lastTickAtIso?: string;
+  liveModeRecentlyEnabled: boolean;
+  totals: {
+    ticks: number;
+    tenantsWithActivity: number;
+    actionsProposed: number;
+    inAgreement: number;
+    tolerated: number;
+  };
+  perTenant: TenantRollup[];
+  readinessHint: string;
+}
+
+function parseWindowHours(raw: string | null): number {
+  if (!raw) return DEFAULT_WINDOW_HOURS;
+  const s = raw.trim().toLowerCase();
+  const m = s.match(/^(\d+(?:\.\d+)?)\s*(h|d)?$/);
+  if (!m) return DEFAULT_WINDOW_HOURS;
+  const num = Number(m[1]);
+  if (!Number.isFinite(num) || num <= 0) return DEFAULT_WINDOW_HOURS;
+  const unit = m[2] ?? 'h';
+  const hours = unit === 'd' ? num * 24 : num;
+  return Math.max(MIN_WINDOW_HOURS, Math.min(MAX_WINDOW_HOURS, hours));
+}
+
+async function listAllBlobs(
+  store: ReturnType<typeof getStore>,
+  prefix: string,
+): Promise<Array<{ key: string }>> {
+  const all: Array<{ key: string }> = [];
+  // Netlify Blobs `list` paginates by default — walk every page.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const iter = (store as any).list({ prefix, paginate: true }) as AsyncIterable<{
+    blobs?: Array<{ key: string }>;
+  }>;
+  for await (const page of iter) {
+    if (page.blobs) for (const b of page.blobs) all.push(b);
+  }
+  return all;
+}
+
+export default async (req: Request, context: Context): Promise<Response> => {
+  if (req.method === 'OPTIONS') return new Response(null, { status: 204 });
+  if (req.method !== 'GET') {
+    return Response.json({ ok: false, error: 'Method not allowed' }, { status: 405 });
+  }
+
+  const rl = await checkRateLimit(req, {
+    clientIp: context.ip,
+    max: 30,
+    namespace: 'asana-reconcile-summary',
+  });
+  if (rl) return rl;
+
+  const auth = authenticate(req);
+  if (!auth.ok) return auth.response ?? Response.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const url = new URL(req.url);
+  const windowHours = parseWindowHours(url.searchParams.get('window'));
+  const windowMs = windowHours * 60 * 60 * 1000;
+  const now = new Date();
+  const fromMs = now.getTime() - windowMs;
+
+  // Walk the YYYY-MM-DD prefixes we care about. One extra day for
+  // safety since the recorded ISO timestamp and the blob key day
+  // bucket can straddle midnight UTC.
+  const dayPrefixes = new Set<string>();
+  for (let offsetMs = 0; offsetMs <= windowMs + 24 * 60 * 60 * 1000; offsetMs += 24 * 60 * 60 * 1000) {
+    dayPrefixes.add(new Date(now.getTime() - offsetMs).toISOString().slice(0, 10));
+  }
+
+  const store = getStore(AUDIT_STORE);
+  const rollup = new Map<string, TenantRollup>();
+  let auditEntriesScanned = 0;
+  let totalTicks = 0;
+  let totalActions = 0;
+  let totalInAgreement = 0;
+  let totalTolerated = 0;
+  let lastTickAtIso: string | undefined;
+  let liveModeRecentlyEnabled = false;
+
+  try {
+    for (const prefix of dayPrefixes) {
+      const blobs = await listAllBlobs(store, `${prefix}/`);
+      for (const blob of blobs) {
+        const body = (await store.get(blob.key, { type: 'json' })) as AuditRow | null;
+        if (!body) continue;
+        // Only interested in cron-tick rows; the cron also writes
+        // per-tenant `asana_reconcile_snapshot_read_failed` rows
+        // which are surfaced via `fallbackReason` in the per-tenant
+        // rollup.
+        if (body.event !== 'asana_reconcile_cron_tick') continue;
+        if (!body.recordedAt) continue;
+        const tickMs = Date.parse(body.recordedAt);
+        if (!Number.isFinite(tickMs) || tickMs < fromMs) continue;
+
+        auditEntriesScanned++;
+        totalTicks++;
+        totalActions += body.totalActions ?? 0;
+        if (body.liveMode) liveModeRecentlyEnabled = true;
+        if (!lastTickAtIso || body.recordedAt > lastTickAtIso) {
+          lastTickAtIso = body.recordedAt;
+        }
+
+        for (const pt of body.perTenant ?? []) {
+          if (!pt.tenantId) continue;
+          let tenant = rollup.get(pt.tenantId);
+          if (!tenant) {
+            tenant = {
+              tenantId: pt.tenantId,
+              ticksObserved: 0,
+              totalActions: 0,
+              totalInAgreement: 0,
+              totalTolerated: 0,
+              totalPlansForTenant: 0,
+              totalAsanaTasksMatched: 0,
+              actionKindCounts: {},
+              healthyReadPct: 0,
+            };
+            rollup.set(pt.tenantId, tenant);
+          }
+          tenant.ticksObserved++;
+          tenant.totalActions += pt.actions ?? 0;
+          tenant.totalInAgreement += pt.inAgreement ?? 0;
+          tenant.totalTolerated += pt.tolerated ?? 0;
+          tenant.totalPlansForTenant += pt.plansForTenant ?? 0;
+          tenant.totalAsanaTasksMatched += pt.asanaTasksMatched ?? 0;
+          totalInAgreement += pt.inAgreement ?? 0;
+          totalTolerated += pt.tolerated ?? 0;
+          for (const kind of pt.actionKinds ?? []) {
+            tenant.actionKindCounts[kind] = (tenant.actionKindCounts[kind] ?? 0) + 1;
+          }
+          if (pt.fallbackReason) {
+            tenant.latestFallbackReason = pt.fallbackReason;
+          }
+          if (!tenant.latestRecordedAtIso || body.recordedAt > tenant.latestRecordedAtIso) {
+            tenant.latestRecordedAtIso = body.recordedAt;
+            tenant.asanaProjectGid = pt.asanaProjectGid ?? null;
+          }
+        }
+      }
+    }
+  } catch (err) {
+    return Response.json(
+      {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 },
+    );
+  }
+
+  // Compute per-tenant healthy-read percentage.
+  for (const tenant of rollup.values()) {
+    if (tenant.ticksObserved === 0) {
+      tenant.healthyReadPct = 0;
+      continue;
+    }
+    // A tick is "healthy" iff the tenant does not carry a fallback
+    // on the latest tick. We only store the latest fallback reason,
+    // so this is a pessimistic boolean: if the latest tick was in
+    // fallback, report the percentage as 0 even if earlier ticks
+    // were clean. That is the right default for a rollout monitor —
+    // the MLRO should see red when the CURRENT state is unhealthy.
+    tenant.healthyReadPct = tenant.latestFallbackReason ? 0 : 100;
+  }
+
+  const perTenant = [...rollup.values()].sort((a, b) =>
+    a.tenantId.localeCompare(b.tenantId),
+  );
+
+  // Plain-English readiness hint so the MLRO doesn't need to read
+  // the runbook on every poll.
+  const readinessHint = (() => {
+    if (totalTicks === 0) {
+      return `No reconcile audit rows in the last ${windowHours}h. Either the cron is disabled (ASANA_RECONCILE_CRON_DISABLED=1) or the audit store is empty.`;
+    }
+    if (!liveModeRecentlyEnabled) {
+      return 'Cron is in OBSERVATIONAL mode (ASANA_RECONCILE_LIVE_READS_ENABLED is not set). Flip the flag when you are ready to start collecting match-quality data.';
+    }
+    const unhealthy = perTenant.filter((t) => t.healthyReadPct < 100);
+    if (unhealthy.length > 0) {
+      return `Live reads enabled. ${unhealthy.length}/${perTenant.length} tenants have an unhealthy latest tick (fallbackReason set). Investigate before wiring actions to dispatch.`;
+    }
+    return `Live reads enabled. All ${perTenant.length} tenants are reading cleanly. Review ${windowHours}h of actionKindCounts before enabling dispatch.`;
+  })();
+
+  const resp: SummaryResponse = {
+    ok: true,
+    generatedAt: now.toISOString(),
+    window: {
+      fromIso: new Date(fromMs).toISOString(),
+      toIso: now.toISOString(),
+      hours: windowHours,
+    },
+    auditEntriesScanned,
+    lastTickAtIso,
+    liveModeRecentlyEnabled,
+    totals: {
+      ticks: totalTicks,
+      tenantsWithActivity: rollup.size,
+      actionsProposed: totalActions,
+      inAgreement: totalInAgreement,
+      tolerated: totalTolerated,
+    },
+    perTenant,
+    readinessHint,
+  };
+
+  return Response.json(resp, {
+    headers: {
+      'Cache-Control': 'no-store',
+      'X-Content-Type-Options': 'nosniff',
+    },
+  });
+};
+
+export const config: Config = {
+  path: '/api/asana/reconcile-summary',
+  method: ['GET', 'OPTIONS'],
+};
+
+// Exports for unit tests only.
+export const __test__ = {
+  parseWindowHours,
+};

--- a/runbooks/asana-reconcile-cron.md
+++ b/runbooks/asana-reconcile-cron.md
@@ -1,0 +1,112 @@
+# asana-reconcile-cron
+
+**Owner:** MLRO + SRE on-call
+**Endpoint:** `/.netlify/functions/asana-reconcile-cron`
+**Summary endpoint (read-only, operator-facing):** `/.netlify/functions/asana-reconcile-summary`
+**Schedule:** every 5 minutes
+**Regulatory anchor:** FDL No.10/2025 Art.20, Art.24; Cabinet Res 134/2025 Art.12-14, Art.19
+
+## Purpose
+Continuous reconciliation of brain state (via `asana-plans` blob
+store) against Asana task state (via `listProjectTasks` for each
+tenant's compliance project). The cron ticks on schedule, writes
+an audit row per tenant, and produces a drift-action list that
+the MLRO reviews before actions become real writes.
+
+## Two operating modes (opt-in)
+
+| Mode | `ASANA_RECONCILE_LIVE_READS_ENABLED` | Behaviour |
+|---|---|---|
+| **Observational** (default) | unset / `0` / `false` | Cron ticks on schedule, writes audit rows with empty `brainCases` + `asanaTasks`, reconciler reports zero actions. **Zero side effects on Asana or the brain.** |
+| **Live reads** | `1` / `true` / `yes` | Cron reads `asana-plans` blob + `listProjectTasks` per tenant, diffs via `reconcileTenant`, records proposed actions in the audit row. **Still zero side effects** — actions are logged, not dispatched. |
+
+Actions only become real writes in a follow-on PR that wires
+`result.actions` into the orchestrator. Flipping the flag is safe
+on its own.
+
+## Rollout checklist — moving from observational to live reads
+
+Pre-flip:
+1. **Confirm observational mode is clean.** Tail `/.netlify/functions/asana-reconcile-summary?window=24h` — expect every row to show `fallbackReason: "live_reads_disabled_by_env"` and zero actions. Any row diverging from that means a stale env var.
+2. **Confirm the tenant registry is current.** The cron iterates
+   `COMPANY_REGISTRY` (in `src/domain/customers.ts`). A tenant
+   missing an `asanaComplianceProjectGid` will be reported as
+   `resolver_failed: ...` in the audit row — harmless, but noisy.
+   Backfill missing GIDs or mark the tenant inactive before flipping.
+3. **Confirm `ASANA_ACCESS_TOKEN` and workspace GID are set** in
+   the same Netlify environment. `listProjectTasks` will return
+   `ok: false` without them.
+
+Flip:
+4. In the Netlify site → Environment variables, set
+   `ASANA_RECONCILE_LIVE_READS_ENABLED=1`. Save.
+5. Wait one cron tick (≤5 min). Netlify functions do not need a
+   redeploy to pick up env changes.
+
+Post-flip — first 24h monitoring (the regulatory-review window):
+6. Poll `/.netlify/functions/asana-reconcile-summary?window=24h` every 1-2 hours:
+   - `matchRatePct` should stabilise; low values (< 40%) suggest
+     task-name drift that the heuristic is missing.
+   - `plansForTenant` should be > 0 for tenants with recent brain activity.
+   - `actionKinds` should be dominated by `no_drift`; the
+     presence of `asana_ahead_of_brain` / `brain_ahead_of_asana`
+     points at real drift that needs manual review.
+7. **Do NOT wire actions to real dispatches** until you see ≥ 3
+   consecutive clean cycles with consistent `matchRatePct`. The
+   follow-on PR that wires dispatch SHOULD:
+   - go through `/regulatory-spec` planning
+   - land behind its own env flag (`ASANA_RECONCILE_DISPATCH_ENABLED`)
+   - default off
+
+## Escape hatches
+
+| Env var | Value | Effect |
+|---|---|---|
+| `ASANA_RECONCILE_CRON_DISABLED` | `1` | The cron becomes a no-op; no audit rows written. Use if the cron is blowing the budget. |
+| `ASANA_RECONCILE_LIVE_READS_ENABLED` | unset/`0` | Reverts to observational mode immediately (next tick). |
+
+## Expected healthy state
+
+- Fires every 5 minutes.
+- Audit row per tick captures: tenants processed, total actions, per-tenant match diagnostics, liveMode flag, duration.
+- Observational: `plansScanned: 0`, `asanaTasksScanned: 0`, every tenant carries `fallbackReason: "live_reads_disabled_by_env"`.
+- Live reads: `plansScanned > 0` on tenants with recent brain activity, `asanaTasksMatched / asanaTasksScanned` > 40%, `fallbackReason` unset for healthy tenants.
+
+## Common failure modes
+
+| Symptom | First check |
+|---|---|
+| Every tenant shows `tenant_not_in_company_registry` | Stale cron — registry changed without redeploy. Trigger a Netlify build. |
+| Heavy `listProjectTasks_failed` rate | `ASANA_ACCESS_TOKEN` expired or workspace GID mismatch. |
+| `matchRatePct` drops after flipping flag | Task-name format changed — the heuristic looks for `caseId` as a substring of the task name. If the dispatcher renamed tasks, update the match function or wire the real custom-field GID. |
+| Summary endpoint returns stale data | Audit store backlog — rows are written hourly, summary reads the last 24h. Normal up to a 5-min cadence lag. |
+| Cron appears to run but no audit rows | Check `ASANA_RECONCILE_CRON_DISABLED` is not accidentally `1`. |
+
+## Recovery steps
+
+1. If actions (real writes) cause unexpected drift, UNSET
+   `ASANA_RECONCILE_LIVE_READS_ENABLED` first. That alone restores
+   observational mode. Do NOT disable the cron — the audit trail
+   is the only regulatory record that the reconciler was monitoring.
+2. If the brain-side plan blobs look corrupt, the cron tolerates
+   malformed entries (caught per-blob, non-fatal). Run
+   `/audit-pack` for the affected tenant to rebuild.
+3. If the Asana side is unreachable, the `fallbackReason` in
+   every audit row will capture the error; nothing to clean up on
+   the brain side.
+
+## Regulatory notes
+
+- **FDL Art.20** — MLRO visibility of brain ↔ Asana drift is the
+  point of this cron. Observational mode satisfies the "scheduled
+  reconciliation" obligation even when live reads are off.
+- **FDL Art.24** — audit rows are retained in the
+  `asana-reconcile-audit` blob store; follow the 10-year retention
+  policy. The summary endpoint is read-only and does not mutate
+  the trail.
+- **Cabinet Res 134/2025 Art.12-14** — four-eyes integrity is not
+  affected by this cron; it reconciles AFTER the four-eyes decision
+  has landed.
+- **Cabinet Res 134/2025 Art.19** — the audit rows + summary
+  endpoint give the internal-review function everything it needs
+  to confirm the reconciler is working.

--- a/tests/asanaReconcileSummary.test.ts
+++ b/tests/asanaReconcileSummary.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for the asana-reconcile-summary read-only diagnostic
+ * endpoint. The endpoint aggregates the last N hours of
+ * `asana-reconcile-cron` audit rows so MLROs can watch the
+ * rollout of ASANA_RECONCILE_LIVE_READS_ENABLED without reading
+ * individual blobs.
+ *
+ * The bulk of the logic is in the per-tenant rollup and the
+ * `readinessHint` string — this test drives the handler through
+ * a fake Netlify Blobs store that scripts a few representative
+ * audit rows.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+interface FakeBlob { value: unknown }
+let store: Map<string, FakeBlob>;
+
+vi.mock('@netlify/blobs', () => ({
+  getStore: () => ({
+    async get(key: string) {
+      return store.get(key)?.value ?? null;
+    },
+    list({ prefix }: { prefix: string; paginate?: boolean }) {
+      const keys = [...store.keys()].filter((k) => k.startsWith(prefix));
+      // Return an async iterable of one page (matches the SDK shape
+      // the endpoint expects).
+      return {
+        async *[Symbol.asyncIterator]() {
+          yield { blobs: keys.map((key) => ({ key })) };
+        },
+      };
+    },
+  }),
+}));
+
+// Bypass auth + rate limit — we are testing the summary aggregation.
+vi.mock('../netlify/functions/middleware/auth.mts', () => ({
+  authenticate: () => ({ ok: true, userId: 'test' }),
+}));
+vi.mock('../netlify/functions/middleware/rate-limit.mts', () => ({
+  checkRateLimit: async () => null,
+}));
+
+beforeEach(() => {
+  store = new Map();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+async function freshModule() {
+  return await import('../netlify/functions/asana-reconcile-summary.mts?t=' + Date.now());
+}
+
+function seedTick(params: {
+  iso: string;
+  liveMode: boolean;
+  perTenant: Array<{
+    tenantId: string;
+    fallbackReason?: string;
+    actions?: number;
+    inAgreement?: number;
+    plansForTenant?: number;
+    asanaTasksMatched?: number;
+    actionKinds?: string[];
+  }>;
+}) {
+  const key = `${params.iso.slice(0, 10)}/${Date.parse(params.iso)}.json`;
+  store.set(key, {
+    value: {
+      event: 'asana_reconcile_cron_tick',
+      recordedAt: params.iso,
+      tenantsProcessed: params.perTenant.length,
+      totalActions: params.perTenant.reduce((a, b) => a + (b.actions ?? 0), 0),
+      liveMode: params.liveMode,
+      perTenant: params.perTenant,
+    },
+  });
+}
+
+async function runSummary(window = '24h') {
+  const mod = await freshModule();
+  const req = new Request(
+    `https://example.test/api/asana/reconcile-summary?window=${window}`,
+    {
+      method: 'GET',
+      headers: { Authorization: 'Bearer ' + 'a'.repeat(40) },
+    },
+  );
+  return (mod.default as any)(req, { ip: '1.2.3.4' });
+}
+
+describe('asana-reconcile-summary', () => {
+  it('reports readinessHint "observational mode" when liveMode is false', async () => {
+    seedTick({
+      iso: new Date().toISOString(),
+      liveMode: false,
+      perTenant: [
+        { tenantId: 'madison', fallbackReason: 'live_reads_disabled_by_env' },
+      ],
+    });
+    const res = await runSummary();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.liveModeRecentlyEnabled).toBe(false);
+    expect(body.readinessHint).toMatch(/OBSERVATIONAL/);
+    expect(body.totals.ticks).toBe(1);
+  });
+
+  it('flags unhealthy tenants in readinessHint when live reads are on', async () => {
+    const iso = new Date().toISOString();
+    seedTick({
+      iso,
+      liveMode: true,
+      perTenant: [
+        { tenantId: 'madison', plansForTenant: 3, asanaTasksMatched: 2, actionKinds: ['no_drift'] },
+        { tenantId: 'naples', fallbackReason: 'listProjectTasks_failed: 401' },
+      ],
+    });
+    const res = await runSummary();
+    const body = await res.json();
+    expect(body.readinessHint).toMatch(/1\/2 tenants.*unhealthy/);
+    const naples = body.perTenant.find((t: { tenantId: string }) => t.tenantId === 'naples');
+    expect(naples.healthyReadPct).toBe(0);
+    expect(naples.latestFallbackReason).toBe('listProjectTasks_failed: 401');
+    const madison = body.perTenant.find((t: { tenantId: string }) => t.tenantId === 'madison');
+    expect(madison.healthyReadPct).toBe(100);
+    expect(madison.actionKindCounts).toEqual({ no_drift: 1 });
+  });
+
+  it('returns "No audit rows" hint when the window is empty', async () => {
+    const res = await runSummary('1h');
+    const body = await res.json();
+    expect(body.totals.ticks).toBe(0);
+    expect(body.readinessHint).toMatch(/No reconcile audit rows/);
+  });
+
+  it('ignores audit rows older than the requested window', async () => {
+    const old = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+    seedTick({ iso: old, liveMode: true, perTenant: [{ tenantId: 'madison' }] });
+    seedTick({
+      iso: new Date().toISOString(),
+      liveMode: true,
+      perTenant: [{ tenantId: 'naples', actionKinds: ['no_drift'] }],
+    });
+    const res = await runSummary('24h');
+    const body = await res.json();
+    expect(body.totals.ticks).toBe(1);
+    expect(body.perTenant.map((t: { tenantId: string }) => t.tenantId)).toEqual(['naples']);
+  });
+
+  it('aggregates action kind counts across multiple ticks', async () => {
+    const now = Date.now();
+    const tickA = new Date(now - 30 * 60 * 1000).toISOString();
+    const tickB = new Date(now - 10 * 60 * 1000).toISOString();
+    seedTick({
+      iso: tickA,
+      liveMode: true,
+      perTenant: [{ tenantId: 'madison', actionKinds: ['no_drift'] }],
+    });
+    seedTick({
+      iso: tickB,
+      liveMode: true,
+      perTenant: [{ tenantId: 'madison', actionKinds: ['asana_ahead_of_brain'] }],
+    });
+    const res = await runSummary('24h');
+    const body = await res.json();
+    const madison = body.perTenant[0];
+    expect(madison.ticksObserved).toBe(2);
+    expect(madison.actionKindCounts).toEqual({
+      no_drift: 1,
+      asana_ahead_of_brain: 1,
+    });
+  });
+
+  it('parses the window query param (h / d suffixes, bounds)', async () => {
+    const mod = await freshModule();
+    const { __test__ } = mod as any;
+    expect(__test__.parseWindowHours(null)).toBe(24);
+    expect(__test__.parseWindowHours('12h')).toBe(12);
+    expect(__test__.parseWindowHours('2d')).toBe(48);
+    // Below the minimum rounds up to 1h.
+    expect(__test__.parseWindowHours('0.1h')).toBe(1);
+    // Above the max clamps to 7d.
+    expect(__test__.parseWindowHours('30d')).toBe(168);
+    // Garbage falls back to default.
+    expect(__test__.parseWindowHours('banana')).toBe(24);
+  });
+});
+
+describe('asana-reconcile-summary — method + auth', () => {
+  it('returns 405 on POST', async () => {
+    const mod = await freshModule();
+    const res = await (mod.default as any)(
+      new Request('https://example.test/api/asana/reconcile-summary', { method: 'POST' }),
+      { ip: '1.2.3.4' },
+    );
+    expect(res.status).toBe(405);
+  });
+
+  it('returns 204 on OPTIONS preflight', async () => {
+    const mod = await freshModule();
+    const res = await (mod.default as any)(
+      new Request('https://example.test/api/asana/reconcile-summary', { method: 'OPTIONS' }),
+      { ip: '1.2.3.4' },
+    );
+    expect(res.status).toBe(204);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the carry-over from #223's evaluation: "Flip `ASANA_RECONCILE_LIVE_READS_ENABLED=1`. ~1 session to enable + monitor."

The reconcile cron already gates live reads behind the env flag and writes per-tick audit rows in both modes. The missing piece for rollout was **operator tooling**:

### `runbooks/asana-reconcile-cron.md`

Runbook following the existing template. Captures:
- **Flipping the flag alone is safe** — it does NOT dispatch writes to Asana or the brain; it only reads both sides and logs proposed actions.
- Pre-flip checklist (confirm observational mode is clean, tenant registry is current, Asana creds are set).
- Post-flip monitoring steps pointing at the new summary endpoint.
- **Follow-on PR that wires real dispatch must land behind `ASANA_RECONCILE_DISPATCH_ENABLED`, default off.**
- Escape hatches (`ASANA_RECONCILE_CRON_DISABLED=1`, revert the flag).

### `netlify/functions/asana-reconcile-summary.mts`

New **read-only** diagnostic endpoint: `GET /api/asana/reconcile-summary[?window=24h|1h|7d]`.

Aggregates `asana-reconcile-audit` rows over the requested window (clamped `[1h, 7d]`). Returns:
- **totals** (ticks, tenants, actions proposed, in-agreement, tolerated)
- **perTenant** (ticksObserved, actionKindCounts, latestFallbackReason, healthyReadPct, asanaProjectGid)
- **liveModeRecentlyEnabled** flag
- **readinessHint** — plain-English line the operator can paste into a ticket

Auth + rate limit match the rest of the diagnostic surfaces (`authenticate` + 30/15min under a dedicated namespace).

### Tests

`tests/asanaReconcileSummary.test.ts` (8 tests): observational-mode hint, unhealthy-tenant hint, empty-window behavior, window filter, multi-tick aggregation, query-param parser (`h`/`d`, clamping, defaults), method gating.

- [x] `npx vitest run tests/asanaReconcileSummary.test.ts` — 8/8 passing
- [x] `npx vitest run` — **4409/4409** passing (4401 → 4409)

## What this does NOT do

- Does NOT flip the env var (lives in Netlify site config, not code — runbook documents the click path).
- Does NOT wire `result.actions` to real dispatches — runbook explicitly defers to a follow-on PR.
- Does NOT alter the reconcile cron itself.

## Regulatory basis

- **FDL Art.20** — MLRO visibility of brain ↔ Asana drift; summary endpoint is the visibility surface.
- **FDL Art.24** — reads audit store only; retention unchanged.
- **Cabinet Res 134/2025 Art.19** — audit-rollup surface for internal review.

https://claude.ai/code/session_01R9Y37tUnmBhH1uF2i3toB8