### PR TITLE
Deep-harden every layer against stream idle timeouts (Cabinet Res 134/2025 Art.19)

### DIFF
--- a/netlify/functions/ai-proxy.mts
+++ b/netlify/functions/ai-proxy.mts
@@ -62,9 +62,13 @@ const MAX_BODY_SIZE = 1024 * 1024; // 1 MB max request body
 /**
  * Upstream request timeouts.
  *
- * Non-streaming calls are capped at 60s — if an AI provider hasn't
- * produced the full response by then, the caller has almost certainly
- * already given up.
+ * Non-streaming calls are capped at 22s — comfortably below Netlify's
+ * 26s synchronous function kill so we abort the upstream ourselves and
+ * return a diagnosable 504 instead of letting Netlify tear the socket.
+ * A torn socket is exactly the failure mode that surfaces as
+ * "Stream idle timeout - partial response received" on the browser.
+ * Callers that legitimately need >22s generations must use streaming,
+ * which has its own (much longer) ceiling and per-byte keepalives.
  *
  * Streaming calls get a much longer ceiling (5 minutes) because the
  * signal is attached to the entire `fetch()` — including the time the
@@ -73,10 +77,11 @@ const MAX_BODY_SIZE = 1024 * 1024; // 1 MB max request body
  * "Stream idle timeout - partial response received" on the browser
  * even though bytes are still flowing. The stream's real lifetime is
  * bounded by (a) Anthropic's own stream cap, (b) the client
- * disconnect signal (propagated below), and (c) Netlify's function
- * wall-clock — all of which are the right stopping conditions.
+ * disconnect signal (propagated below), (c) Netlify's function
+ * wall-clock (enforced explicitly via STREAM_WALL_CLOCK_MS below), and
+ * (d) the server-side stale-byte watchdog (STREAM_STALE_BYTE_MS).
  */
-const NONSTREAM_UPSTREAM_TIMEOUT_MS = 60_000;
+const NONSTREAM_UPSTREAM_TIMEOUT_MS = 22_000;
 const STREAM_UPSTREAM_TIMEOUT_MS = 300_000;
 
 /**
@@ -102,6 +107,21 @@ const STREAM_UPSTREAM_TIMEOUT_MS = 300_000;
  * adds a few hundred bytes per minute — negligible.
  */
 const STREAM_KEEPALIVE_MS = 10_000;
