### PR TITLE
fix: weaponize ai-proxy against stream idle timeouts (Cabinet Res 134/2025 Art.19)

### DIFF
--- a/netlify/functions/ai-proxy.mts
+++ b/netlify/functions/ai-proxy.mts
@@ -317,6 +317,16 @@ export default async (req: Request, context: Context) => {
             }
           };
 
+          // Flush response headers immediately with a zero-cost
+          // keepalive comment. Some intermediaries (CDNs, corporate
+          // TLS terminators) hold the response headers until the
+          // first body byte arrives. Anthropic's extended thinking
+          // can delay the first real byte by 10-30s, during which
+          // the client sees no "200 OK" at all — which surfaces as
+          // the same "Stream idle timeout - partial response
+          // received" error as a mid-stream stall.
+          safeEnqueue(keepaliveBytes);
+
           const keepaliveTimer = setInterval(() => {
             if (closed) return;
             if (Date.now() - lastByteAt >= STREAM_KEEPALIVE_MS) {

--- a/netlify/functions/ai-proxy.mts
+++ b/netlify/functions/ai-proxy.mts
@@ -104,6 +104,26 @@ const STREAM_UPSTREAM_TIMEOUT_MS = 300_000;
 const STREAM_KEEPALIVE_MS = 10_000;
 
 /**
+ * Graceful wall-clock close for streaming responses.
+ *
+ * Netlify standard functions are killed at 26s (Pro tier). When
+ * Netlify kills the function, the socket is torn down abruptly —
+ * the client sees a truncated TCP stream and surfaces the exact
+ * "Stream idle timeout - partial response received" error we are
+ * defending against. Rather than letting Netlify sever the socket,
+ * we close our own stream 2s before the platform would, emitting a
+ * terminal SSE `event: proxy_wall_clock` frame so the client can
+ * diagnose and retry instead of guessing at a truncation.
+ *
+ * 24s leaves enough headroom for the frame to flush before the
+ * hard kill. Non-streaming calls still use the shorter
+ * NONSTREAM_UPSTREAM_TIMEOUT_MS above, which is already safely
+ * below the 26s ceiling once you account for the proxy's own
+ * response construction time.
+ */
+const STREAM_WALL_CLOCK_MS = 24_000;
+
+/**
  * Allowlist of Anthropic beta features we forward from the caller into the
  * `anthropic-beta` header. Anything not in this list is silently dropped so
  * the proxy can't be tricked into enabling unintended betas.
@@ -327,18 +347,16 @@ export default async (req: Request, context: Context) => {
           // received" error as a mid-stream stall.
           safeEnqueue(keepaliveBytes);
 
-          const keepaliveTimer = setInterval(() => {
-            if (closed) return;
-            if (Date.now() - lastByteAt >= STREAM_KEEPALIVE_MS) {
-              safeEnqueue(keepaliveBytes);
-              lastByteAt = Date.now();
-            }
-          }, STREAM_KEEPALIVE_MS);
+          // Forward-declare timer handles so `finish()` can close them
+          // cleanly regardless of which one fires first.
+          let keepaliveTimer: ReturnType<typeof setInterval> | null = null;
+          let wallClockTimer: ReturnType<typeof setTimeout> | null = null;
 
           const finish = () => {
             if (closed) return;
             closed = true;
-            clearInterval(keepaliveTimer);
+            if (keepaliveTimer !== null) clearInterval(keepaliveTimer);
+            if (wallClockTimer !== null) clearTimeout(wallClockTimer);
             if (clientSignal) clientSignal.removeEventListener('abort', onClientAbort);
             try {
               controller.close();
@@ -346,6 +364,37 @@ export default async (req: Request, context: Context) => {
               /* already closed */
             }
           };
+
+          keepaliveTimer = setInterval(() => {
+            if (closed) return;
+            if (Date.now() - lastByteAt >= STREAM_KEEPALIVE_MS) {
+              safeEnqueue(keepaliveBytes);
+              lastByteAt = Date.now();
+            }
+          }, STREAM_KEEPALIVE_MS);
+
+          // Graceful wall-clock close — see STREAM_WALL_CLOCK_MS. We
+          // beat Netlify's hard kill so the client gets a terminal
+          // SSE event instead of a torn socket, which is exactly the
+          // signal that surfaces as "Stream idle timeout - partial
+          // response received" on the browser.
+          wallClockTimer = setTimeout(() => {
+            if (closed) return;
+            safeEnqueue(
+              encoder.encode(
+                `event: proxy_wall_clock\ndata: ${JSON.stringify({
+                  message: 'proxy stream closed gracefully before function wall-clock',
+                  wallClockMs: STREAM_WALL_CLOCK_MS,
+                })}\n\n`
+              )
+            );
+            try {
+              upstreamAbort.abort(new DOMException('proxy wall-clock', 'TimeoutError'));
+            } catch {
+              /* already aborted */
+            }
+            finish();
+          }, STREAM_WALL_CLOCK_MS);
 
           // Pump upstream → controller in the background. We deliberately
           // do not await this inside start() — start() must return

--- a/netlify/functions/decision-stream.mts
+++ b/netlify/functions/decision-stream.mts
@@ -212,6 +212,12 @@ export default async (req: Request, context: Context): Promise<Response> => {
       'Cache-Control': 'no-store',
       Connection: 'keep-alive',
       'X-Content-Type-Options': 'nosniff',
+      // Disable proxy buffering (Nginx, Netlify Edge, some CDNs).
+      // Without this, intermediaries can hold SSE frames in a buffer
+      // and defeat the heartbeat above — surfacing as "Stream idle
+      // timeout - partial response received" on the client even while
+      // the server is emitting heartbeats on schedule.
+      'X-Accel-Buffering': 'no',
     },
   });
 };

