### PR TITLE
Fix lint-and-test CI failures on main (ESLint + Prettier + flaky CDD review test)

### DIFF
--- a/src/domain/periodicReview.ts
+++ b/src/domain/periodicReview.ts
@@ -57,9 +57,22 @@ export function createReviewSchedule(
   };
 }
 
-export function checkReviewStatus(schedule: PeriodicReviewSchedule): PeriodicReviewSchedule {
+/**
+ * Derive the live status of a review schedule against the wall-clock.
+ *
+ * Accepts an optional `now` so callers that already hold an authoritative
+ * report clock (weekly CDD rollup, audit snapshots, MLRO timeline replay)
+ * can thread it through instead of re-reading the system clock. Without
+ * this, a test that pins NOW via its own fixture and a production call
+ * that happens at real-time diverge mid-run — which is exactly the
+ * failure mode the CDD weekly-report test hit when fixture-now and
+ * real-now fell on opposite sides of a scheduled date.
+ */
+export function checkReviewStatus(
+  schedule: PeriodicReviewSchedule,
+  now: Date = new Date()
+): PeriodicReviewSchedule {
   if (schedule.status === 'completed') return schedule;
-  const now = new Date();
   const next = new Date(schedule.nextReviewDate);
   if (isNaN(next.getTime())) return { ...schedule, status: 'scheduled' };
   if (next < now) return { ...schedule, status: 'overdue' };

--- a/src/services/advisorStrategy.ts
+++ b/src/services/advisorStrategy.ts
@@ -397,7 +397,7 @@ async function accumulateAdvisorStream(
   const usage: RawAnthropicResponse['usage'] = { input_tokens: 0, output_tokens: 0 };
 
   try {
-    while (true) {
+    for (;;) {
       const { value, done } = await reader.read();
       if (done) break;
       buffer += decoder.decode(value, { stream: true });
@@ -572,9 +572,7 @@ export async function callAdvisorAssisted(
 
   if (input.stream) {
     if (!res.body) {
-      throw new Error(
-        'callAdvisorAssisted: stream requested but proxy response has no body'
-      );
+      throw new Error('callAdvisorAssisted: stream requested but proxy response has no body');
     }
     const raw = await accumulateAdvisorStream(res.body);
     return parseAdvisorResponse(raw);

--- a/src/services/cddReportGenerator.ts
+++ b/src/services/cddReportGenerator.ts
@@ -209,7 +209,7 @@ export function buildWeeklyCddReport(input: WeeklyCddReportInput): WeeklyCddRepo
   // 2) Overdue + due-soon reviews.
   const overdueReviews: OverdueReview[] = [];
   for (const schedule of reviewSchedules) {
-    const live = checkReviewStatus(schedule);
+    const live = checkReviewStatus(schedule, now);
     if (live.status !== 'overdue' && live.status !== 'due') continue;
     const source = customers.find((c) => c.id === schedule.customerId);
     const tier = source

--- a/src/services/multiModalNameMatcher.ts
+++ b/src/services/multiModalNameMatcher.ts
@@ -79,9 +79,9 @@ export function levenshteinDistance(a: string, b: string): number {
     for (let i = 1; i <= la; i++) {
       const cost = a[i - 1] === b[j - 1] ? 0 : 1;
       curr[i] = Math.min(
-        curr[i - 1] + 1,       // insertion
-        prev[i] + 1,           // deletion
-        prev[i - 1] + cost,    // substitution
+        curr[i - 1] + 1, // insertion
+        prev[i] + 1, // deletion
+        prev[i - 1] + cost // substitution
       );
     }
     [prev, curr] = [curr, prev];
@@ -108,11 +108,23 @@ export function levenshteinSimilarity(a: string, b: string): number {
 // ---------------------------------------------------------------------------
 
 const SOUNDEX_CODE: Record<string, string> = {
-  b: '1', f: '1', p: '1', v: '1',
-  c: '2', g: '2', j: '2', k: '2', q: '2', s: '2', x: '2', z: '2',
-  d: '3', t: '3',
+  b: '1',
+  f: '1',
+  p: '1',
+  v: '1',
+  c: '2',
+  g: '2',
+  j: '2',
+  k: '2',
+  q: '2',
+  s: '2',
+  x: '2',
+  z: '2',
+  d: '3',
+  t: '3',
   l: '4',
-  m: '5', n: '5',
+  m: '5',
+  n: '5',
   r: '6',
 };
 
@@ -180,10 +192,11 @@ export function soundex(raw: string): string {
   // The loop above mapped s[0] as well. Peel it off now.
   dedup = dedup.replace(/\?/g, '');
   // Remove the code corresponding to the first letter.
-  const firstCode =
-    'aeiouy'.includes(s[0]) ? '?' :
-    s[0] === 'h' || s[0] === 'w' ? '.' :
-    SOUNDEX_CODE[s[0]] ?? '?';
+  const firstCode = 'aeiouy'.includes(s[0])
+    ? '?'
+    : s[0] === 'h' || s[0] === 'w'
+      ? '.'
+      : (SOUNDEX_CODE[s[0]] ?? '?');
   if (firstCode !== '?' && firstCode !== '.' && dedup[0] === firstCode) {
     dedup = dedup.slice(1);
   }
@@ -221,16 +234,15 @@ export interface MultiModalWeights {
  *   - Arabic ↔ Latin after translit.     → ≥ 0.70 (flagged)
  */
 export const DEFAULT_WEIGHTS: MultiModalWeights = Object.freeze({
-  jaroWinkler: 0.20,
+  jaroWinkler: 0.2,
   levenshtein: 0.15,
-  soundex: 0.10,
+  soundex: 0.1,
   metaphone: 0.15,
-  tokenSet: 0.40,
+  tokenSet: 0.4,
 });
 
 function normaliseWeights(w: MultiModalWeights): MultiModalWeights {
-  const sum =
-    w.jaroWinkler + w.levenshtein + w.soundex + w.metaphone + w.tokenSet;
+  const sum = w.jaroWinkler + w.levenshtein + w.soundex + w.metaphone + w.tokenSet;
   if (sum === 0) return DEFAULT_WEIGHTS;
   return {
     jaroWinkler: w.jaroWinkler / sum,
@@ -306,7 +318,7 @@ function agreementOf(scores: readonly number[]): number {
 export function multiModalMatch(
   rawA: string,
   rawB: string,
-  weights?: Partial<MultiModalWeights>,
+  weights?: Partial<MultiModalWeights>
 ): MultiModalMatchBreakdown {
   // Pre-process: legal-suffix strip, transliterate if one side is Arabic.
   let a = stripLegalSuffix(rawA);
@@ -331,8 +343,16 @@ export function multiModalMatch(
   // signals. Character-level algorithms (Jaro-Winkler, Levenshtein)
   // are positional — without this, surname-first ↔ surname-last
   // swaps tank their scores even though the names are identical.
-  const sortedA = normA.split(/\s+/).filter((t) => t.length > 0).sort().join(' ');
-  const sortedB = normB.split(/\s+/).filter((t) => t.length > 0).sort().join(' ');
+  const sortedA = normA
+    .split(/\s+/)
+    .filter((t) => t.length > 0)
+    .sort()
+    .join(' ');
+  const sortedB = normB
+    .split(/\s+/)
+    .filter((t) => t.length > 0)
+    .sort()
+    .join(' ');
 
   const jw = jaroWinkler(sortedA, sortedB);
   const lev = levenshteinSimilarity(sortedA, sortedB);
@@ -361,8 +381,7 @@ export function multiModalMatch(
   // by token-order false positives. See nameMatching.ts §matchScore.
   let token = tsb.mean;
   const heavilyDistinct = tsb.min < 0.6;
-  const sharedSingleTokenWithDistinctOther =
-    tsb.max >= 0.999 && tsb.min < 0.8;
+  const sharedSingleTokenWithDistinctOther = tsb.max >= 0.999 && tsb.min < 0.8;
   if (heavilyDistinct || sharedSingleTokenWithDistinctOther) {
     token = tsb.min * tsb.min;
   }
@@ -374,7 +393,7 @@ export function multiModalMatch(
       lev * w.levenshtein +
       sx * w.soundex +
       meta * w.metaphone +
-      token * w.tokenSet,
+      token * w.tokenSet
   );
 
   const agreement = agreementOf([jw, lev, sx, meta, token]);
@@ -396,11 +415,7 @@ export function multiModalMatch(
 }
 
 /** True if `multiModalMatch(a, b).score >= threshold`. */
-export function isMultiModalMatch(
-  a: string,
-  b: string,
-  threshold = 0.7,
-): boolean {
+export function isMultiModalMatch(a: string, b: string, threshold = 0.7): boolean {
   return multiModalMatch(a, b).score >= threshold;
 }
 
@@ -415,10 +430,9 @@ export function findBestMultiModalMatch(
   query: string,
   candidates: readonly string[],
   threshold = 0.7,
-  weights?: Partial<MultiModalWeights>,
+  weights?: Partial<MultiModalWeights>
 ): { candidate: string; breakdown: MultiModalMatchBreakdown } | null {
-  let best: { candidate: string; breakdown: MultiModalMatchBreakdown } | null =
-    null;
+  let best: { candidate: string; breakdown: MultiModalMatchBreakdown } | null = null;
   for (const c of candidates) {
     const breakdown = multiModalMatch(query, c, weights);
     if (breakdown.score < threshold) continue;
@@ -476,7 +490,7 @@ export interface MultiModalScreeningResponse {
  * how close a "no hit" actually was.
  */
 export function runMultiModalNameMatcher(
-  req: MultiModalScreeningRequest,
+  req: MultiModalScreeningRequest
 ): MultiModalScreeningResponse {
   const threshold = req.threshold ?? 0.7;
   const maxHits = req.maxHits ?? 20;


### PR DESCRIPTION
## Summary

Three blockers turned `lint-and-test (20)` red on `main` as of `d1eee78`. This PR fixes all three.

1. **ESLint `no-constant-condition`** on `src/services/advisorStrategy.ts` — the SSE accumulation loop used `while (true)`. Switched to `for (;;)`. Same semantics, idiomatic for "loop until break", not flagged by the rule. No behaviour change.
2. **Prettier format drift** on `src/services/multiModalNameMatcher.ts` — shipped in #241 with multi-declaration lines and chained ternaries that the repo's prettier config reflows. Ran `prettier --write` — zero logic change, whitespace only.
3. **Flaky `cddReportGenerator` weekly-review test** — root cause was `periodicReview.checkReviewStatus` hardcoding `new Date()` instead of accepting the caller's authoritative clock. A schedule at `fixtureNow + 5 days` flipped `due → overdue` the moment real-time crossed that instant. Added an optional `now: Date = new Date()` parameter and threaded the weekly report's clock through from `cddReportGenerator`. Default-param preserves source compatibility for every existing caller.

## Regulatory basis

- **FDL No.10/2025 Art.12-14** + **Cabinet Res 134/2025 Art.7-10** — periodic CDD review cadence (SDD 12mo / CDD 6mo / EDD 3mo, per `frequencyMonths` in `PeriodicReviewSchedule`). A review-status function that silently diverges from the caller's report clock threatens audit reproducibility on every MoE/LBMA inspection that replays a historical weekly CDD rollup.

## Test plan

- [x] `npm run lint:ts` — clean
- [x] `npm run format:check` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — **4498 / 4498 pass** (was 4497 / 4498 on `main`)

https://claude.ai/code/session_012rjtCsfQPyfK5xEfKmNPJs