+
+/**
+ * Server-side stale-byte watchdog.
+ *
+ * The keepalive interval emits a frame every 10s *when the upstream is
+ * silent*. But controller.enqueue is fire-and-forget: the bytes land in
+ * the ReadableStream's internal queue, and the runtime drains them onto
+ * the TCP socket on its own schedule. If the runtime is backpressured
+ * (slow client, congested link, upstream flooding us) the keepalives
+ * pile up in the queue while real TCP idle continues. This watchdog
+ * detects "we haven't emitted anything in 15s" — twice the keepalive
+ * cadence — and forces an additional frame. Two missed cadence windows
+ * is the earliest point at which most CDN idle timers start triggering.
+ */
+const STREAM_STALE_BYTE_MS = 15_000;
 
 /**
  * Graceful wall-clock close for streaming responses.
@@ -139,6 +159,14 @@ const ALLOWED_ANTHROPIC_BETAS = new Set<string>(['advisor-tool-2026-03-01']);
 // ─── Handler ────────────────────────────────────────────────────────────────
 
 export default async (req: Request, context: Context) => {
+  // Capture function start-time so the stream wall-clock deadline is
+  // computed relative to when Netlify invoked us, not relative to when
+  // the ReadableStream's start() runs. Upstream fetches can take 1-5s
+  // to return headers; if the wall-clock timer only starts after the
+  // fetch resolves, we can overshoot Netlify's 26s hard kill and lose
+  // the chance to emit a clean terminal frame.
+  const functionStartedAt = Date.now();
+
   if (req.method === 'OPTIONS') {
     return new Response(null, { status: 204 });
   }
@@ -322,9 +350,10 @@ export default async (req: Request, context: Context) => {
       const encoder = new TextEncoder();
       const keepaliveBytes = encoder.encode(': keepalive\n\n');
 
+      const reader = upstreamBody.getReader();
+
       const passthrough = new ReadableStream<Uint8Array>({
         start(controller) {
-          const reader = upstreamBody.getReader();
           let lastByteAt = Date.now();
           let closed = false;
 
@@ -346,18 +375,56 @@ export default async (req: Request, context: Context) => {
           // the same "Stream idle timeout - partial response
           // received" error as a mid-stream stall.
           safeEnqueue(keepaliveBytes);
+          // Follow the header flush with an advisory "ready" frame
+          // carrying the server wall-clock so the client can compute
+          // its own deadline and detect clock skew. Plain SSE comment
+          // frames don't reach EventSource handlers; this structured
+          // frame does, and a stricter intermediary that strips
+          // comment frames will still forward this one.
+          safeEnqueue(
+            encoder.encode(
+              `event: proxy_ready\ndata: ${JSON.stringify({
+                serverTime: new Date(functionStartedAt).toISOString(),
+                wallClockMs: STREAM_WALL_CLOCK_MS,
+                keepaliveMs: STREAM_KEEPALIVE_MS,
+              })}\n\n`
+            )
+          );
+
+          // Track the last byte we actually *emitted downstream* so
+          // the stale-byte watchdog can distinguish between upstream
+          // silence (keepalive handles it) and downstream backpressure
+          // (keepalive frames queued but not flushed).
+          let lastEmitAt = Date.now();
+          const trackingEnqueue = (chunk: Uint8Array) => {
+            safeEnqueue(chunk);
+            lastEmitAt = Date.now();
+          };
+          // Retroactively credit the initial header-flush keepalive.
+          lastEmitAt = Date.now();
 
           // Forward-declare timer handles so `finish()` can close them
           // cleanly regardless of which one fires first.
           let keepaliveTimer: ReturnType<typeof setInterval> | null = null;
+          let staleByteTimer: ReturnType<typeof setInterval> | null = null;
           let wallClockTimer: ReturnType<typeof setTimeout> | null = null;
 
           const finish = () => {
             if (closed) return;
             closed = true;
             if (keepaliveTimer !== null) clearInterval(keepaliveTimer);
+            if (staleByteTimer !== null) clearInterval(staleByteTimer);
             if (wallClockTimer !== null) clearTimeout(wallClockTimer);
             if (clientSignal) clientSignal.removeEventListener('abort', onClientAbort);
+            // Release the upstream reader so its socket is reclaimed
+            // promptly instead of drifting until GC. A leaked reader
+            // can hold the upstream TCP connection in CLOSE_WAIT and
+            // consume file descriptors on long-running deploys.
+            try {
+              reader.cancel(new DOMException('proxy stream finished', 'AbortError'));
+            } catch {
+              /* reader already detached */
+            }
             try {
               controller.close();
             } catch {
@@ -368,23 +435,45 @@ export default async (req: Request, context: Context) => {
           keepaliveTimer = setInterval(() => {
             if (closed) return;
             if (Date.now() - lastByteAt >= STREAM_KEEPALIVE_MS) {
-              safeEnqueue(keepaliveBytes);
+              trackingEnqueue(keepaliveBytes);
               lastByteAt = Date.now();
             }
           }, STREAM_KEEPALIVE_MS);
+
+          // Stale-byte watchdog — catches the case where the keepalive
+          // timer has emitted but the bytes are stuck in the
+          // ReadableStream queue due to downstream backpressure. Forcing
+          // an extra frame can't unblock a truly backpressured consumer,
+          // but it DOES guarantee that any intermediary that relies on
+          // observing bytes (rather than on controller activity) gets
+          // one within STREAM_STALE_BYTE_MS of the last flushed byte.
+          staleByteTimer = setInterval(() => {
+            if (closed) return;
+            if (Date.now() - lastEmitAt >= STREAM_STALE_BYTE_MS) {
+              trackingEnqueue(keepaliveBytes);
+            }
+          }, Math.max(1_000, Math.floor(STREAM_STALE_BYTE_MS / 3)));
 
           // Graceful wall-clock close — see STREAM_WALL_CLOCK_MS. We
           // beat Netlify's hard kill so the client gets a terminal
           // SSE event instead of a torn socket, which is exactly the
           // signal that surfaces as "Stream idle timeout - partial
-          // response received" on the browser.
+          // response received" on the browser. Deadline is computed
+          // from `functionStartedAt`, not from now, so upstream header
+          // latency doesn't push us past Netlify's 26s ceiling.
+          const wallClockRemaining = Math.max(
+            1_000,
+            STREAM_WALL_CLOCK_MS - (Date.now() - functionStartedAt)
+          );
           wallClockTimer = setTimeout(() => {
             if (closed) return;
-            safeEnqueue(
+            trackingEnqueue(
               encoder.encode(
                 `event: proxy_wall_clock\ndata: ${JSON.stringify({
                   message: 'proxy stream closed gracefully before function wall-clock',
                   wallClockMs: STREAM_WALL_CLOCK_MS,
+                  elapsedMs: Date.now() - functionStartedAt,
+                  retryable: true,
                 })}\n\n`
               )
             );
@@ -394,7 +483,7 @@ export default async (req: Request, context: Context) => {
               /* already aborted */
             }
             finish();
-          }, STREAM_WALL_CLOCK_MS);
+          }, wallClockRemaining);
 
           // Pump upstream → controller in the background. We deliberately
           // do not await this inside start() — start() must return
@@ -406,14 +495,25 @@ export default async (req: Request, context: Context) => {
                 const { value, done } = await reader.read();
                 if (done) break;
                 lastByteAt = Date.now();
-                safeEnqueue(value);
+                trackingEnqueue(value);
               }
             } catch (err) {
               // Surface the upstream error as a terminal SSE event so
               // the client gets a diagnosable message instead of a
-              // silent truncation.
+              // silent truncation. Distinct event name (upstream_error
+              // vs plain error) lets the client distinguish a proxy
+              // pump failure from an Anthropic stream-level error.
               const message = err instanceof Error ? err.message : String(err);
-              safeEnqueue(encoder.encode(`event: error\ndata: ${JSON.stringify({ message })}\n\n`));
+              const name = err instanceof Error ? err.name : 'Error';
+              trackingEnqueue(
+                encoder.encode(
+                  `event: upstream_error\ndata: ${JSON.stringify({
+                    message,
+                    name,
+                    retryable: name === 'TimeoutError' || name === 'AbortError',
+                  })}\n\n`
+                )
+              );
             } finally {
               finish();
             }
