### PR TITLE
Add SSE streaming support to advisor calls with keepalive

### DIFF
--- a/src/services/advisorStrategy.ts
+++ b/src/services/advisorStrategy.ts
@@ -125,6 +125,25 @@ export interface AdvisorRequestInput {
   advisorCaching?: { type: 'ephemeral'; ttl: '5m' | '1h' };
   /** Any extra client-side tools to include alongside the advisor tool. */
   additionalTools?: ReadonlyArray<Record<string, unknown>>;
+  /**
+   * Request an SSE-streamed response from /api/ai-proxy.
+   *
+   * Why enable this: Opus advisor sub-inferences routinely run 20-40s
+   * end-to-end, during which no bytes flow over the socket. Intermediate
+   * proxies (Netlify Edge, corporate TLS terminators, the browser) enforce
+   * idle-read timeouts in the 30-60s range and will close an otherwise
+   * healthy connection, surfacing as "Stream idle timeout - partial
+   * response received". The /api/ai-proxy Netlify function injects
+   * `: keepalive` SSE comments every 10s when it sees `stream: true`, so
+   * the TCP write window never goes idle long enough to trip those
+   * timers. Without this flag the caller gets the non-streaming path
+   * and loses the keepalive protection.
+   *
+   * Default: undefined (non-streaming) to preserve backwards compat.
+   * Production callers should set this to true — see
+   * brainBridge.createDefaultAdvisorEscalation.
+   */
+  stream?: boolean;
 }
 
 /** Shape of the POST body that gets sent to /api/ai-proxy. */
@@ -132,6 +151,12 @@ export interface AiProxyBody {
   provider: 'anthropic';
   path: '/v1/messages';
   betas: string[];
+  /**
+   * Top-level stream flag read by /api/ai-proxy. When true, the proxy
+   * uses its streaming code path (extended upstream timeout + SSE
+   * keepalive comment injection). See ai-proxy.mts STREAM_KEEPALIVE_MS.
+   */
+  stream?: boolean;
   payload: {
     model: string;
     max_tokens: number;
@@ -141,6 +166,13 @@ export interface AiProxyBody {
       role: 'user' | 'assistant';
       content: string | Array<Record<string, unknown>>;
     }>;
+    /**
+     * Inner stream flag read by Anthropic's /v1/messages. Must be
+     * mirrored alongside the top-level flag above — the proxy only
+     * controls its own connection behaviour, Anthropic only emits
+     * SSE when its own payload asks for it.
+     */
+    stream?: boolean;
   };
 }
 
@@ -222,7 +254,7 @@ export function buildAdvisorRequest(input: AdvisorRequestInput): AiProxyBody {
     tools.push(...input.additionalTools);
   }
 
-  return {
+  const body: AiProxyBody = {
     provider: 'anthropic',
     path: '/v1/messages',
     betas: [ADVISOR_BETA_HEADER],
@@ -234,6 +266,13 @@ export function buildAdvisorRequest(input: AdvisorRequestInput): AiProxyBody {
       messages: [{ role: 'user', content: input.userMessage }],
     },
   };
+
+  if (input.stream) {
+    body.stream = true;
+    body.payload.stream = true;
+  }
+
+  return body;
 }
 
 // ---------------------------------------------------------------------------