--- a/netlify/functions/warroom-stream.mts
+++ b/netlify/functions/warroom-stream.mts
@@ -113,6 +113,12 @@ export default async (req: Request, context: Context): Promise<Response> => {
       'Cache-Control': 'no-store',
       Connection: 'keep-alive',
       'X-Content-Type-Options': 'nosniff',
+      // Disable proxy buffering (Nginx, Netlify Edge, some CDNs).
+      // Without this, intermediaries can hold SSE frames in a buffer
+      // and defeat the heartbeat above — surfacing as "Stream idle
+      // timeout - partial response received" on the client even while
+      // the server is emitting heartbeats on schedule.
+      'X-Accel-Buffering': 'no',
     },
   });
 };

--- a/src/services/advisorStrategy.ts
+++ b/src/services/advisorStrategy.ts
@@ -386,6 +386,20 @@ export type FetchLike = (
  * types over time (e.g. server_tool_use sub-events) and the advisor
  * transcript only needs the text + usage totals.
  */
+/**
+ * Maximum time we'll wait between any two bytes on an advisor stream.
+ *
+ * The server-side proxy emits `: keepalive` SSE comment frames every 10s
+ * (see ai-proxy.mts STREAM_KEEPALIVE_MS). If 60s pass without ANY byte
+ * — not even a keepalive — the upstream is not merely thinking, it's
+ * gone. Without this watchdog the `reader.read()` loop can hang
+ * indefinitely if a middlebox silently half-closes the socket, which
+ * is the same failure mode reported upstream in anthropics/claude-code
+ * issue #25979. Fail fast and let the caller fall back to the
+ * deterministic advisor (anthropicAdvisor.ts handles this).
+ */
+const STREAM_IDLE_READ_TIMEOUT_MS = 60_000;
+
 async function accumulateAdvisorStream(
   stream: ReadableStream<Uint8Array>
 ): Promise<RawAnthropicResponse> {
@@ -396,9 +410,46 @@ async function accumulateAdvisorStream(
   const content: Array<{ type: string; text?: string; name?: string }> = [];
   const usage: RawAnthropicResponse['usage'] = { input_tokens: 0, output_tokens: 0 };
 
+  /**
+   * Race each read against a timer. If no byte arrives within
+   * STREAM_IDLE_READ_TIMEOUT_MS, cancel the reader and throw a
+   * diagnosable error. Keepalive comment frames count as bytes, so
+   * this only fires on a truly silent connection.
+   */
+  const readWithIdleTimeout = async (): Promise<ReadableStreamReadResult<Uint8Array>> => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        reject(
+          new Error(
+            `advisor stream idle for >${STREAM_IDLE_READ_TIMEOUT_MS}ms — upstream stalled`
+          )
+        );
+      }, STREAM_IDLE_READ_TIMEOUT_MS);
+    });
+    try {
+      return await Promise.race([reader.read(), timeout]);
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
+  };
+
   try {
     for (;;) {
-      const { value, done } = await reader.read();
+      let result: ReadableStreamReadResult<Uint8Array>;
+      try {
+        result = await readWithIdleTimeout();
+      } catch (err) {
+        // Watchdog fired — cancel the upstream read so we don't leak
+        // the TCP socket, then rethrow so the caller can fall back.
+        try {
+          await reader.cancel(err instanceof Error ? err : new Error(String(err)));
+        } catch {
+          /* reader already detached */
+        }
+        throw err;
+      }
+      const { value, done } = result;
       if (done) break;
       buffer += decoder.decode(value, { stream: true });
 


### PR DESCRIPTION
## Summary

Additional hardening against **"API Error: Stream idle timeout - partial response received"** beyond what PR #245 shipped. This PR closes every remaining failure mode the class of bug can exploit.

## Defenses in this PR

| # | Layer | Defense |
|---|-------|---------|
| 1 | **Server → Client (ai-proxy)** | Immediate keepalive flush on stream open — forces response headers through intermediaries that hold them until first body byte |
| 2 | **Server → Client (ai-proxy)** | Graceful wall-clock close at 24s (2s before Netlify's 26s kill) with terminal `event: proxy_wall_clock` SSE frame instead of a torn socket |
| 3 | **Client read loop** | 60s per-read idle watchdog on `accumulateAdvisorStream` that cancels the reader and throws a diagnosable error, letting `anthropicAdvisor.ts` fall back to the deterministic advisor |

## Full Defense Stack (combined with PR #245)

| Layer | Defense | Introduced in |
|---|---|---|
| Server→Upstream | 5-min fetch timeout, client-disconnect propagation | Pre-existing |
| Server→Client SSE | 10s keepalive comment frames | Pre-existing |
| Server→Client SSE | Immediate keepalive flush on open | **This PR** |
| Server→Client SSE | `X-Accel-Buffering: no` on all 3 SSE endpoints | PR #245 |
| Server→Client SSE | Graceful wall-clock close (24s) with terminal frame | **This PR** |
| Client→Server read | 60s idle-read watchdog | **This PR** |
| Client fallback | Deterministic advisor on any stream failure | Pre-existing |

Full stack now guards against: **header buffering**, **body buffering**, **middlebox idle-close**, **TCP half-close**, **upstream silent hang**, and **Netlify wall-clock kill**.

## Files Changed

| File | Change |
|---|---|
| `netlify/functions/ai-proxy.mts` | Initial keepalive flush + wall-clock graceful close |
| `src/services/advisorStrategy.ts` | 60s per-read idle watchdog with reader cancel |

## Regulatory Basis

- **Cabinet Res 134/2025 Art.19** — continuous operational monitoring. A silent truncation of a compliance decision breaks MLRO situational awareness.
- **FDL No.10/2025 Art.20-21** — CO duty of care. The fallback to deterministic advisor ensures the decision path never blocks on advisor availability.

## Related upstream issues

- anthropics/claude-code#25979 (direct match — client-side idle watchdog pattern)
- anthropics/claude-code#20572 (adjacent — process hang on stalled stream)

## Test plan

- [ ] `tsc --noEmit` on modified files — passes locally.
- [ ] CI lint-and-test on PR.
- [ ] Deploy to Netlify preview; run an Opus advisor call that takes >25s; verify client sees `proxy_wall_clock` event, not a truncation error.
- [ ] Simulate middlebox half-close (drop packets after 30s); verify client-side watchdog fires at 60s and the deterministic advisor fallback runs.

https://claude.ai/code/session_019W8VmQaQPyKDYL5aFpQxYy