@@ -449,11 +549,37 @@ export default async (req: Request, context: Context) => {
       });
     }
 
-    // Non-streaming path: response is buffered below, timer can fire.
+    // Non-streaming path: the timeout must stay armed through the
+    // body read. fetch() resolves on response headers, but the body
+    // can dribble in for an arbitrarily long tail — and that tail
+    // runs inside the same 26s Netlify wall-clock. If we cleared the
+    // timeout here, a slow-bodied upstream would silently push us
+    // over the Netlify kill and produce the exact truncated socket
+    // we're defending against. We keep the AbortController alive
+    // until the whole body has been buffered, then clear.
+    let responseBody: string;
+    try {
+      responseBody = await upstreamRes.text();
+    } catch (err) {
+      clearTimeout(upstreamTimeout);
+      if (clientSignal) clientSignal.removeEventListener('abort', onClientAbort);
+      const name = err instanceof Error ? err.name : 'Error';
+      if (name === 'TimeoutError') {
+        return Response.json(
+          {
+            error: 'AI provider timed out while streaming response body.',
+            retryable: true,
+            reason: 'nonstream_body_timeout',
+            upstreamTimeoutMs: NONSTREAM_UPSTREAM_TIMEOUT_MS,
+          },
+          { status: 504 }
+        );
+      }
+      throw err;
+    }
     clearTimeout(upstreamTimeout);
     if (clientSignal) clientSignal.removeEventListener('abort', onClientAbort);
 
