### PR TITLE
fix: disable proxy buffering on SSE streams (Cabinet Res 134/2025 Art.19)

### DIFF
--- a/netlify/functions/decision-stream.mts
+++ b/netlify/functions/decision-stream.mts
@@ -212,6 +212,12 @@ export default async (req: Request, context: Context): Promise<Response> => {
       'Cache-Control': 'no-store',
       Connection: 'keep-alive',
       'X-Content-Type-Options': 'nosniff',
+      // Disable proxy buffering (Nginx, Netlify Edge, some CDNs).
+      // Without this, intermediaries can hold SSE frames in a buffer
+      // and defeat the heartbeat above — surfacing as "Stream idle
+      // timeout - partial response received" on the client even while
+      // the server is emitting heartbeats on schedule.
+      'X-Accel-Buffering': 'no',
     },
   });
 };

--- a/netlify/functions/warroom-stream.mts
+++ b/netlify/functions/warroom-stream.mts
@@ -113,6 +113,12 @@ export default async (req: Request, context: Context): Promise<Response> => {
       'Cache-Control': 'no-store',
       Connection: 'keep-alive',
       'X-Content-Type-Options': 'nosniff',
+      // Disable proxy buffering (Nginx, Netlify Edge, some CDNs).
+      // Without this, intermediaries can hold SSE frames in a buffer
+      // and defeat the heartbeat above — surfacing as "Stream idle
+      // timeout - partial response received" on the client even while
+      // the server is emitting heartbeats on schedule.
+      'X-Accel-Buffering': 'no',
     },
   });
 };


### PR DESCRIPTION
## Summary

- Adds `X-Accel-Buffering: no` to `decision-stream.mts` and `warroom-stream.mts` responses.
- Fixes **"API Error: Stream idle timeout - partial response received"** on the NORAD war room and compliance decision streams.
- Matches the fix already shipped in `ai-proxy.mts` (PR #151).

## Root Cause

Both SSE endpoints already emit heartbeat comment frames (`: heartbeat\n\n`) every 5s. Without `X-Accel-Buffering: no`, intermediate layers (Nginx, Netlify Edge, some CDNs) buffer the response body and hold those heartbeats server-side. The client's socket goes quiet and the browser reports a stream idle timeout even though the server is emitting bytes on schedule.

## Files Changed

| File | Change |
|---|---|
| `netlify/functions/decision-stream.mts` | Add `X-Accel-Buffering: no` |
| `netlify/functions/warroom-stream.mts` | Add `X-Accel-Buffering: no` |

Two one-line header additions. Zero behavioural change for clients; only affects intermediary byte timing.

## Regulatory Basis

Cabinet Res 134/2025 Art.19 (continuous operational monitoring). A stream that silently truncates breaks the MLRO's situational awareness — exactly the failure mode Art.19 is intended to prevent.

## Test plan

- [ ] `tsc --noEmit` passes.
- [ ] Deploy to a Netlify preview; open the NORAD war room, run a compliance decision, confirm no timeout error over a 20s+ run.
- [ ] `curl -N /api/warroom/stream` from a network behind a buffering proxy — heartbeats should arrive every ~5s instead of being batched.

https://claude.ai/code/session_019W8VmQaQPyKDYL5aFpQxYy