@@ -311,11 +350,147 @@ export function parseAdvisorResponse(raw: unknown): AdvisorCallResult {
 /**
  * Minimal fetch-like transport. Matches the subset of the global fetch
  * surface we actually use, which makes it trivial to mock in tests.
+ *
+ * The optional `body` field is only consumed on the streaming path
+ * (input.stream === true). Non-streaming callers can ignore it and
+ * return `{ ok, status, json }` as before.
  */
 export type FetchLike = (
   input: string,
   init: { method: string; headers: Record<string, string>; body: string }
-) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>;
+) => Promise<{
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+  body?: ReadableStream<Uint8Array> | null;
+}>;
+
+/**
+ * Accumulate an Anthropic SSE stream into the same `RawAnthropicResponse`
+ * shape that parseAdvisorResponse understands. We reconstruct the content
+ * blocks and the usage totals as the events arrive, so downstream parsing
+ * stays identical between streaming and non-streaming callers.
+ *
+ * Events we care about (anthropic-sdk / API docs):
+ *   message_start         → carries initial usage.input_tokens
+ *   content_block_start   → opens a block (text, server_tool_use, etc.)
+ *   content_block_delta   → appends to the current block (text_delta, input_json_delta)
+ *   content_block_stop    → closes the block
+ *   message_delta         → carries usage.output_tokens on completion
+ *   message_stop          → end-of-stream marker (no payload of interest)
+ *   error                 → stream-level error (surfaces as thrown error)
+ *   ping / : keepalive    → ignored — these exist precisely to hold the
+ *                           socket open during idle gaps
+ *
+ * Ignoring unknown events is deliberate: Anthropic has added new event
+ * types over time (e.g. server_tool_use sub-events) and the advisor
+ * transcript only needs the text + usage totals.
+ */
+async function accumulateAdvisorStream(
+  stream: ReadableStream<Uint8Array>
+): Promise<RawAnthropicResponse> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  const content: Array<{ type: string; text?: string; name?: string }> = [];
+  const usage: RawAnthropicResponse['usage'] = { input_tokens: 0, output_tokens: 0 };
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      // SSE frames are separated by a blank line. Split conservatively so
+      // a partial frame at the tail of the buffer is kept for the next
+      // chunk instead of dropped.
+      let sep = buffer.indexOf('\n\n');
+      while (sep !== -1) {
+        const frame = buffer.slice(0, sep);
+        buffer = buffer.slice(sep + 2);
+        sep = buffer.indexOf('\n\n');
+
+        // Comment frames (":keepalive") are how the proxy prevents idle
+        // timeouts — skip them before we try to parse as JSON.
+        const dataLines: string[] = [];
+        for (const line of frame.split('\n')) {
+          if (line.startsWith(':')) continue;
+          if (line.startsWith('data:')) dataLines.push(line.slice(5).trim());
+        }
+        if (dataLines.length === 0) continue;
+        const dataJson = dataLines.join('\n');
+        if (!dataJson || dataJson === '[DONE]') continue;
+
+        let event: {
+          type?: string;
+          index?: number;
+          content_block?: { type?: string; text?: string; name?: string };
+          delta?: { type?: string; text?: string };
+          message?: { usage?: { input_tokens?: number; output_tokens?: number } };
+          usage?: { input_tokens?: number; output_tokens?: number };
+          error?: { message?: string; type?: string };
+        };
+        try {
+          event = JSON.parse(dataJson);
+        } catch {
+          // Malformed frame — skip rather than throw, so a single bad
+          // line can't tear down a long-running advisor transcript.
+          continue;
+        }
+
+        if (event.type === 'error') {
+          const msg = event.error?.message ?? 'advisor stream error';
+          throw new Error(`advisor SSE error: ${msg}`);
+        }
+
+        if (event.type === 'message_start' && event.message?.usage) {
+          usage.input_tokens = event.message.usage.input_tokens ?? usage.input_tokens;
+          usage.output_tokens = event.message.usage.output_tokens ?? usage.output_tokens;
+          continue;
+        }
+
+        if (event.type === 'content_block_start' && typeof event.index === 'number') {
+          const block = event.content_block ?? { type: 'text' };
+          content[event.index] = {
+            type: block.type ?? 'text',
+            text: block.type === 'text' ? '' : undefined,
+            name: block.name,
+          };
+          continue;
+        }
+
+        if (event.type === 'content_block_delta' && typeof event.index === 'number') {
+          const existing = content[event.index] ?? { type: 'text', text: '' };
+          if (event.delta?.type === 'text_delta' && typeof event.delta.text === 'string') {
+            existing.text = (existing.text ?? '') + event.delta.text;
+          }
+          content[event.index] = existing;
+          continue;
+        }
+
+        if (event.type === 'message_delta' && event.usage) {
+          if (typeof event.usage.output_tokens === 'number') {
+            usage.output_tokens = event.usage.output_tokens;
+          }
+          if (typeof event.usage.input_tokens === 'number') {
+            usage.input_tokens = event.usage.input_tokens;
+          }
+          continue;
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  // Drop undefined gaps in the sparse array (content blocks arrive in order
+  // but via indexed events, so an in-flight disconnect could leave holes).
+  return {
+    content: content.filter((b) => b !== undefined),
+    usage,
+  };
+}
 
 export interface AdvisorCallDeps {
   /** HTTP transport. Defaults to the global fetch at call time. */
@@ -375,17 +550,34 @@ export async function callAdvisorAssisted(
   const endpoint = deps.endpoint ?? '/api/ai-proxy';
   const fetchImpl = deps.fetch ?? defaultFetch();
 
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${token}`,
+  };
+  // Signal SSE intent to any intermediary (Netlify Edge, corporate
+  // proxies) so content negotiation and buffering flip to the
+  // streaming path. The ai-proxy keepalive only works end-to-end
+  // when every hop treats the response as text/event-stream.
+  if (input.stream) headers['Accept'] = 'text/event-stream';
+
   const res = await fetchImpl(endpoint, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
-    },
+    headers,
     body: JSON.stringify(body),
   });
 
   if (!res.ok) {
     throw new Error(`callAdvisorAssisted: proxy returned HTTP ${res.status}`);
+  }
+
+  if (input.stream) {
+    if (!res.body) {
+      throw new Error(
+        'callAdvisorAssisted: stream requested but proxy response has no body'
+      );
+    }
+    const raw = await accumulateAdvisorStream(res.body);
+    return parseAdvisorResponse(raw);
   }
 
   const raw = await res.json();

--- a/src/services/brainBridge.ts
+++ b/src/services/brainBridge.ts
@@ -227,6 +227,13 @@ export function createDefaultAdvisorEscalation(deps: AdvisorCallDeps = {}): Advi
           // high-quality second opinion, not a multi-turn debate.
           maxAdvisorUses: 1,
           maxTokens: 800,
+          // Stream by default: Opus advisor sub-inferences regularly
+          // run 20-40s with no bytes flowing during the sub-inference
+          // window. Without SSE + keepalive the intermediate layers
+          // (Netlify Edge, CDN, browser) close the socket and surface
+          // a truncated "Stream idle timeout - partial response
+          // received" to the caller even though the upstream is fine.
+          stream: true,
           additionalSystemPrompt:
             'You are reviewing a compliance verdict produced by the Weaponized Brain. ' +
             'The verdict itself is already decided — do not attempt to change it. ' +

--- a/tests/advisorStrategy.test.ts
+++ b/tests/advisorStrategy.test.ts
@@ -357,3 +357,167 @@ describe('advisorStrategy — callAdvisorAssisted', () => {
     expect(fake.calls[0].url).toBe('/custom/advisor');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Streaming path — SSE + keepalive
+// ---------------------------------------------------------------------------
+
+describe('advisorStrategy — streaming mode', () => {
+  it('buildAdvisorRequest sets stream on both proxy-level and payload-level', () => {
+    const body = buildAdvisorRequest({ userMessage: 'x', stream: true });
+    expect(body.stream).toBe(true);
+    expect(body.payload.stream).toBe(true);
+  });
+
+  it('buildAdvisorRequest omits stream flags by default', () => {
+    const body = buildAdvisorRequest({ userMessage: 'x' });
+    expect(body.stream).toBeUndefined();
+    expect(body.payload.stream).toBeUndefined();
+  });
+
+  /**
+   * Build a ReadableStream of SSE bytes for a canonical Anthropic
+   * streamed /v1/messages response. Interleaves a `: keepalive` comment
+   * frame to prove the accumulator skips idle-gap fillers.
+   */
+  function sseStream(frames: string[]): ReadableStream<Uint8Array> {
+    const encoder = new TextEncoder();
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const f of frames) controller.enqueue(encoder.encode(f));
+        controller.close();
+      },
+    });
+  }
+
+  function frameEvent(type: string, data: Record<string, unknown>): string {
+    return `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`;
+  }
+
+  function fakeStreamingFetch(frames: string[]): {
+    fn: FetchLike;
+    calls: Array<{ url: string; init: { method: string; headers: Record<string, string>; body: string } }>;
+  } {
+    const calls: Array<{ url: string; init: { method: string; headers: Record<string, string>; body: string } }> = [];
+    const fn: FetchLike = async (url, init) => {
+      calls.push({ url, init });
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+        body: sseStream(frames),
+      };
+    };
+    return { fn, calls };
+  }
+
+  it('sends Accept: text/event-stream when streaming', async () => {
+    const fake = fakeStreamingFetch([
+      frameEvent('message_start', { type: 'message_start', message: { usage: { input_tokens: 5, output_tokens: 0 } } }),
+      frameEvent('message_stop', { type: 'message_stop' }),
+    ]);
+    await callAdvisorAssisted(
+      { userMessage: 'x', stream: true },
+      { fetch: fake.fn, authToken: 'tok' }
+    );
+    expect(fake.calls[0].init.headers['Accept']).toBe('text/event-stream');
+  });
+
+  it('accumulates text_delta events into the executor text output', async () => {
+    const fake = fakeStreamingFetch([
+      frameEvent('message_start', { type: 'message_start', message: { usage: { input_tokens: 10, output_tokens: 0 } } }),
+      frameEvent('content_block_start', { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } }),
+      frameEvent('content_block_delta', { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Hello ' } }),
+      ': keepalive\n\n',
+      frameEvent('content_block_delta', { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'world.' } }),
+      frameEvent('content_block_stop', { type: 'content_block_stop', index: 0 }),
+      frameEvent('message_delta', { type: 'message_delta', usage: { output_tokens: 42 } }),
+      frameEvent('message_stop', { type: 'message_stop' }),
+    ]);
+    const result = await callAdvisorAssisted(
+      { userMessage: 'x', stream: true },
+      { fetch: fake.fn, authToken: 'tok' }
+    );
+    expect(result.text).toBe('Hello world.');
+    expect(result.usage.executorInputTokens).toBe(10);
+    expect(result.usage.executorOutputTokens).toBe(42);
+  });
+
+  it('counts server_tool_use blocks named "advisor" in a streamed response', async () => {
+    const fake = fakeStreamingFetch([
+      frameEvent('message_start', { type: 'message_start', message: { usage: { input_tokens: 0, output_tokens: 0 } } }),
+      frameEvent('content_block_start', { type: 'content_block_start', index: 0, content_block: { type: 'server_tool_use', name: 'advisor' } }),
+      frameEvent('content_block_stop', { type: 'content_block_stop', index: 0 }),
+      frameEvent('content_block_start', { type: 'content_block_start', index: 1, content_block: { type: 'text', text: '' } }),
+      frameEvent('content_block_delta', { type: 'content_block_delta', index: 1, delta: { type: 'text_delta', text: 'done' } }),
+      frameEvent('content_block_stop', { type: 'content_block_stop', index: 1 }),
+      frameEvent('message_stop', { type: 'message_stop' }),
+    ]);
+    const result = await callAdvisorAssisted(
+      { userMessage: 'x', stream: true },
+      { fetch: fake.fn, authToken: 'tok' }
+    );
+    expect(result.advisorCallCount).toBe(1);
+    expect(result.text).toBe('done');
+  });
+
+  it('handles SSE frames split across multiple chunks', async () => {
+    // Split a single frame across three TCP chunks to prove the
+    // buffer-accumulation logic does not drop or duplicate bytes.
+    const full = frameEvent('content_block_delta', {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text: 'chunked' },
+    });
+    const third = Math.floor(full.length / 3);
+    const chunkA = full.slice(0, third);
+    const chunkB = full.slice(third, 2 * third);
+    const chunkC = full.slice(2 * third);
+    const fake = fakeStreamingFetch([
+      frameEvent('message_start', { type: 'message_start', message: { usage: { input_tokens: 0, output_tokens: 0 } } }),
+      frameEvent('content_block_start', { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } }),
+      chunkA,
+      chunkB,
+      chunkC,
+      frameEvent('content_block_stop', { type: 'content_block_stop', index: 0 }),
+      frameEvent('message_stop', { type: 'message_stop' }),
+    ]);
+    const result = await callAdvisorAssisted(
+      { userMessage: 'x', stream: true },
+      { fetch: fake.fn, authToken: 'tok' }
+    );
+    expect(result.text).toBe('chunked');
+  });
+
+  it('throws when a stream-level error frame arrives', async () => {
+    const fake = fakeStreamingFetch([
+      frameEvent('message_start', { type: 'message_start', message: { usage: { input_tokens: 0, output_tokens: 0 } } }),
+      frameEvent('error', { type: 'error', error: { type: 'overloaded_error', message: 'overloaded' } }),
+    ]);
+    await expect(
+      callAdvisorAssisted({ userMessage: 'x', stream: true }, { fetch: fake.fn, authToken: 'tok' })
+    ).rejects.toThrow(/advisor SSE error: overloaded/);
+  });
+
+  it('throws when stream is requested but the response has no body', async () => {
+    const fn: FetchLike = async () => ({ ok: true, status: 200, json: async () => ({}), body: null });
+    await expect(
+      callAdvisorAssisted({ userMessage: 'x', stream: true }, { fetch: fn, authToken: 'tok' })
+    ).rejects.toThrow(/no body/);
+  });
+
+  it('ignores malformed JSON frames and keeps accumulating', async () => {
+    const fake = fakeStreamingFetch([
+      frameEvent('message_start', { type: 'message_start', message: { usage: { input_tokens: 0, output_tokens: 0 } } }),
+      frameEvent('content_block_start', { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } }),
+      'data: {not valid json\n\n',
+      frameEvent('content_block_delta', { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'survived' } }),
+      frameEvent('message_stop', { type: 'message_stop' }),
+    ]);
+    const result = await callAdvisorAssisted(
+      { userMessage: 'x', stream: true },
+      { fetch: fake.fn, authToken: 'tok' }
+    );
+    expect(result.text).toBe('survived');
+  });
+});


### PR DESCRIPTION
## Summary
Add Server-Sent Events (SSE) streaming support to advisor API calls to prevent idle timeout disconnections during long-running inferences. Opus advisor sub-inferences can take 20-40 seconds with no data flowing, causing intermediate proxies (Netlify Edge, CDN, corporate TLS terminators) to close connections after 30-60 second idle timeouts. The streaming path enables keepalive comment injection to hold connections open.

## Key Changes

- **New `stream` option in `AdvisorRequestInput`**: Optional boolean flag to enable SSE streaming. Defaults to undefined (non-streaming) for backwards compatibility.

- **Updated `AiProxyBody` interface**: Added top-level `stream` flag (read by `/api/ai-proxy` to enable keepalive injection) and inner `stream` flag in payload (read by Anthropic's `/v1/messages` API). Both must be set together for end-to-end streaming.

- **New `accumulateAdvisorStream()` function**: Parses Anthropic SSE events and reconstructs the same `RawAnthropicResponse` shape that non-streaming callers receive. Handles:
  - `message_start` / `message_delta` / `message_stop` for usage tracking
  - `content_block_start` / `content_block_delta` / `content_block_stop` for content accumulation
  - `: keepalive` comment frames (skipped, exist only to prevent idle timeouts)
  - Malformed JSON frames (skipped gracefully to prevent single bad lines from breaking long transcripts)
  - Stream-level error frames (thrown as errors)

- **Updated `callAdvisorAssisted()`**: 
  - Sets `Accept: text/event-stream` header when streaming to signal intent to intermediaries
  - Routes to streaming path when `input.stream === true`, accumulating SSE events
  - Falls back to non-streaming JSON path otherwise

- **Updated `buildAdvisorRequest()`**: Conditionally sets both `stream` flags when `input.stream === true`

- **Updated `FetchLike` type**: Added optional `body?: ReadableStream<Uint8Array>` field for streaming responses

- **Updated `createDefaultAdvisorEscalation()`**: Enables streaming by default (`stream: true`) to protect against idle timeouts in production

## Implementation Details

- SSE frame parsing is conservative: splits on `\n\n` boundaries and preserves partial frames across TCP chunks
- Content blocks are accumulated in a sparse array indexed by event order, then filtered to remove gaps
- Usage tokens are updated incrementally as `message_start`, `message_delta`, and `message_stop` events arrive
- Downstream `parseAdvisorResponse()` logic remains unchanged — streaming and non-streaming paths converge on the same response shape
- Comprehensive test coverage for frame splitting, keepalive comments, error handling, and malformed data

https://claude.ai/code/session_012rjtCsfQPyfK5xEfKmNPJs