-    const responseBody = await upstreamRes.text();
     return new Response(responseBody, {
       status: upstreamRes.status,
       headers: {
@@ -464,7 +590,35 @@ export default async (req: Request, context: Context) => {
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
-    console.error(`[ai-proxy] ${providerName} request failed:`, message);
+    const name = err instanceof Error ? err.name : 'Error';
+    console.error(`[ai-proxy] ${providerName} request failed:`, name, message);
+    // Translate AbortController-driven timeouts into a proper 504
+    // with a retryable flag so the browser/client falls back instead
+    // of guessing at a 502. This is the fingerprint the downstream
+    // SDK uses to surface a clean retry instead of the truncated
+    // socket that reads as "Stream idle timeout - partial response
+    // received".
+    if (name === 'TimeoutError') {
+      return Response.json(
+        {
+          error: `AI provider request timed out: ${message}`,
+          retryable: true,
+          reason: 'upstream_timeout',
+          upstreamTimeoutMs: stream ? STREAM_UPSTREAM_TIMEOUT_MS : NONSTREAM_UPSTREAM_TIMEOUT_MS,
+        },
+        { status: 504 }
+      );
+    }
+    if (name === 'AbortError') {
+      return Response.json(
+        {
+          error: `AI provider request aborted: ${message}`,
+          retryable: false,
+          reason: 'client_disconnected',
+        },
+        { status: 499 }
+      );
+    }
     return Response.json({ error: `AI provider request failed: ${message}` }, { status: 502 });
   }
 };

--- a/netlify/functions/decision-stream.mts
+++ b/netlify/functions/decision-stream.mts
@@ -46,6 +46,14 @@ const MAX_BODY_BYTES = 512 * 1024;
 const HEARTBEAT_MS = 5_000;
 
 /**
+ * Stale-emit watchdog — forces an additional keepalive if we haven't
+ * pushed any byte in this window, which catches the case where the
+ * heartbeat timer is enqueuing bytes but they're stuck in the
+ * ReadableStream queue due to downstream backpressure.
+ */
+const STALE_EMIT_MS = 7_500;
+
+/**
  * Hard cap on total stream duration. Netlify standard functions abort
  * after ~26s wall time; we close cleanly at 24s so the client receives
  * a terminal `timeout` event rather than a truncated TCP stream.
@@ -122,13 +130,16 @@ export default async (req: Request, context: Context): Promise<Response> => {
     async start(controller) {
       const enc = new TextEncoder();
       let closed = false;
+      let lastEmitAt = Date.now();
       let heartbeat: ReturnType<typeof setInterval> | null = null;
+      let staleEmitTimer: ReturnType<typeof setInterval> | null = null;
       let deadline: ReturnType<typeof setTimeout> | null = null;
 
       const safeEnqueue = (chunk: Uint8Array) => {
         if (closed) return;
         try {
           controller.enqueue(chunk);
+          lastEmitAt = Date.now();
         } catch {
           // Controller already closed (client disconnect). Stop further writes.
           closed = true;
@@ -142,6 +153,7 @@ export default async (req: Request, context: Context): Promise<Response> => {
         if (closed) return;
         closed = true;
         if (heartbeat) clearInterval(heartbeat);
+        if (staleEmitTimer) clearInterval(staleEmitTimer);
         if (deadline) clearTimeout(deadline);
         if (clientSignal) clientSignal.removeEventListener('abort', onAbort);
         try {
@@ -156,11 +168,36 @@ export default async (req: Request, context: Context): Promise<Response> => {
       }
       if (clientSignal) clientSignal.addEventListener('abort', onAbort);
 
+      // Flush response headers immediately with a zero-cost comment
+      // frame plus an advisory `stream:ready` event. Some intermediaries
+      // hold response headers until the first body byte arrives;
+      // runComplianceDecision can take 10-20s to reach its first emit,
+      // which is long enough for idle timers to trip. Pushing bytes
+      // before we await anything guarantees the 200 OK reaches the
+      // client synchronously.
+      safeEnqueue(enc.encode(`: keepalive ${Date.now()}\n\n`));
+      emit('stream:ready', {
+        maxStreamMs: MAX_STREAM_MS,
+        heartbeatMs: HEARTBEAT_MS,
+        serverTime: new Date().toISOString(),
+      });
+
       // Keep-alive heartbeat during the long-running runComplianceDecision
       // await. Prevents idle-timeout on any intermediate proxy.
       heartbeat = setInterval(() => {
         safeEnqueue(enc.encode(sseHeartbeat()));
       }, HEARTBEAT_MS);
+
+      // Stale-emit watchdog — catches the case where the heartbeat
+      // timer enqueued bytes but backpressure kept them in the queue.
+      // The check rate is a third of STALE_EMIT_MS so we detect a
+      // stall within one window rather than two.
+      staleEmitTimer = setInterval(() => {
+        if (closed) return;
+        if (Date.now() - lastEmitAt >= STALE_EMIT_MS) {
+          safeEnqueue(enc.encode(`: keepalive-stale ${Date.now()}\n\n`));
+        }
+      }, Math.max(1_000, Math.floor(STALE_EMIT_MS / 3)));
 
       // Hard deadline: close with a terminal `timeout` event before the
       // Netlify wall-clock kills the function. Client should retry.
@@ -168,6 +205,7 @@ export default async (req: Request, context: Context): Promise<Response> => {
         emit('timeout', {
           reason: 'max-stream-duration',
           maxStreamMs: MAX_STREAM_MS,
+          retryable: true,
         });
         cleanup();
       }, MAX_STREAM_MS);

--- a/netlify/functions/warroom-stream.mts
+++ b/netlify/functions/warroom-stream.mts
@@ -27,12 +27,24 @@ import { buildDashboardSnapshot } from '../../src/services/warRoomDashboard';
 
 const HEARTBEAT_MS = 5_000;
 // Hard cap on stream duration. Netlify functions run for up to 26s
-// on the standard tier; cap to 25s so the server closes cleanly
-// before the platform aborts. Clients should auto-reconnect.
-const MAX_STREAM_MS = 25_000;
+// on the standard tier; cap to 24s so the server closes cleanly
+// before the platform aborts, matching the same safety margin used
+// by ai-proxy and decision-stream. Clients should auto-reconnect.
+// (Previously 25s, which left only 1s for the reconnect frame to
+// flush — too tight if buildDashboardSnapshot runs long.)
+const MAX_STREAM_MS = 24_000;
+// Stale-emit watchdog: if more than this many ms pass without any
+// byte landing in the ReadableStream queue, force a comment frame.
+// Picked at 1.5× the heartbeat cadence so it fires on exactly one
+// missed heartbeat rather than two.
+const STALE_EMIT_MS = 7_500;
 
 function sseFrame(event: string, data: unknown): string {
   return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function sseHeartbeat(): string {
+  return `: heartbeat ${Date.now()}\n\n`;
 }
 
 export default async (req: Request, context: Context): Promise<Response> => {
@@ -59,50 +71,106 @@ export default async (req: Request, context: Context): Promise<Response> => {
 
   const feed = getWarRoomFeed();
 
+  const signal = (req as unknown as { signal?: AbortSignal }).signal;
+
   const stream = new ReadableStream<Uint8Array>({
     start(controller) {
       const enc = new TextEncoder();
-      const startedAt = Date.now();
+      let closed = false;
+      let lastEmitAt = Date.now();
+      let heartbeat: ReturnType<typeof setInterval> | null = null;
+      let staleEmitTimer: ReturnType<typeof setInterval> | null = null;
+      let deadline: ReturnType<typeof setTimeout> | null = null;
+
+      const safeEnqueue = (chunk: Uint8Array) => {
+        if (closed) return;
+        try {
+          controller.enqueue(chunk);
+          lastEmitAt = Date.now();
+        } catch {
+          // Controller closed (client disconnect). Stop further writes.
+          closed = true;
+        }
+      };
+      const emit = (event: string, data: unknown) => {
+        safeEnqueue(enc.encode(sseFrame(event, data)));
+      };
+
+      const cleanup = () => {
+        if (closed) return;
+        closed = true;
+        if (heartbeat) clearInterval(heartbeat);
+        if (staleEmitTimer) clearInterval(staleEmitTimer);
+        if (deadline) clearTimeout(deadline);
+        if (signal) signal.removeEventListener('abort', onAbort);
+        try {
+          controller.close();
+        } catch {
+          /* already closed */
+        }
+      };
+
+      function onAbort() {
+        cleanup();
+      }
+      if (signal) signal.addEventListener('abort', onAbort);
+
+      // Flush response headers immediately with a zero-cost comment so
+      // intermediaries release the 200 OK before buildDashboardSnapshot
+      // runs. If the snapshot build hangs or throws, the client still
+      // has an open socket and can recover rather than seeing the
+      // "Stream idle timeout - partial response received" failure.
+      safeEnqueue(enc.encode(`: keepalive ${Date.now()}\n\n`));
+      emit('stream:ready', {
+        maxStreamMs: MAX_STREAM_MS,
+        heartbeatMs: HEARTBEAT_MS,
+        serverTime: new Date().toISOString(),
+      });
+
       // Send initial snapshot immediately so the client has something
       // to render before the first heartbeat.
       try {
         const snapshot = buildDashboardSnapshot(feed, tenantId);
-        controller.enqueue(enc.encode(sseFrame('snapshot', snapshot)));
+        emit('snapshot', snapshot);
       } catch (err) {
-        controller.enqueue(
-          enc.encode(sseFrame('error', { message: (err as Error).message }))
-        );
+        emit('error', { message: (err as Error).message, recoverable: true });
       }
 
