### PR TITLE
feat: wire real /screen execution into Asana comment handler (FDL Art.35, Cabinet Res 74/2020 Art.4-7)

### DIFF
--- a/netlify/functions/asana-comment-skill-handler.mts
+++ b/netlify/functions/asana-comment-skill-handler.mts
@@ -32,6 +32,7 @@ import { getStore } from '@netlify/blobs';
 
 const JOBS_STORE = 'asana-skill-jobs';
 const AUDIT_STORE = 'asana-skill-audit';
+const SANCTIONS_SNAPSHOT_STORE = 'sanctions-snapshots';
 const ASANA_API_BASE = 'https://app.asana.com/api/1.0';
 
 // Poison-pill defence: after this many failed attempts, the job is
@@ -39,6 +40,36 @@ const ASANA_API_BASE = 'https://app.asana.com/api/1.0';
 // Five gives a ~5-minute window of natural retries for transient
 // Asana outages before we declare the job permanently poisoned.
 const MAX_ATTEMPTS = 5;
+
+// Sources the `sanctions-ingest-cron` persists snapshots for. Mirrors
+// the `SanctionsSource` type in src/services/sanctionsIngest.ts —
+// duplicated here to keep this handler a zero-import unit testable
+// surface.
+const SANCTIONS_SOURCES = [
+  'OFAC_SDN',
+  'OFAC_CONS',
+  'UN',
+  'EU',
+  'UK_OFSI',
+  'UAE_EOCN',
+] as const;
+
+// Cap total matches returned to the MLRO. The Asana stories API
+// rejects bodies > ~65 KB; a few dozen names with aliases is well
+// within that, while 1 000 matches could blow the limit. The MLRO
+// can always narrow the query if the cap is hit.
+const SCREEN_MAX_TOTAL_MATCHES = 25;
+const SCREEN_MAX_PER_SOURCE = 8;
+
+interface NormalisedSanction {
+  source: string;
+  sourceId: string;
+  primaryName: string;
+  aliases: string[];
+  type: string;
+  programmes?: string[];
+  nationality?: string;
+}
 
 interface SkillJob {
   jobId: string;
@@ -65,6 +96,224 @@ async function writeAudit(payload: Record<string, unknown>): Promise<void> {
   } catch {
     /* audit store failures are non-fatal */
   }
+}
+
+// ---------------------------------------------------------------------------
+// Real skill execution
+// ---------------------------------------------------------------------------
+//
+// Rounds 5-10 left this handler posting a canned acknowledgement for
+// every slash command. This round wires real execution for the
+// highest-leverage skill — `/screen` — by reading the persisted
+// sanctions snapshots the `sanctions-ingest-cron` writes into the
+// `sanctions-snapshots` blob store. Other skills still fall back to
+// `buildStubExecution` until they are plumbed individually (follow-on
+// PRs, tracked in the evaluation doc).
+
+function normaliseQueryToken(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize('NFKD')
+    // Strip combining marks (diaeresis, cedilla, tilde, etc.) so
+    // `Björk` collapses to `bjork` in the same token. Done BEFORE
+    // the punctuation sweep so the mark doesn't become a space and
+    // split the token.
+    .replace(/\p{M}+/gu, '')
+    .replace(/[^\p{L}\p{N}\s]/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function sanctionMatchesQuery(
+  entry: NormalisedSanction,
+  queryLower: string,
+): boolean {
+  if (!queryLower) return false;
+  const candidates: string[] = [entry.primaryName, ...(entry.aliases ?? [])];
+  for (const raw of candidates) {
+    if (!raw) continue;
+    const normalised = normaliseQueryToken(raw);
+    if (!normalised) continue;
+    if (normalised.includes(queryLower)) return true;
+  }
+  return false;
+}
+
+async function loadLatestSnapshot(
+  source: string,
+): Promise<NormalisedSanction[]> {
+  try {
+    const store = getStore(SANCTIONS_SNAPSHOT_STORE);
+    const list = await store.list({ prefix: `${source}/` });
+    if (!list.blobs || list.blobs.length === 0) return [];
+    // Blob list order is not guaranteed lexicographic; sort by key
+    // (prefixed with YYYY-MM-DD) and take the newest.
+    const sorted = [...list.blobs].sort((a, b) => (a.key < b.key ? 1 : -1));
+    const latest = sorted[0];
+    const data = (await store.get(latest.key, { type: 'json' })) as
+      | NormalisedSanction[]
+      | null;
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+interface SkillExecutionResult {
+  reply: string;
+  citation: string;
+  /** True when this handler produced the reply itself (vs falling
+   *  back to the stub). Surfaces in the audit row for observability. */
+  real: boolean;
+  /** Non-fatal diagnostic messages surfaced alongside the audit
+   *  row but NEVER in the Asana reply (so we do not leak internal
+   *  state to the MLRO comment). */
+  diagnostics?: string[];
+}
+
+async function executeScreenSkill(
+  rawQuery: string,
+): Promise<SkillExecutionResult> {
+  const citation = 'FDL No.10/2025 Art.35; Cabinet Res 74/2020 Art.4-7';
+  const diagnostics: string[] = [];
+
+  const queryLower = normaliseQueryToken(rawQuery);
+  if (!queryLower || queryLower.length < 2) {
+    return {
+      reply:
+        'Skill `/screen` rejected: query must be at least 2 non-punctuation characters.\n\n' +
+        'FDL Art.29 — do not share this reply with the subject.',
+      citation,
+      real: true,
+    };
+  }
+
+  // Load every source snapshot in parallel so the whole command
+  // completes within the Netlify 10 s default budget even when all
+  // six lists are cached cold.
+  const loadResults = await Promise.all(
+    SANCTIONS_SOURCES.map(async (source) => {
+      const snapshot = await loadLatestSnapshot(source);
+      return { source, snapshot };
+    }),
+  );
+
+  let totalEntriesChecked = 0;
+  let totalMatches = 0;
+  const perSource: Array<{
+    source: string;
+    total: number;
+    matches: NormalisedSanction[];
+  }> = [];
+
+  for (const { source, snapshot } of loadResults) {
+    totalEntriesChecked += snapshot.length;
+    if (snapshot.length === 0) {
+      diagnostics.push(`no snapshot for ${source}`);
+      perSource.push({ source, total: 0, matches: [] });
+      continue;
+    }
+    const matches: NormalisedSanction[] = [];
+    for (const entry of snapshot) {
+      if (sanctionMatchesQuery(entry, queryLower)) {
+        matches.push(entry);
+        if (matches.length >= SCREEN_MAX_PER_SOURCE) break;
+      }
+    }
+    totalMatches += matches.length;
+    perSource.push({ source, total: matches.length, matches });
+  }
+
+  const lines: string[] = [
+    `Skill \`/screen\` — sanctions screening`,
+    '',
+    `Query: \`${rawQuery}\``,
+    `Lists checked: ${SANCTIONS_SOURCES.join(', ')}`,
+    `Entries scanned: ${totalEntriesChecked.toLocaleString('en-US')}`,
+    `Matches found: ${totalMatches}${totalMatches >= SCREEN_MAX_TOTAL_MATCHES ? ' (capped)' : ''}`,
+    '',
+  ];
+
+  if (totalMatches === 0) {
+    lines.push('No matches across any list.');
+    lines.push('');
+    lines.push(
+      '**Important:** a zero-match result is NOT a clearance. Re-run' +
+        ' with alias variants (name order, transliteration, legal-form' +
+        ' suffixes stripped) before you rely on this.',
+    );
+  } else {
+    let surfaced = 0;
+    for (const { source, total, matches } of perSource) {
+      if (matches.length === 0) continue;
+      lines.push(`**${source}** — ${total} match${total === 1 ? '' : 'es'}`);
+      for (const m of matches) {
+        if (surfaced >= SCREEN_MAX_TOTAL_MATCHES) {
+          lines.push(`… plus further matches (output capped at ${SCREEN_MAX_TOTAL_MATCHES})`);
+          break;
+        }
+        surfaced++;
+        const programmes = (m.programmes ?? []).slice(0, 3).join(', ');
+        const aliasSummary =
+          m.aliases && m.aliases.length > 0
+            ? ` — aka ${m.aliases.slice(0, 2).join(' / ')}${m.aliases.length > 2 ? ' …' : ''}`
+            : '';
+        const programmeSuffix = programmes ? ` [${programmes}]` : '';
+        lines.push(
+          `  • ${m.primaryName}${aliasSummary}${programmeSuffix}  (id: ${m.sourceId})`,
+        );
+      }
+      lines.push('');
+      if (surfaced >= SCREEN_MAX_TOTAL_MATCHES) break;
+    }
+    lines.push(
+      '**Next step:** if any of these are plausibly the subject,' +
+        ' open an incident via `/incident <case-id> sanctions-match`' +
+        ' and raise the four-eyes queue.',
+    );
+  }
+
+  lines.push('');
+  lines.push(
+    `Regulatory basis: ${citation}`,
+  );
+  lines.push('FDL Art.29 — no tipping off. Do not share this comment with the subject.');
+
+  return {
+    reply: lines.join('\n'),
+    citation,
+    real: true,
+    diagnostics: diagnostics.length > 0 ? diagnostics : undefined,
+  };
+}
+
+async function executeSkillInvocation(
+  routerModule: {
+    buildStubExecution: (invocation: {
+      skill: { name: string; category: string; description: string; citation: string };
+      args: string[];
+      rawComment: string;
+    }) => { reply: string; citation: string };
+  },
+  invocation: {
+    skill: { name: string; category: string; description: string; citation: string };
+    args: string[];
+    rawComment: string;
+  },
+): Promise<SkillExecutionResult> {
+  const name = invocation.skill.name;
+  if (name === 'screen' && invocation.args.length > 0) {
+    // Concatenate args so `/screen Acme Trading LLC` is one query.
+    // Trim trailing punctuation so the MLRO can copy-paste from
+    // emails without losing precision.
+    const query = invocation.args.join(' ').replace(/[.,;:!?]+$/g, '').trim();
+    return executeScreenSkill(query);
+  }
+  // Any other skill — fall back to the stub. Each "real" executor is
+  // added incrementally; the stub's reply body is stable so partial
+  // rollout is safe for the MLRO.
+  const stub = routerModule.buildStubExecution(invocation);
+  return { reply: stub.reply, citation: stub.citation, real: false };
 }
 
 interface AsanaGetResult<T> {
@@ -292,7 +541,22 @@ export default async (): Promise<Response> => {
       // slot instead of retried forever, which previously pegged
       // the shared Asana rate limit on any poison-pill job.
       if (routed.invocation && job.parentTaskGid) {
-        const execResult = routerModule.buildStubExecution(routed.invocation);
+        const execResult = await executeSkillInvocation(
+          routerModule,
+          routed.invocation,
+        );
+        if (execResult.diagnostics && execResult.diagnostics.length > 0) {
+          // Diagnostics never leave the audit trail — we deliberately
+          // do NOT include them in the Asana reply so operators do not
+          // see the internal state of the snapshot store.
+          await writeAudit({
+            event: 'skill_exec_diagnostics',
+            jobId: job.jobId,
+            skill: routed.invocation.skill.name,
+            real: execResult.real,
+            diagnostics: execResult.diagnostics,
+          });
+        }
         const postRes = await asanaPost(
           `/tasks/${encodeURIComponent(job.parentTaskGid)}/stories`,
           token,
@@ -352,4 +616,13 @@ export default async (): Promise<Response> => {
 
 export const config: Config = {
   schedule: '* * * * *',
+};
+
+// Exports for unit tests only. Production callers use the default
+// cron handler above.
+export const __test__ = {
+  executeScreenSkill,
+  executeSkillInvocation,
+  sanctionMatchesQuery,
+  normaliseQueryToken,
 };

--- a/tests/asanaSkillScreenExecutor.test.ts
+++ b/tests/asanaSkillScreenExecutor.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Tests for the real `/screen` skill executor inside
+ * netlify/functions/asana-comment-skill-handler.mts.
+ *
+ * Previously the handler posted a canned "acknowledged" reply for
+ * every slash command. This round wires real sanctions screening
+ * for `/screen <query>` by reading the persisted sanctions
+ * snapshots (the `sanctions-snapshots` blob store populated by
+ * `sanctions-ingest-cron`). Every other skill still falls back to
+ * the stub executor.
+ *
+ * Scope of these tests:
+ *   - query normalisation + substring matching against primary name
+ *     and aliases, case-insensitive, punctuation-safe;
+ *   - multi-list scan (UN + OFAC_SDN + EU etc.) returns a per-source
+ *     match count;
+ *   - per-source cap + total cap prevent a huge payload from
+ *     breaking the Asana stories API;
+ *   - zero-match reply includes the regulator-mandated
+ *     "zero match is NOT a clearance" caveat;
+ *   - every reply ends with the FDL Art.29 no-tipping-off line;
+ *   - non-`/screen` skills still return the stub executor's reply,
+ *     so partial rollout is safe for the MLRO.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Fake Netlify Blobs store — tests script the shape of
+// `sanctions-snapshots/<SOURCE>/<day>/snapshot.json`.
+let snapshotStore: Map<string, unknown[]>;
+
+vi.mock('@netlify/blobs', () => ({
+  getStore: (name: string) => {
+    if (name === 'sanctions-snapshots') {
+      return {
+        async list({ prefix }: { prefix: string }) {
+          const keys = [...snapshotStore.keys()].filter((k) =>
+            k.startsWith(prefix),
+          );
+          return { blobs: keys.map((key) => ({ key })) };
+        },
+        async get(key: string) {
+          return snapshotStore.get(key) ?? null;
+        },
+      };
+    }
+    // Any other store (audit) — no-op.
+    return {
+      async setJSON() {},
+      async get() { return null; },
+      async list() { return { blobs: [] }; },
+      async delete() {},
+    };
+  },
+}));
+
+beforeEach(() => {
+  snapshotStore = new Map();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+async function freshModule() {
+  return await import('../netlify/functions/asana-comment-skill-handler.mts?t=' + Date.now());
+}
+
+function seed(source: string, day: string, entries: unknown[]) {
+  snapshotStore.set(`${source}/${day}/snapshot.json`, entries);
+}
+
+describe('/screen — query normalisation', () => {
+  it('lowercases, strips punctuation, collapses whitespace', async () => {
+    const { __test__ } = await freshModule();
+    expect(__test__.normaliseQueryToken('  Acme,  Trading  LLC.  ')).toBe(
+      'acme trading llc',
+    );
+  });
+
+  it('normaliseQueryToken strips diacritics', async () => {
+    const { __test__ } = await freshModule();
+    expect(__test__.normaliseQueryToken('Björk Ösçar')).toBe('bjork oscar');
+  });
+});
+
+describe('/screen — matching', () => {
+  it('matches against primaryName case-insensitively', async () => {
+    const { __test__ } = await freshModule();
+    const entry = {
+      source: 'OFAC_SDN',
+      sourceId: '1',
+      primaryName: 'ACME TRADING LLC',
+      aliases: [],
+      type: 'entity',
+    };
+    expect(__test__.sanctionMatchesQuery(entry, 'acme trading')).toBe(true);
+  });
+
+  it('matches against aliases', async () => {
+    const { __test__ } = await freshModule();
+    const entry = {
+      source: 'OFAC_SDN',
+      sourceId: '1',
+      primaryName: 'Unrelated Shell Co',
+      aliases: ['Acme Trading LLC', 'ATL'],
+      type: 'entity',
+    };
+    expect(__test__.sanctionMatchesQuery(entry, 'acme')).toBe(true);
+  });
+
+  it('does not match on a 2-word fragment that spans tokens uninterestingly', async () => {
+    const { __test__ } = await freshModule();
+    const entry = {
+      source: 'UN',
+      sourceId: '2',
+      primaryName: 'Bob Smith',
+      aliases: [],
+      type: 'individual',
+    };
+    expect(__test__.sanctionMatchesQuery(entry, 'alice')).toBe(false);
+  });
+});
+
+describe('/screen — end-to-end executor', () => {
+  it('returns a zero-match reply with the no-clearance caveat', async () => {
+    seed('OFAC_SDN', '2026-04-17', [
+      {
+        source: 'OFAC_SDN',
+        sourceId: '1',
+        primaryName: 'Someone Else',
+        aliases: [],
+        type: 'individual',
+      },
+    ]);
+
+    const { __test__ } = await freshModule();
+    const result = await __test__.executeScreenSkill('Brand New Customer LLC');
+    expect(result.real).toBe(true);
+    expect(result.reply).toContain('Matches found: 0');
+    expect(result.reply).toContain('NOT a clearance');
+    expect(result.reply).toContain('FDL Art.29');
+  });
+
+  it('lists matches per source when the query hits multiple lists', async () => {
+    seed('OFAC_SDN', '2026-04-17', [
+      {
+        source: 'OFAC_SDN',
+        sourceId: '10001',
+        primaryName: 'ACME TRADING LLC',
+        aliases: ['ATL'],
+        type: 'entity',
+        programmes: ['SDGT'],
+      },
+    ]);
+    seed('UN', '2026-04-17', [
+      {
+        source: 'UN',
+        sourceId: 'UN-99',
+        primaryName: 'Acme Shipping',
+        aliases: ['Acme Trading'],
+        type: 'entity',
+        programmes: ['UNSC-1718'],
+      },
+    ]);
+
+    const { __test__ } = await freshModule();
+    const result = await __test__.executeScreenSkill('Acme');
+    expect(result.real).toBe(true);
+    expect(result.reply).toContain('Matches found: 2');
+    expect(result.reply).toContain('**OFAC_SDN**');
+    expect(result.reply).toContain('ACME TRADING LLC');
+    expect(result.reply).toContain('[SDGT]');
+    expect(result.reply).toContain('**UN**');
+    expect(result.reply).toContain('Acme Shipping');
+    expect(result.reply).toContain('id: 10001');
+    expect(result.reply).toContain('id: UN-99');
+    expect(result.reply).toContain('/incident');
+  });
+
+  it('caps total matches at SCREEN_MAX_TOTAL_MATCHES', async () => {
+    // Seed 50 matching entries in one source; cap is 25 total /
+    // 8 per source.
+    const many = Array.from({ length: 50 }, (_, i) => ({
+      source: 'OFAC_SDN',
+      sourceId: String(i),
+      primaryName: 'Acme Variant ' + i,
+      aliases: [],
+      type: 'entity',
+    }));
+    seed('OFAC_SDN', '2026-04-17', many);
+
+    const { __test__ } = await freshModule();
+    const result = await __test__.executeScreenSkill('acme');
+    // Per-source cap is 8; the reply text reports 8, not 50.
+    expect(result.reply).toContain('Matches found: 8');
+    expect(result.reply).toContain('(id: 0)');
+    expect(result.reply).toContain('(id: 7)');
+    expect(result.reply).not.toContain('(id: 8)');
+  });
+
+  it('rejects too-short queries without hitting the blob store', async () => {
+    const { __test__ } = await freshModule();
+    const result = await __test__.executeScreenSkill(' .');
+    expect(result.real).toBe(true);
+    expect(result.reply).toContain('at least 2 non-punctuation');
+  });
+
+  it('handles a completely empty snapshot store gracefully', async () => {
+    const { __test__ } = await freshModule();
+    const result = await __test__.executeScreenSkill('acme trading');
+    expect(result.real).toBe(true);
+    expect(result.reply).toContain('Matches found: 0');
+    expect(result.diagnostics?.length ?? 0).toBeGreaterThanOrEqual(6);
+  });
+
+  it('picks the most recent day-bucketed snapshot per source', async () => {
+    // Older entry that WOULD match if we read the oldest bucket.
+    seed('OFAC_SDN', '2024-01-01', [
+      {
+        source: 'OFAC_SDN',
+        sourceId: 'STALE',
+        primaryName: 'ACME STALE',
+        aliases: [],
+        type: 'entity',
+      },
+    ]);
+    seed('OFAC_SDN', '2026-04-17', [
+      {
+        source: 'OFAC_SDN',
+        sourceId: 'FRESH',
+        primaryName: 'ACME FRESH',
+        aliases: [],
+        type: 'entity',
+      },
+    ]);
+
+    const { __test__ } = await freshModule();
+    const result = await __test__.executeScreenSkill('Acme');
+    expect(result.reply).toContain('ACME FRESH');
+    expect(result.reply).not.toContain('ACME STALE');
+    expect(result.reply).toContain('Matches found: 1');
+  });
+});
+
+describe('/screen — dispatch', () => {
+  it('non-screen skills still get the stub', async () => {
+    const { __test__ } = await freshModule();
+    const router = {
+      buildStubExecution: (_inv: unknown) => ({
+        reply: 'STUB REPLY',
+        citation: 'stub citation',
+      }),
+    };
+    const result = await __test__.executeSkillInvocation(router as any, {
+      skill: { name: 'audit', category: 'audit', description: '', citation: '' },
+      args: ['acme'],
+      rawComment: '/audit acme',
+    });
+    expect(result.real).toBe(false);
+    expect(result.reply).toBe('STUB REPLY');
+  });
+
+  it('/screen without args falls back to stub so the MLRO sees usage', async () => {
+    const { __test__ } = await freshModule();
+    const router = {
+      buildStubExecution: (_inv: unknown) => ({
+        reply: 'USAGE REPLY',
+        citation: 'stub citation',
+      }),
+    };
+    const result = await __test__.executeSkillInvocation(router as any, {
+      skill: { name: 'screen', category: 'screening', description: '', citation: '' },
+      args: [],
+      rawComment: '/screen',
+    });
+    expect(result.real).toBe(false);
+    expect(result.reply).toBe('USAGE REPLY');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the carry-over: "skill-runner wiring — /screen, /incident, /audit-pack parse slash commands and post canned replies; no subprocess call into skills/."

Lights up the **highest-leverage** slash command — `/screen <name>` — as a real sanctions screen against every list the `sanctions-ingest-cron` persists into `sanctions-snapshots`. Every other skill still falls back to the existing `buildStubExecution` so the rollout is additive.

## What `/screen <query>` now does

1. **Normalises** the query: lowercase + NFKD + strip combining marks + punctuation → space + collapse whitespace. `Björk Ösçar` → `bjork oscar`; `Acme, Trading LLC.` → `acme trading llc`.
2. **Reads the latest snapshot** per source (OFAC_SDN, OFAC_CONS, UN, EU, UK_OFSI, UAE_EOCN) from `sanctions-snapshots/<SOURCE>/<day>/snapshot.json`. Snapshots sorted by key (YYYY-MM-DD prefix) so the freshest wins regardless of listing order.
3. **Substring-matches** the normalised query against each entry's `primaryName` + every alias.
4. **Emits a per-source match summary** — top 8 hits/source, 25 total (Asana stories body cap). Each hit surfaces `primaryName`, first two aliases, up to 3 programmes, `sourceId` — enough for the MLRO to open an incident immediately.

## Art.29 discipline
- Reply quotes verbatim only the MLRO's own typed query + public-record list data. Never echoes the subject's legal name or other MLRO-only context.
- Diagnostics (e.g. "no snapshot for UAE_EOCN") go to `asana-skill-audit` only — never into the Asana reply.
- Zero-match reply carries the regulator-mandated "a zero-match result is NOT a clearance" caveat.

## Cold-start budget
All 6 sources loaded in parallel via `Promise.all`. Per-source 8-cap + total 25-cap keeps the reply body under Asana stories API limits.

## Back-compat
- Non-`/screen` skills → still call `routerModule.buildStubExecution` (identical reply shape).
- `/screen` with zero args → stub (usage hint is visible to MLRO).
- New `skill_exec_diagnostics` audit event surfaces the per-source "no snapshot" messages + `real: true|false`.

## Tests

`tests/asanaSkillScreenExecutor.test.ts` (13 tests): query normalisation incl. diacritics; alias/primaryName matching; end-to-end zero-match caveat, multi-list reply format, per-source cap, short-query rejection, empty-store graceful, most-recent-day wins; dispatch for non-/screen and /screen-without-args.

`tests/asanaCommentSkillHandlerRetry.test.ts` — 7 pre-existing retry/dead-letter tests still pass unchanged.

- [x] `npx vitest run tests/asanaSkillScreenExecutor.test.ts` — 13/13
- [x] `npx vitest run` — **4422/4422** passing (4409 → 4422)

## Not in this PR
- Real execution for `/incident`, `/audit-pack`, `/onboard`, `/goaml`, `/filing-compliance`, `/multi-agent-screen` — each is a follow-on ~100-line addition to the same `executeSkillInvocation` dispatcher. `/goaml` stays blocked on the FIU portal integration (a separate government tool).

## Regulatory basis
- **FDL Art.35** — TFS obligations require a sanctions screen before onboarding / transaction processing; now directly runnable from an Asana comment.
- **Cabinet Res 74/2020 Art.4-7** — 24h freeze clock. Reply surfaces enough detail to open an incident immediately.
- **FDL Art.29** — no tipping off; reply body constructed from public-record list data + the MLRO's own query only.

https://claude.ai/code/session_01R9Y37tUnmBhH1uF2i3toB8