-      const heartbeat = setInterval(() => {
-        if (Date.now() - startedAt > MAX_STREAM_MS) {
-          clearInterval(heartbeat);
-          controller.enqueue(enc.encode(sseFrame('reconnect', { reason: 'max-duration' })));
-          controller.close();
-          return;
-        }
+      heartbeat = setInterval(() => {
+        if (closed) return;
         try {
           const snapshot = buildDashboardSnapshot(feed, tenantId);
-          controller.enqueue(enc.encode(sseFrame('snapshot', snapshot)));
+          emit('snapshot', snapshot);
         } catch (err) {
-          controller.enqueue(
-            enc.encode(sseFrame('error', { message: (err as Error).message }))
-          );
+          // Never let a single snapshot failure tear down the stream —
+          // the client's auto-reconnect is strictly worse than letting
+          // the next heartbeat try again with fresh state.
+          emit('error', { message: (err as Error).message, recoverable: true });
         }
       }, HEARTBEAT_MS);
 
-      // Abort cleanup if the client disconnects.
-      const signal = (req as unknown as { signal?: AbortSignal }).signal;
-      if (signal) {
-        signal.addEventListener('abort', () => {
-          clearInterval(heartbeat);
-          try {
-            controller.close();
-          } catch {
-            /* already closed */
-          }
+      // Stale-emit watchdog — forces a keepalive if the heartbeat
+      // interval enqueued bytes but backpressure kept them in the queue.
+      staleEmitTimer = setInterval(() => {
+        if (closed) return;
+        if (Date.now() - lastEmitAt >= STALE_EMIT_MS) {
+          safeEnqueue(enc.encode(`: keepalive-stale ${Date.now()}\n\n`));
+        }
+      }, Math.max(1_000, Math.floor(STALE_EMIT_MS / 3)));
+
+      // Hard deadline, independent of the heartbeat interval. Previously
+      // the max-duration check piggy-backed on the heartbeat, which
+      // could miss by up to HEARTBEAT_MS if a snapshot build ran long.
+      // A dedicated timer guarantees we close within MAX_STREAM_MS even
+      // if the heartbeat is blocked.
+      deadline = setTimeout(() => {
+        emit('reconnect', {
+          reason: 'max-duration',
+          maxStreamMs: MAX_STREAM_MS,
+          retryable: true,
         });
-      }
+        cleanup();
+      }, MAX_STREAM_MS);
     },
   });
 

--- a/src/services/advisorStrategy.ts
+++ b/src/services/advisorStrategy.ts
@@ -390,15 +390,60 @@ export type FetchLike = (
  * Maximum time we'll wait between any two bytes on an advisor stream.
  *
  * The server-side proxy emits `: keepalive` SSE comment frames every 10s
- * (see ai-proxy.mts STREAM_KEEPALIVE_MS). If 60s pass without ANY byte
+ * (see ai-proxy.mts STREAM_KEEPALIVE_MS). If 30s pass without ANY byte
  * — not even a keepalive — the upstream is not merely thinking, it's
- * gone. Without this watchdog the `reader.read()` loop can hang
- * indefinitely if a middlebox silently half-closes the socket, which
- * is the same failure mode reported upstream in anthropics/claude-code
- * issue #25979. Fail fast and let the caller fall back to the
- * deterministic advisor (anthropicAdvisor.ts handles this).
+ * gone. 30s is three missed keepalive cadences, which is already
+ * beyond normal network jitter; anything longer is a silent half-close.
+ * Without this watchdog the `reader.read()` loop can hang indefinitely
+ * if a middlebox silently half-closes the socket, which is the same
+ * failure mode reported upstream in anthropics/claude-code issue #25979.
+ * Tightened from 60s → 30s so the client fails over to the deterministic
+ * advisor (anthropicAdvisor.ts handles this) roughly 2x faster.
  */
-const STREAM_IDLE_READ_TIMEOUT_MS = 60_000;
+const STREAM_IDLE_READ_TIMEOUT_MS = 30_000;
+
+/**
+ * Dedicated time-to-first-byte watchdog.
+ *
+ * TCP connection + TLS handshake + Netlify cold-start + upstream header
+ * latency can legitimately consume 5-15s before a single byte lands,
+ * even when the server is healthy. Separating TTFB from the inter-byte
+ * watchdog lets us (a) surface a distinct failure mode when the stream
+ * never starts at all vs. stalls mid-way, and (b) keep the inter-byte
+ * ceiling tight without flagging healthy cold starts as dead.
+ *
+ * The proxy emits its `: keepalive` + `event: proxy_ready` frames
+ * immediately after the upstream fetch resolves, so in practice the
+ * first byte lands within ~1s of fetch() returning. 45s is generous.
+ */
+const STREAM_FIRST_BYTE_TIMEOUT_MS = 45_000;
+
+/**
+ * Diagnostic shape of a stream failure. Thrown by
+ * `accumulateAdvisorStream`; the caller (`callAdvisorAssisted`) pipes
+ * this up through the advisor escalation and into brainBridge so the
+ * deterministic fallback path gets a usable reason code.
+ */
+export class AdvisorStreamError extends Error {
+  readonly kind:
+    | 'first_byte_timeout'
+    | 'idle_timeout'
+    | 'proxy_wall_clock'
+    | 'proxy_upstream_error'
+    | 'anthropic_error'
+    | 'malformed_frame';
+  readonly retryable: boolean;
+  constructor(
+    kind: AdvisorStreamError['kind'],
+    message: string,
+    options: { retryable?: boolean } = {}
+  ) {
+    super(message);
+    this.name = 'AdvisorStreamError';
+    this.kind = kind;
+    this.retryable = options.retryable ?? false;
+  }
+}
 
 async function accumulateAdvisorStream(
   stream: ReadableStream<Uint8Array>
@@ -406,29 +451,42 @@ async function accumulateAdvisorStream(
   const reader = stream.getReader();
   const decoder = new TextDecoder();
   let buffer = '';
+  // Track whether we've received any byte yet. The first-byte
+  // watchdog uses the longer STREAM_FIRST_BYTE_TIMEOUT_MS budget;
+  // every subsequent read uses the shorter inter-byte budget.
+  let receivedAnyByte = false;
 
   const content: Array<{ type: string; text?: string; name?: string }> = [];
   const usage: RawAnthropicResponse['usage'] = { input_tokens: 0, output_tokens: 0 };
 
   /**
-   * Race each read against a timer. If no byte arrives within
-   * STREAM_IDLE_READ_TIMEOUT_MS, cancel the reader and throw a
-   * diagnosable error. Keepalive comment frames count as bytes, so
-   * this only fires on a truly silent connection.
+   * Race each read against a timer. If no byte arrives within the
+   * applicable budget (TTFB before the first byte, inter-byte after),
+   * cancel the reader and throw a diagnosable error. Keepalive
+   * comment frames count as bytes, so this only fires on a truly
+   * silent connection.
    */
   const readWithIdleTimeout = async (): Promise<ReadableStreamReadResult<Uint8Array>> => {
+    const budgetMs = receivedAnyByte ? STREAM_IDLE_READ_TIMEOUT_MS : STREAM_FIRST_BYTE_TIMEOUT_MS;
+    const kind = receivedAnyByte ? 'idle_timeout' : 'first_byte_timeout';
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeout = new Promise<never>((_, reject) => {
       timer = setTimeout(() => {
         reject(
-          new Error(
-            `advisor stream idle for >${STREAM_IDLE_READ_TIMEOUT_MS}ms — upstream stalled`
+          new AdvisorStreamError(
+            kind,
+            receivedAnyByte
+              ? `advisor stream idle for >${budgetMs}ms — upstream stalled`
+              : `advisor stream produced no bytes in ${budgetMs}ms — upstream never opened`,
+            { retryable: true }
           )
         );
-      }, STREAM_IDLE_READ_TIMEOUT_MS);
+      }, budgetMs);
     });
     try {
-      return await Promise.race([reader.read(), timeout]);
+      const result = await Promise.race([reader.read(), timeout]);
+      if (!result.done) receivedAnyByte = true;
+      return result;
     } finally {
       if (timer !== undefined) clearTimeout(timer);
     }
@@ -464,14 +522,75 @@ async function accumulateAdvisorStream(
 
         // Comment frames (":keepalive") are how the proxy prevents idle
         // timeouts — skip them before we try to parse as JSON.
+        // We also capture the `event:` field so we can distinguish
+        // proxy-level events (proxy_wall_clock, upstream_error,
+        // proxy_ready) from Anthropic stream events.
         const dataLines: string[] = [];
+        let sseEventName = '';
         for (const line of frame.split('\n')) {
           if (line.startsWith(':')) continue;
+          if (line.startsWith('event:')) {
+            sseEventName = line.slice(6).trim();
+            continue;
+          }
           if (line.startsWith('data:')) dataLines.push(line.slice(5).trim());
         }
         if (dataLines.length === 0) continue;
         const dataJson = dataLines.join('\n');
         if (!dataJson || dataJson === '[DONE]') continue;
+
+        // Proxy-level events never use Anthropic's event schema, so
+        // intercept them before JSON.parse and translate into a
+        // structured error the caller can react to. If we forwarded
+        // them as normal frames, the caller would silently receive a
+        // truncated transcript and never know why — which is exactly
+        // the "Stream idle timeout - partial response received" class
+        // of silent failure we are defending against.
+        if (sseEventName === 'proxy_wall_clock') {
+          try {
+            await reader.cancel(new Error('proxy_wall_clock'));
+          } catch {
+            /* ignored */
+          }
+          throw new AdvisorStreamError(
+            'proxy_wall_clock',
+            `advisor stream closed by proxy wall-clock: ${dataJson}`,
+            { retryable: true }
+          );
+        }
+        if (sseEventName === 'upstream_error') {
+          // Proxy-emitted error (ai-proxy.mts passthrough pump failed
+          // or was aborted). Distinct from Anthropic's own `event:
+          // error` stream frame, which we still let the Anthropic
+          // handler below process by its `event.type === 'error'`
+          // branch. Keeping the two sources separate is what lets the
+          // caller tell "our proxy broke" from "Anthropic returned an
+          // error mid-stream".
+          let retryable = true;
+          try {
+            const parsed = JSON.parse(dataJson) as { retryable?: boolean; message?: string };
+            if (typeof parsed.retryable === 'boolean') retryable = parsed.retryable;
+          } catch {
+            /* keep retryable default */
+          }
+          try {
+            await reader.cancel(new Error(sseEventName));
+          } catch {
+            /* ignored */
+          }
+          throw new AdvisorStreamError(
+            'proxy_upstream_error',
+            `advisor stream proxy error (${sseEventName}): ${dataJson}`,
+            { retryable }
+          );
+        }
+        if (sseEventName === 'proxy_ready') {
+          // Advisory frame only — acknowledges the proxy is live and
+          // announces its timing constants. Nothing for the accumulator
+          // to do with it; receivedAnyByte was already set above when
+          // the bytes landed.
+          continue;
+        }
 
         let event: {
           type?: string;
@@ -492,7 +611,14 @@ async function accumulateAdvisorStream(
 
         if (event.type === 'error') {
           const msg = event.error?.message ?? 'advisor stream error';
-          throw new Error(`advisor SSE error: ${msg}`);
+          try {
+            await reader.cancel(new Error(msg));
+          } catch {
+            /* ignored */
+          }
+          throw new AdvisorStreamError('anthropic_error', `advisor SSE error: ${msg}`, {
+            retryable: true,
+          });
         }
 
         if (event.type === 'message_start' && event.message?.usage) {

--- a/tests/advisorStrategy.test.ts
+++ b/tests/advisorStrategy.test.ts
@@ -24,6 +24,7 @@ import {
   buildAdvisorRequest,
   parseAdvisorResponse,
   callAdvisorAssisted,
+  AdvisorStreamError,
   type FetchLike,
 } from '@/services/advisorStrategy';
 
@@ -519,5 +520,71 @@ describe('advisorStrategy — streaming mode', () => {
       { fetch: fake.fn, authToken: 'tok' }
     );
     expect(result.text).toBe('survived');
+  });
+
+  // --- Proxy-level event recognition -------------------------------------
+  // Proves the client recognises the structured frames that the ai-proxy
+  // emits when IT runs into a timeout / wall-clock / upstream failure,
+  // instead of treating them as silent Anthropic frames. This is the
+  // core defence against "API Error: Stream idle timeout - partial
+  // response received" — the proxy tells us exactly what went wrong
+  // and we surface it as a typed, retryable error.
+
+  it('surfaces event: proxy_wall_clock as a retryable AdvisorStreamError', async () => {
+    const fake = fakeStreamingFetch([
+      frameEvent('message_start', { type: 'message_start', message: { usage: { input_tokens: 0, output_tokens: 0 } } }),
+      frameEvent('content_block_start', { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } }),
+      frameEvent('content_block_delta', { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'partial' } }),
+      'event: proxy_wall_clock\ndata: {"message":"proxy stream closed","wallClockMs":24000}\n\n',
+    ]);
+    const err = await callAdvisorAssisted(
+      { userMessage: 'x', stream: true },
+      { fetch: fake.fn, authToken: 'tok' }
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(AdvisorStreamError);
+    expect((err as AdvisorStreamError).kind).toBe('proxy_wall_clock');
+    expect((err as AdvisorStreamError).retryable).toBe(true);
+  });
+
+  it('surfaces event: upstream_error as an AdvisorStreamError with retryable flag', async () => {
+    const fake = fakeStreamingFetch([
+      frameEvent('message_start', { type: 'message_start', message: { usage: { input_tokens: 0, output_tokens: 0 } } }),
+      'event: upstream_error\ndata: {"message":"upstream aborted","retryable":true,"name":"TimeoutError"}\n\n',
+    ]);
+    const err = await callAdvisorAssisted(
+      { userMessage: 'x', stream: true },
+      { fetch: fake.fn, authToken: 'tok' }
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(AdvisorStreamError);
+    expect((err as AdvisorStreamError).kind).toBe('proxy_upstream_error');
+    expect((err as AdvisorStreamError).retryable).toBe(true);
+  });
+
+  it('treats upstream_error with retryable:false as non-retryable', async () => {
+    const fake = fakeStreamingFetch([
+      frameEvent('message_start', { type: 'message_start', message: { usage: { input_tokens: 0, output_tokens: 0 } } }),
+      'event: upstream_error\ndata: {"message":"fatal","retryable":false}\n\n',
+    ]);
+    const err = await callAdvisorAssisted(
+      { userMessage: 'x', stream: true },
+      { fetch: fake.fn, authToken: 'tok' }
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(AdvisorStreamError);
+    expect((err as AdvisorStreamError).retryable).toBe(false);
+  });
+
+  it('ignores the advisory event: proxy_ready frame', async () => {
+    const fake = fakeStreamingFetch([
+      'event: proxy_ready\ndata: {"serverTime":"2026-04-18T00:00:00Z","wallClockMs":24000,"keepaliveMs":10000}\n\n',
+      frameEvent('message_start', { type: 'message_start', message: { usage: { input_tokens: 3, output_tokens: 0 } } }),
+      frameEvent('content_block_start', { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } }),
+      frameEvent('content_block_delta', { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'ok' } }),
+      frameEvent('message_stop', { type: 'message_stop' }),
+    ]);
+    const result = await callAdvisorAssisted(
+      { userMessage: 'x', stream: true },
+      { fetch: fake.fn, authToken: 'tok' }
+    );
+    expect(result.text).toBe('ok');
   });
 });


### PR DESCRIPTION
## Summary

Closes every remaining gap that could surface as **"API Error: Stream idle timeout - partial response received"** on the browser. Builds on #245 + #246; covers the failure modes those PRs left open.

Layered defences now cover: header buffering, body buffering, upstream stall, middlebox idle-close, TCP half-close, Netlify wall-clock, **downstream backpressure**, **slow non-stream bodies**, **first-byte latency**, and **proxy-level terminal frames that were previously silent**.

### `netlify/functions/ai-proxy.mts`
- Non-stream upstream timeout tightened **60s → 22s** (below Netlify's 26s synchronous-function kill) so we return a clean **504 retryable** instead of letting Netlify tear the socket — the exact fingerprint of the failure mode.
- Body-read stays inside the `AbortController` window so a slow body can't push us over the kill.
- Stream wall-clock is now **absolute** (computed from `functionStartedAt`) — upstream header latency no longer pushes the terminal frame past Netlify's ceiling.
- New `STREAM_STALE_BYTE_MS = 15_000` watchdog forces a keepalive when the `ReadableStream` queue is stuck behind downstream backpressure.
- Pump errors now emit `event: upstream_error` with a structured `{message, name, retryable}` payload, distinct from Anthropic's own `event: error`.
- Initial `event: proxy_ready` frame announces server time + timing constants after the header-flush keepalive (enables client clock-skew detection).
- `finish()` explicitly cancels the upstream reader, preventing `CLOSE_WAIT` leaks.
- Timeouts / aborts return proper **504** (retryable) / **499** (client gone) instead of bare 502.

### `src/services/advisorStrategy.ts`
- Idle-read watchdog tightened **60s → 30s** (three missed keepalive cadences) for ~2× faster failover.
- Dedicated **45s first-byte (TTFB) budget** so cold starts don't get flagged as dead while mid-stream stalls still fail fast.
- New `AdvisorStreamError` subclass (`kind`, `retryable`) replaces flat `Error` — kinds: `first_byte_timeout`, `idle_timeout`, `proxy_wall_clock`, `proxy_upstream_error`, `anthropic_error`, `malformed_frame`.
- Recognises `event: proxy_wall_clock` and `event: upstream_error` from the proxy and throws actionable errors — previously these were silently swallowed as unknown Anthropic frames (producing truncated transcripts with no error).
- `event: proxy_ready` is explicitly consumed; Anthropic's `event: error` is left to the existing handler so `overloaded_error` etc. still surfaces correctly.
- `reader.cancel()` on every throw path → socket always freed.

### `netlify/functions/decision-stream.mts`
- Initial `: keepalive` + `stream:ready` frames flush the 200 OK before the long `runComplianceDecision` await.
- Stale-emit watchdog (7.5s) forces a keepalive if the heartbeat's bytes are stuck behind backpressure.
- Terminal `timeout` event now carries `{retryable: true}`.

### `netlify/functions/warroom-stream.mts`
- `MAX_STREAM_MS` tightened **25s → 24s** (2s platform-kill headroom, matching the other streams).
- Dedicated `setTimeout` deadline, independent of the heartbeat interval — previously the check piggy-backed on the heartbeat and could miss by up to `HEARTBEAT_MS`.
- Adopted the `safeEnqueue` + `cleanup` pattern, initial keepalive flush, `stream:ready` advisory, stale-emit watchdog, client-signal abort cleanup, and recoverable error frame (single snapshot failures no longer tear down the stream).

### Tests
- 4 new streaming tests lock in the `AdvisorStreamError` contract for `proxy_wall_clock`, `upstream_error` (retryable + non-retryable), and `proxy_ready`.
- Full suite: **4502 / 4502 passing**. Advisor suite: **46 / 46 passing**.

## Regulatory basis

- **Cabinet Res 134/2025 Art.19** — continuous operational monitoring. A silently truncated compliance stream breaks the MLRO's situational awareness, which is exactly what Art.19 is intended to prevent.
- **FDL No.10/2025 Art.20-21** — CO duty of care. Decisions must either complete or fail diagnosably, never silently.

## Test plan

- [x] `./node_modules/.bin/vitest run tests/advisorStrategy.test.ts` — 46/46 pass
- [x] `./node_modules/.bin/vitest run` — 4502/4502 pass
- [x] `npx tsc --noEmit` — no new errors in any touched file (pre-existing errors in `WarRoomPanel.tsx`, `asanaEnvCheck.ts`, `goamlSchemaValidator.ts` are unrelated)
- [ ] Manual smoke: Opus advisor call over `/api/ai-proxy` with a fake 30s+ upstream stall — expect `AdvisorStreamError(kind='idle_timeout', retryable=true)` instead of the legacy `"Stream idle timeout - partial response received"` message
- [ ] Manual smoke: decision-stream + war-room EventSource — confirm initial `stream:ready` frame arrives <1s after POST, terminal `timeout` frame arrives at ~24s

https://claude.ai/code/session_019W8VmQaQPyKDYL5aFpQxYy