### PR TITLE
feat: screening-command — Mandatory/Enhanced list selector + MLRO disposition workflow + anomaly Asana

### DIFF
--- a/netlify/functions/screening-run.mts
+++ b/netlify/functions/screening-run.mts
@@ -5,13 +5,30 @@
  *   body = {
  *     subjectName: string,
  *     subjectId?: string,
+ *     entityType: "individual" | "legal_entity",
+ *     dob?: string,                 // dd/mm/yyyy (date of birth or registration)
+ *     country?: string,             // free text (e.g. "UAE", "Iran", "Russia")
+ *     idNumber?: string,            // passport / Emirates ID / trade licence
+ *     eventType: "new_customer_onboarding" | "periodic_review"
+ *              | "transaction_trigger" | "name_change"
+ *              | "adverse_media_hit" | "pep_change" | "ad_hoc",
  *     riskTier?: "high" | "medium" | "low",
  *     jurisdiction?: string,
  *     notes?: string,
- *     enrollInWatchlist?: boolean,   // default true
- *     runAdverseMedia?: boolean,     // default true
- *     createAsanaTask?: boolean,     // default true on confirmed/potential
+ *     selectedLists?: string[],     // optional opt-in for enhanced lists
+ *     enrollInWatchlist?: boolean,  // default true
+ *     runAdverseMedia?: boolean,    // default true
+ *     createAsanaTask?: boolean,    // default true on match / anomaly
  *   }
+ *
+ * List-selection rules (Cabinet Decision 74/2020 + EOCN guidance):
+ *   - UAE_EOCN and UN are LEGALLY MANDATORY — always run, cannot be
+ *     opted out.
+ *   - OFAC, EU, UK_OFSI are "Enhanced Controls" — default on, caller
+ *     may opt out by setting selectedLists.
+ *   - INTERPOL Red Notices — placeholder entry (integration pending);
+ *     selecting it surfaces a manual-verification notice in the
+ *     per-list result.
  *
  * Pipeline (all in-process, one RTT for the client):
  *   1. Multi-modal name matching across six sanctions lists in parallel
@@ -105,15 +122,77 @@ function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
 // Input validation
 // ---------------------------------------------------------------------------
 
+export type EntityType = 'individual' | 'legal_entity';
+export type ScreeningEventType =
+  | 'new_customer_onboarding'
+  | 'periodic_review'
+  | 'transaction_trigger'
+  | 'name_change'
+  | 'adverse_media_hit'
+  | 'pep_change'
+  | 'ad_hoc';
+
+const ENTITY_TYPES: readonly EntityType[] = ['individual', 'legal_entity'] as const;
+const EVENT_TYPES: readonly ScreeningEventType[] = [
+  'new_customer_onboarding',
+  'periodic_review',
+  'transaction_trigger',
+  'name_change',
+  'adverse_media_hit',
+  'pep_change',
+  'ad_hoc',
+] as const;
+
+/**
+ * Lists the MLRO can opt into. UAE_EOCN and UN are legally mandatory
+ * (Cabinet Decision 74/2020) and are always screened regardless of
+ * this input. INTERPOL is a placeholder — integration pending.
+ */
+export type SelectableList = 'OFAC' | 'EU' | 'UK_OFSI' | 'INTERPOL';
+const SELECTABLE_LISTS: readonly SelectableList[] = [
+  'OFAC',
+  'EU',
+  'UK_OFSI',
+  'INTERPOL',
+] as const;
+
 export interface ScreeningRunInput {
   subjectName: string;
   subjectId?: string;
+  entityType: EntityType;
+  dob?: string;
+  country?: string;
+  idNumber?: string;
+  eventType: ScreeningEventType;
   riskTier?: RiskTier;
   jurisdiction?: string;
   notes?: string;
+  selectedLists?: SelectableList[];
   enrollInWatchlist?: boolean;
   runAdverseMedia?: boolean;
   createAsanaTask?: boolean;
+}
+
+/**
+ * Accepts dd/mm/yyyy (preferred, UAE convention) or ISO-ish
+ * yyyy-mm-dd. Returns null if it cannot be parsed. We do not coerce
+ * — bad formats are rejected so the MLRO sees the error immediately.
+ */
+function validateUaeDate(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const ddmmyyyy = /^(\d{2})\/(\d{2})\/(\d{4})$/.exec(trimmed);
+  if (ddmmyyyy) {
+    const [, dd, mm, yyyy] = ddmmyyyy;
+    const d = new Date(`${yyyy}-${mm}-${dd}T00:00:00Z`);
+    if (!Number.isNaN(d.getTime())) return trimmed;
+  }
+  const iso = /^(\d{4})-(\d{2})-(\d{2})$/.exec(trimmed);
+  if (iso) {
+    const [, yyyy, mm, dd] = iso;
+    return `${dd}/${mm}/${yyyy}`;
+  }
+  return null;
 }
 
 function validateInput(
@@ -130,6 +209,35 @@ function validateInput(
   if (o.subjectId !== undefined && (typeof o.subjectId !== 'string' || o.subjectId.length > 128)) {
     return { ok: false, error: 'subjectId must be a string up to 128 chars' };
   }
+  if (!ENTITY_TYPES.includes(o.entityType as EntityType)) {
+    return { ok: false, error: 'entityType must be "individual" | "legal_entity"' };
+  }
+  if (!EVENT_TYPES.includes(o.eventType as ScreeningEventType)) {
+    return {
+      ok: false,
+      error:
+        'eventType must be one of: ' +
+        EVENT_TYPES.join(', ') +
+        ' (see Cabinet Res 134/2025 Art.19 periodic-review trigger taxonomy)',
+    };
+  }
+  let dob: string | undefined;
+  if (o.dob !== undefined) {
+    if (typeof o.dob !== 'string' || o.dob.length > 20) {
+      return { ok: false, error: 'dob must be a string up to 20 chars (dd/mm/yyyy preferred)' };
+    }
+    if (o.dob.trim().length > 0) {
+      const parsed = validateUaeDate(o.dob);
+      if (!parsed) return { ok: false, error: 'dob must be dd/mm/yyyy or yyyy-mm-dd' };
+      dob = parsed;
+    }
+  }
+  if (o.country !== undefined && (typeof o.country !== 'string' || o.country.length > 64)) {
+    return { ok: false, error: 'country must be a string up to 64 chars' };
+  }
+  if (o.idNumber !== undefined && (typeof o.idNumber !== 'string' || o.idNumber.length > 64)) {
+    return { ok: false, error: 'idNumber must be a string up to 64 chars' };
+  }
   if (o.riskTier !== undefined && !['high', 'medium', 'low'].includes(o.riskTier as string)) {
     return { ok: false, error: 'riskTier must be "high" | "medium" | "low"' };
   }
@@ -142,14 +250,36 @@ function validateInput(
   if (o.notes !== undefined && (typeof o.notes !== 'string' || o.notes.length > 2000)) {
     return { ok: false, error: 'notes must be a string up to 2000 chars' };
   }
+  let selectedLists: SelectableList[] | undefined;
+  if (o.selectedLists !== undefined) {
+    if (!Array.isArray(o.selectedLists)) {
+      return { ok: false, error: 'selectedLists must be an array of list codes' };
+    }
+    const invalid = (o.selectedLists as unknown[]).filter(
+      (x) => typeof x !== 'string' || !SELECTABLE_LISTS.includes(x as SelectableList)
+    );
+    if (invalid.length > 0) {
+      return {
+        ok: false,
+        error: 'selectedLists contains invalid codes; allowed: ' + SELECTABLE_LISTS.join(', '),
+      };
+    }
+    selectedLists = Array.from(new Set(o.selectedLists as SelectableList[]));
+  }
   return {
     ok: true,
     input: {
       subjectName: o.subjectName.trim(),
       subjectId: typeof o.subjectId === 'string' ? o.subjectId.trim() : undefined,
+      entityType: o.entityType as EntityType,
+      dob,
+      country: typeof o.country === 'string' ? o.country.trim() : undefined,
+      idNumber: typeof o.idNumber === 'string' ? o.idNumber.trim() : undefined,
+      eventType: o.eventType as ScreeningEventType,
       riskTier: o.riskTier as RiskTier | undefined,
       jurisdiction: typeof o.jurisdiction === 'string' ? o.jurisdiction.trim() : undefined,
       notes: typeof o.notes === 'string' ? o.notes.trim() : undefined,
+      selectedLists,
       enrollInWatchlist: o.enrollInWatchlist !== false,
       runAdverseMedia: o.runAdverseMedia !== false,
       createAsanaTask: o.createAsanaTask !== false,
@@ -222,15 +352,47 @@ export interface PerListResult {
   error?: string;
 }
 
+/**
+ * Names of the lists the caller is permitted to opt OUT of. UAE_EOCN
+ * and UN never appear here because they are legally mandatory under
+ * Cabinet Decision 74/2020.
+ */
+const MANDATORY_LISTS: ReadonlySet<string> = new Set(['UAE_EOCN', 'UN']);
+
 function screenAgainstAllLists(
   subjectName: string,
-  snapshot: ListSnapshot
+  snapshot: ListSnapshot,
+  selectedLists?: SelectableList[]
 ): {
   perList: PerListResult[];
   overallTopScore: number;
   overallTopClassification: MultiModalClassification;
 } {
-  const perList: PerListResult[] = snapshot.lists.map((listSnap) => {
+  // When selectedLists is omitted, enhanced lists default to on (back-compat
+  // with the v1 behaviour). When present, only the named enhanced lists
+  // run; mandatory lists ALWAYS run regardless.
+  const runEnhanced = (name: string): boolean => {
+    if (MANDATORY_LISTS.has(name)) return true;
+    if (!selectedLists) return true;
+    return (selectedLists as string[]).includes(name);
+  };
+
+  const perList: PerListResult[] = [];
+
+  for (const listSnap of snapshot.lists) {
+    if (!runEnhanced(listSnap.name)) {
+      perList.push({
+        list: listSnap.name,
+        candidatesChecked: 0,
+        hitCount: 0,
+        topScore: 0,
+        topClassification: 'none',
+        hits: [],
+        error: 'opted out by MLRO (enhanced control)',
+      });
+      continue;
+    }
+
     const candidates: string[] = [];
     for (const e of listSnap.entries) {
       candidates.push(e.name);
@@ -242,7 +404,7 @@ function screenAgainstAllLists(
       threshold: 0.7,
       maxHits: 10,
     });
-    return {
+    perList.push({
       list: listSnap.name,
       candidatesChecked: candidates.length,
       hitCount: resp.hitCount,
@@ -250,8 +412,26 @@ function screenAgainstAllLists(
       topClassification: resp.topClassification,
       hits: [...resp.hits],
       error: listSnap.error,
-    };
-  });
+    });
+  }
+
+  // Interpol Red Notices — placeholder. We expose the list in the
+  // per-list output with an actionable error so MLROs know they must
+  // manually check interpol.int/wanted until we finish the integration.
+  const interpolSelected = !selectedLists || (selectedLists as string[]).includes('INTERPOL');
+  if (interpolSelected) {
+    perList.push({
+      list: 'INTERPOL',
+      candidatesChecked: 0,
+      hitCount: 0,
+      topScore: 0,
+      topClassification: 'none',
+      hits: [],
+      error:
+        'Integration pending — manual verification required via www.interpol.int/wanted (EOCN guidance)',
+    });
+  }
+
   let overallTopScore = 0;
   let overallTopClassification: MultiModalClassification = 'none';
   for (const r of perList) {
@@ -357,6 +537,8 @@ async function postAsanaTask(params: {
   adverseMediaCount: number;
   jurisdiction?: string;
   notes?: string;
+  anomalies?: string[];
+  eventType?: ScreeningEventType;
 }): Promise<{ ok: boolean; gid?: string; error?: string }> {
   const projectId = process.env.ASANA_SCREENINGS_PROJECT_GID || '1213759768596515';
   if (!process.env.ASANA_TOKEN && !process.env.ASANA_ACCESS_TOKEN && !process.env.ASANA_API_TOKEN) {
@@ -366,6 +548,7 @@ async function postAsanaTask(params: {
   const lines: string[] = [];
   lines.push(`Subject: ${params.subjectName}`);
   lines.push(`Subject ID: ${params.subjectId}`);
+  if (params.eventType) lines.push(`Event type: ${params.eventType}`);
   lines.push(`Classification: ${params.classification.toUpperCase()}`);
   lines.push(`Top match score: ${(params.topScore * 100).toFixed(1)}%`);
   if (params.jurisdiction) lines.push(`Jurisdiction: ${params.jurisdiction}`);
@@ -373,11 +556,18 @@ async function postAsanaTask(params: {
   lines.push('Per-list results:');
   for (const l of params.perList) {
     lines.push(
-      `  - ${l.list}: ${l.hitCount} hit(s), top ${(l.topScore * 100).toFixed(1)}% (${l.topClassification})`
+      `  - ${l.list}: ${l.hitCount} hit(s), top ${(l.topScore * 100).toFixed(1)}% (${l.topClassification})${
+        l.error ? ` — ${l.error}` : ''
+      }`
     );
   }
   lines.push('');
   lines.push(`Adverse-media hits: ${params.adverseMediaCount}`);
+  if (params.anomalies && params.anomalies.length > 0) {
+    lines.push('');
+    lines.push('ANOMALIES DETECTED — investigate immediately:');
+    for (const a of params.anomalies) lines.push(`  - ${a}`);
+  }
   if (params.notes) {
     lines.push('');
     lines.push(`Notes: ${params.notes}`);
@@ -391,18 +581,26 @@ async function postAsanaTask(params: {
   lines.push('Do NOT notify the subject — FDL Art.29 no tipping off.');
 
   const severityTag =
-    params.classification === 'confirmed'
-      ? '[CONFIRMED MATCH]'
-      : params.classification === 'potential'
-        ? '[POTENTIAL MATCH]'
-        : '[WEAK MATCH]';
+    params.anomalies && params.anomalies.length > 0 && params.classification === 'none'
+      ? '[ANOMALY]'
+      : params.classification === 'confirmed'
+        ? '[CONFIRMED MATCH]'
+        : params.classification === 'potential'
+          ? '[POTENTIAL MATCH]'
+          : params.classification === 'weak'
+            ? '[WEAK MATCH]'
+            : '[ADVERSE MEDIA]';
   const name = `${severityTag} Screening: ${params.subjectName}`;
+
+  const tags = ['screening-command', params.classification];
+  if (params.anomalies && params.anomalies.length > 0) tags.push('anomaly');
+  if (params.eventType) tags.push(`event-${params.eventType}`);
 
   const result = await createAsanaTask({
     name,
     notes: lines.join('\n'),
     projects: [projectId],
-    tags: ['screening-command', params.classification, `list-${params.perList[0]?.list ?? 'NA'}`],
+    tags,
   });
   return result;
 }
@@ -463,10 +661,21 @@ export default async (req: Request, context: Context): Promise<Response> => {
   const snapshot = await loadAllLists();
   const { perList, overallTopScore, overallTopClassification } = screenAgainstAllLists(
     input.subjectName,
-    snapshot
+    snapshot,
+    input.selectedLists
   );
   const totalCandidates = perList.reduce((acc, l) => acc + l.candidatesChecked, 0);
   const listErrors = perList.filter((l) => l.error).map((l) => ({ list: l.list, error: l.error }));
+  // Distinguish "integration / fetch failure on a mandatory list" —
+  // a real anomaly that the MLRO needs paged on — from the benign
+  // "opted out by MLRO" or the expected Interpol-manual-check notice.
+  const anomalousListErrors = perList.filter(
+    (l) =>
+      l.error &&
+      l.list !== 'INTERPOL' &&
+      l.error !== 'opted out by MLRO (enhanced control)' &&
+      !/^Integration pending/i.test(l.error)
+  );
 
   // ─── 2. Adverse media (optional, provider-dependent) ──────────────────
   let adverseMediaHits: number = 0;
@@ -511,7 +720,9 @@ export default async (req: Request, context: Context): Promise<Response> => {
     enrollment = await enrollIntoWatchlist(subjectId, input.subjectName, riskTier, metadata);
   }
 
-  // ─── 5. Asana task (confirmed / potential / weak match) ───────────────
+  // ─── 5. Asana task — any match, any adverse-media hit, or any anomaly
+  // (mandatory-list fetch failure). "If any anomaly or event → notify
+  // Asana" — see Cabinet Res 134/2025 Art.19 periodic internal review.
   let asana: { ok: boolean; gid?: string; error?: string; skipped?: boolean } = {
     ok: false,
     skipped: true,
@@ -521,7 +732,8 @@ export default async (req: Request, context: Context): Promise<Response> => {
     (overallTopClassification === 'confirmed' ||
       overallTopClassification === 'potential' ||
       overallTopClassification === 'weak' ||
-      adverseMediaHits > 0);
+      adverseMediaHits > 0 ||
+      anomalousListErrors.length > 0);
   if (shouldCreateAsana) {
     const res = await postAsanaTask({
       subjectName: input.subjectName,
@@ -532,6 +744,8 @@ export default async (req: Request, context: Context): Promise<Response> => {
       adverseMediaCount: adverseMediaHits,
       jurisdiction: input.jurisdiction,
       notes: input.notes,
+      anomalies: anomalousListErrors.map((l) => `${l.list}: ${l.error}`),
+      eventType: input.eventType,
     });
     asana = res;
   }
@@ -542,9 +756,15 @@ export default async (req: Request, context: Context): Promise<Response> => {
     subject: {
       id: subjectId,
       name: input.subjectName,
+      entityType: input.entityType,
+      dob: input.dob,
+      country: input.country,
+      idNumber: input.idNumber,
+      eventType: input.eventType,
       riskTier,
       jurisdiction: input.jurisdiction,
     },
+    anomalies: anomalousListErrors.map((l) => ({ list: l.list, error: l.error })),
     sanctions: {
       totalCandidatesChecked: totalCandidates,
       listsChecked: perList.map((l) => l.list),

--- a/netlify/functions/screening-save.mts
+++ b/netlify/functions/screening-save.mts
@@ -1,0 +1,525 @@
+/**
+ * Screening Command — persistent disposition save endpoint.
+ *
+ * POST /api/screening/save
+ *   body = {
+ *     // Subject identity
+ *     subjectName: string,
+ *     subjectId?: string,            // echoed back from /api/screening/run
+ *     entityType: "individual" | "legal_entity",
+ *     dob?: string,                  // dd/mm/yyyy
+ *     country?: string,
+ *     idNumber?: string,
+ *
+ *     // Event classification
+ *     eventType: "new_customer_onboarding" | "periodic_review"
+ *              | "transaction_trigger" | "name_change"
+ *              | "adverse_media_hit" | "pep_change" | "ad_hoc",
+ *
+ *     // Which lists were screened + their outcome (captured from /run)
+ *     listsScreened: string[],
+ *     overallTopScore: number,
+ *     overallTopClassification: "confirmed" | "potential" | "weak" | "none",
+ *     anomalies?: Array<{ list: string; error: string }>,
+ *
+ *     // MLRO disposition (MUST be filled)
+ *     screeningDate: string,         // dd/mm/yyyy
+ *     reviewedBy: string,            // compliance officer / MLRO name
+ *     outcome: "negative_no_match" | "false_positive"
+ *            | "partial_match" | "confirmed_match",
+ *     rationale: string,             // >= 20 chars
+ *
+ *     // Optional linkage
+ *     runId?: string,                // if the run created an Asana task
+ *     riskTier?: "high" | "medium" | "low",
+ *     jurisdiction?: string,
+ *   }
+ *
+ * Behaviour:
+ *   1. Validates every field. Disposition fields are MANDATORY — the
+ *      MLRO cannot save a screening event without an outcome + rationale
+ *      + named reviewer (auditor's golden rule).
+ *   2. Persists the ScreeningEvent record into Netlify Blob store
+ *      `screening-events`, key = eventId. CAS-safe (onlyIfNew).
+ *   3. ALWAYS creates an Asana task in the SCREENINGS project with the
+ *      full disposition attestation — regardless of outcome. Negative
+ *      no-match events also create a task so MoE audit can confirm the
+ *      reviewer actually looked.
+ *   4. If outcome === "confirmed_match", the task is prefixed
+ *      [FREEZE-24H] and explicitly cites Cabinet Res 74/2020 Art.4-7
+ *      (24-hour freeze deadline).
+ *   5. Returns { ok: true, eventId, asanaGid }.
+ *
+ * Regulatory basis:
+ *   - FDL No.10/2025 Art.20-21 (compliance officer role), Art.24
+ *     (10-year record retention), Art.26-27 (STR filing), Art.29
+ *     (no tipping off)
+ *   - Cabinet Res 134/2025 Art.14 (PEP/EDD), Art.19 (periodic internal
+ *     review)
+ *   - Cabinet Res 74/2020 Art.4-7 (asset freeze workflow)
+ *   - Cabinet Decision No.(74)/2020 (mandatory list screening —
+ *     captured by listsScreened)
+ *   - FATF Rec 10 / 22 / 23
+ */
+
+import type { Config, Context } from '@netlify/functions';
+import { getStore } from '@netlify/blobs';
+import { authenticate } from './middleware/auth.mts';
+import { checkRateLimit } from './middleware/rate-limit.mts';
+import { createAsanaTask } from '../../src/services/asanaClient';
+
+const EVENTS_STORE = 'screening-events';
+const MAX_BODY_SIZE = 32 * 1024;
+const MAX_CAS_ATTEMPTS = 5;
+const MIN_RATIONALE_LEN = 20;
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin':
+    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://hawkeye-sterling-v2.netlify.app',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+  'Access-Control-Max-Age': '600',
+  Vary: 'Origin',
+} as const;
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return Response.json(body, {
+    ...init,
+    headers: { ...CORS_HEADERS, ...(init.headers ?? {}) },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+const ENTITY_TYPES = ['individual', 'legal_entity'] as const;
+const EVENT_TYPES = [
+  'new_customer_onboarding',
+  'periodic_review',
+  'transaction_trigger',
+  'name_change',
+  'adverse_media_hit',
+  'pep_change',
+  'ad_hoc',
+] as const;
+const CLASSIFICATIONS = ['confirmed', 'potential', 'weak', 'none'] as const;
+const OUTCOMES = [
+  'negative_no_match',
+  'false_positive',
+  'partial_match',
+  'confirmed_match',
+] as const;
+const RISK_TIERS = ['high', 'medium', 'low'] as const;
+
+type EntityType = (typeof ENTITY_TYPES)[number];
+type EventType = (typeof EVENT_TYPES)[number];
+type Classification = (typeof CLASSIFICATIONS)[number];
+type Outcome = (typeof OUTCOMES)[number];
+type RiskTier = (typeof RISK_TIERS)[number];
+
+export interface ScreeningEvent {
+  eventId: string;
+  subjectName: string;
+  subjectId: string;
+  entityType: EntityType;
+  dob?: string;
+  country?: string;
+  idNumber?: string;
+  eventType: EventType;
+  listsScreened: string[];
+  overallTopScore: number;
+  overallTopClassification: Classification;
+  anomalies?: Array<{ list: string; error: string }>;
+  screeningDate: string;
+  reviewedBy: string;
+  outcome: Outcome;
+  rationale: string;
+  runId?: string;
+  riskTier?: RiskTier;
+  jurisdiction?: string;
+  savedAt: string;
+  asanaGid?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+interface ValidatedInput
+  extends Omit<ScreeningEvent, 'eventId' | 'savedAt' | 'asanaGid'> {}
+
+function validateDdMmYyyy(raw: string): string | null {
+  const trimmed = raw.trim();
+  const m = /^(\d{2})\/(\d{2})\/(\d{4})$/.exec(trimmed);
+  if (!m) {
+    const iso = /^(\d{4})-(\d{2})-(\d{2})$/.exec(trimmed);
+    if (iso) {
+      const [, y, mo, d] = iso;
+      return `${d}/${mo}/${y}`;
+    }
+    return null;
+  }
+  return trimmed;
+}
+
+function validateInput(
+  raw: unknown
+): { ok: true; input: ValidatedInput } | { ok: false; error: string } {
+  if (!raw || typeof raw !== 'object') return { ok: false, error: 'body must be a JSON object' };
+  const o = raw as Record<string, unknown>;
+
+  if (typeof o.subjectName !== 'string' || o.subjectName.trim().length === 0) {
+    return { ok: false, error: 'subjectName is required' };
+  }
+  if (o.subjectName.length > 200) return { ok: false, error: 'subjectName too long (max 200)' };
+
+  if (
+    o.subjectId !== undefined &&
+    (typeof o.subjectId !== 'string' || o.subjectId.length > 128)
+  ) {
+    return { ok: false, error: 'subjectId must be a string up to 128 chars' };
+  }
+
+  if (!ENTITY_TYPES.includes(o.entityType as EntityType)) {
+    return { ok: false, error: 'entityType must be "individual" | "legal_entity"' };
+  }
+
+  let dob: string | undefined;
+  if (o.dob !== undefined) {
+    if (typeof o.dob !== 'string' || o.dob.length > 20) {
+      return { ok: false, error: 'dob must be a string up to 20 chars' };
+    }
+    if (o.dob.trim().length > 0) {
+      const parsed = validateDdMmYyyy(o.dob);
+      if (!parsed) return { ok: false, error: 'dob must be dd/mm/yyyy' };
+      dob = parsed;
+    }
+  }
+
+  if (o.country !== undefined && (typeof o.country !== 'string' || o.country.length > 64)) {
+    return { ok: false, error: 'country must be a string up to 64 chars' };
+  }
+  if (o.idNumber !== undefined && (typeof o.idNumber !== 'string' || o.idNumber.length > 64)) {
+    return { ok: false, error: 'idNumber must be a string up to 64 chars' };
+  }
+
+  if (!EVENT_TYPES.includes(o.eventType as EventType)) {
+    return { ok: false, error: 'eventType invalid; allowed: ' + EVENT_TYPES.join(', ') };
+  }
+
+  if (!Array.isArray(o.listsScreened) || o.listsScreened.length === 0) {
+    return { ok: false, error: 'listsScreened must be a non-empty array' };
+  }
+  if (
+    (o.listsScreened as unknown[]).some(
+      (x) => typeof x !== 'string' || (x as string).length > 32
+    )
+  ) {
+    return { ok: false, error: 'listsScreened entries must be short strings' };
+  }
+
+  if (typeof o.overallTopScore !== 'number' || !Number.isFinite(o.overallTopScore)) {
+    return { ok: false, error: 'overallTopScore must be a finite number' };
+  }
+  if (o.overallTopScore < 0 || o.overallTopScore > 1) {
+    return { ok: false, error: 'overallTopScore must be between 0 and 1' };
+  }
+
+  if (!CLASSIFICATIONS.includes(o.overallTopClassification as Classification)) {
+    return {
+      ok: false,
+      error: 'overallTopClassification must be one of: ' + CLASSIFICATIONS.join(', '),
+    };
+  }
+
+  let anomalies: Array<{ list: string; error: string }> | undefined;
+  if (o.anomalies !== undefined) {
+    if (!Array.isArray(o.anomalies)) {
+      return { ok: false, error: 'anomalies must be an array' };
+    }
+    const raw = o.anomalies as unknown[];
+    const parsed: Array<{ list: string; error: string }> = [];
+    for (const a of raw) {
+      if (!a || typeof a !== 'object') return { ok: false, error: 'anomaly entries must be objects' };
+      const entry = a as Record<string, unknown>;
+      if (typeof entry.list !== 'string' || typeof entry.error !== 'string') {
+        return { ok: false, error: 'anomaly entries must have string list + error' };
+      }
+      parsed.push({ list: entry.list.slice(0, 32), error: entry.error.slice(0, 256) });
+    }
+    anomalies = parsed;
+  }
+
+  if (typeof o.screeningDate !== 'string') {
+    return { ok: false, error: 'screeningDate is required (dd/mm/yyyy)' };
+  }
+  const screeningDate = validateDdMmYyyy(o.screeningDate);
+  if (!screeningDate) return { ok: false, error: 'screeningDate must be dd/mm/yyyy' };
+
+  if (typeof o.reviewedBy !== 'string' || o.reviewedBy.trim().length === 0) {
+    return {
+      ok: false,
+      error: 'reviewedBy is required — name the compliance officer / MLRO',
+    };
+  }
+  if (o.reviewedBy.length > 128) return { ok: false, error: 'reviewedBy too long (max 128)' };
+
+  if (!OUTCOMES.includes(o.outcome as Outcome)) {
+    return {
+      ok: false,
+      error:
+        'outcome must be one of: ' +
+        OUTCOMES.join(', ') +
+        ' — MLRO must attest (FDL Art.20-21)',
+    };
+  }
+
+  if (typeof o.rationale !== 'string' || o.rationale.trim().length < MIN_RATIONALE_LEN) {
+    return {
+      ok: false,
+      error: `rationale is required and must be at least ${MIN_RATIONALE_LEN} characters — document the full basis for your decision (auditor requirement)`,
+    };
+  }
+  if (o.rationale.length > 4000) return { ok: false, error: 'rationale too long (max 4000)' };
+
+  if (o.runId !== undefined && (typeof o.runId !== 'string' || o.runId.length > 64)) {
+    return { ok: false, error: 'runId must be a string up to 64 chars' };
+  }
+  if (o.riskTier !== undefined && !RISK_TIERS.includes(o.riskTier as RiskTier)) {
+    return { ok: false, error: 'riskTier must be "high" | "medium" | "low"' };
+  }
+  if (
+    o.jurisdiction !== undefined &&
+    (typeof o.jurisdiction !== 'string' || o.jurisdiction.length > 32)
+  ) {
+    return { ok: false, error: 'jurisdiction must be a string up to 32 chars' };
+  }
+
+  return {
+    ok: true,
+    input: {
+      subjectName: o.subjectName.trim(),
+      subjectId: typeof o.subjectId === 'string' ? o.subjectId.trim() : '',
+      entityType: o.entityType as EntityType,
+      dob,
+      country: typeof o.country === 'string' ? o.country.trim() : undefined,
+      idNumber: typeof o.idNumber === 'string' ? o.idNumber.trim() : undefined,
+      eventType: o.eventType as EventType,
+      listsScreened: (o.listsScreened as string[]).map((l) => l.trim()),
+      overallTopScore: o.overallTopScore,
+      overallTopClassification: o.overallTopClassification as Classification,
+      anomalies,
+      screeningDate,
+      reviewedBy: o.reviewedBy.trim(),
+      outcome: o.outcome as Outcome,
+      rationale: o.rationale.trim(),
+      runId: typeof o.runId === 'string' ? o.runId.trim() : undefined,
+      riskTier: o.riskTier as RiskTier | undefined,
+      jurisdiction: typeof o.jurisdiction === 'string' ? o.jurisdiction.trim() : undefined,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Persistence — one blob per event (eventId is the key). Append-only.
+// ---------------------------------------------------------------------------
+
+function newEventId(): string {
+  return (
+    'SE-' +
+    Date.now().toString(36).toUpperCase() +
+    '-' +
+    Math.random().toString(36).slice(2, 10).toUpperCase()
+  );
+}
+
+async function saveEvent(
+  event: ScreeningEvent
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const store = getStore(EVENTS_STORE);
+    for (let attempt = 0; attempt < MAX_CAS_ATTEMPTS; attempt++) {
+      try {
+        const res: unknown = await (
+          store as unknown as {
+            setJSON: (key: string, value: unknown, opts?: unknown) => Promise<unknown>;
+          }
+        ).setJSON(event.eventId, event, { onlyIfNew: true });
+        const landed =
+          res == null
+            ? true
+            : typeof res === 'object' && 'modified' in (res as Record<string, unknown>)
+              ? (res as { modified: boolean }).modified === true
+              : res !== false;
+        if (landed) return { ok: true };
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : 'setJSON failed' };
+      }
+      // If onlyIfNew blocked, bump the id and retry
+      event.eventId = newEventId();
+    }
+    return { ok: false, error: 'could not allocate unique eventId after retries' };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : 'blob store unavailable' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Asana — every saved event creates a task (audit attestation)
+// ---------------------------------------------------------------------------
+
+function outcomeTag(outcome: Outcome): string {
+  switch (outcome) {
+    case 'confirmed_match':
+      return '[CONFIRMED MATCH — FREEZE-24H]';
+    case 'partial_match':
+      return '[PARTIAL MATCH — ESCALATED]';
+    case 'false_positive':
+      return '[FALSE POSITIVE — DISMISSED]';
+    case 'negative_no_match':
+      return '[NEGATIVE — NO MATCH]';
+  }
+}
+
+async function postDispositionAsana(
+  event: ScreeningEvent
+): Promise<{ ok: boolean; gid?: string; error?: string }> {
+  const projectId = process.env.ASANA_SCREENINGS_PROJECT_GID || '1213759768596515';
+  if (!process.env.ASANA_TOKEN && !process.env.ASANA_ACCESS_TOKEN && !process.env.ASANA_API_TOKEN) {
+    return { ok: false, error: 'ASANA_TOKEN not configured' };
+  }
+
+  const lines: string[] = [];
+  lines.push(`Event ID: ${event.eventId}`);
+  lines.push(`Saved at: ${event.savedAt}`);
+  lines.push('');
+  lines.push('— Subject —');
+  lines.push(`Name: ${event.subjectName}`);
+  lines.push(`Subject ID: ${event.subjectId || '(auto)'}`);
+  lines.push(`Entity type: ${event.entityType}`);
+  if (event.dob) lines.push(`DoB / registration: ${event.dob}`);
+  if (event.country) lines.push(`Country: ${event.country}`);
+  if (event.idNumber) lines.push(`ID / register no.: ${event.idNumber}`);
+  if (event.jurisdiction) lines.push(`Jurisdiction: ${event.jurisdiction}`);
+  if (event.riskTier) lines.push(`Risk tier: ${event.riskTier}`);
+  lines.push('');
+  lines.push('— Screening —');
+  lines.push(`Event type: ${event.eventType}`);
+  lines.push(`Lists screened: ${event.listsScreened.join(', ')}`);
+  lines.push(
+    `Top score: ${(event.overallTopScore * 100).toFixed(1)}% (${event.overallTopClassification})`
+  );
+  if (event.anomalies && event.anomalies.length > 0) {
+    lines.push('Anomalies during screening:');
+    for (const a of event.anomalies) lines.push(`  - ${a.list}: ${a.error}`);
+  }
+  lines.push('');
+  lines.push('— MLRO Disposition (attestation) —');
+  lines.push(`Screening date: ${event.screeningDate}`);
+  lines.push(`Reviewed by: ${event.reviewedBy}`);
+  lines.push(`Outcome: ${event.outcome.toUpperCase()}`);
+  lines.push('Rationale:');
+  lines.push(event.rationale);
+  if (event.runId) {
+    lines.push('');
+    lines.push(`Linked run: ${event.runId}`);
+  }
+  lines.push('');
+  lines.push(
+    'Regulatory basis: FDL No.10/2025 Art.20-21 (CO duties), Art.24 (10yr retention), Art.26-27 (STR), Art.29 (no tipping off); Cabinet Res 134/2025 Art.14, Art.19; Cabinet Res 74/2020 Art.4-7; Cabinet Decision No.(74)/2020 (mandatory list screening).'
+  );
+  lines.push('');
+  lines.push('Source: /api/screening/save (Screening Command page).');
+  lines.push('Do NOT notify the subject — FDL Art.29 no tipping off.');
+
+  const tag = outcomeTag(event.outcome);
+  const name = `${tag} ${event.subjectName} — ${event.eventType}`;
+
+  const tags = ['screening-disposition', event.outcome, `event-${event.eventType}`];
+  if (event.overallTopClassification !== 'none') tags.push(event.overallTopClassification);
+  if (event.anomalies && event.anomalies.length > 0) tags.push('anomaly');
+
+  return createAsanaTask({
+    name,
+    notes: lines.join('\n'),
+    projects: [projectId],
+    tags,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export default async (req: Request, context: Context): Promise<Response> => {
+  if (req.method === 'OPTIONS') return new Response(null, { status: 204, headers: CORS_HEADERS });
+  if (req.method !== 'POST') {
+    return jsonResponse({ ok: false, error: 'method not allowed' }, { status: 405 });
+  }
+
+  const rl = await checkRateLimit(req, {
+    max: 30,
+    clientIp: context.ip,
+    namespace: 'screening-save',
+  });
+  if (rl) return rl;
+
+  const auth = authenticate(req);
+  if (!auth.ok) return auth.response!;
+
+  const contentLength = req.headers.get('content-length');
+  if (contentLength) {
+    const n = Number(contentLength);
+    if (Number.isFinite(n) && n > MAX_BODY_SIZE) {
+      return jsonResponse({ ok: false, error: 'request body too large' }, { status: 413 });
+    }
+  }
+  let parsed: unknown;
+  try {
+    const raw = await req.text();
+    if (raw.length > MAX_BODY_SIZE) {
+      return jsonResponse({ ok: false, error: 'request body too large' }, { status: 413 });
+    }
+    parsed = JSON.parse(raw);
+  } catch {
+    return jsonResponse({ ok: false, error: 'invalid JSON body' }, { status: 400 });
+  }
+
+  const v = validateInput(parsed);
+  if (!v.ok) return jsonResponse({ ok: false, error: v.error }, { status: 400 });
+
+  const event: ScreeningEvent = {
+    eventId: newEventId(),
+    savedAt: new Date().toISOString(),
+    ...v.input,
+  };
+
+  const persist = await saveEvent(event);
+  if (!persist.ok) {
+    return jsonResponse(
+      { ok: false, error: 'persist failed: ' + (persist.error || 'unknown') },
+      { status: 500 }
+    );
+  }
+
+  const asana = await postDispositionAsana(event);
+  if (asana.ok && asana.gid) event.asanaGid = asana.gid;
+
+  return jsonResponse({
+    ok: true,
+    eventId: event.eventId,
+    savedAt: event.savedAt,
+    asana,
+  });
+};
+
+export const __test__ = {
+  validateInput,
+  outcomeTag,
+};
+
+export const config: Config = {
+  path: '/api/screening/save',
+  method: ['POST', 'OPTIONS'],
+};

--- a/netlify/functions/transaction-monitor.mts
+++ b/netlify/functions/transaction-monitor.mts
@@ -309,12 +309,15 @@ export default async (req: Request, context: Context): Promise<Response> => {
     critical: allAlerts.filter((a) => a.severity === 'critical').length,
   };
 
-  // Asana tasks for critical alerts only — mediums and highs flow via
-  // the normal compliance dashboard and do not raise a paging task.
+  // Asana tasks for every high+ anomaly — user directive: "if any
+  // anomaly or event I need to notification to Asana". Highs page
+  // the MLRO; criticals page the CO; mediums flow via dashboard.
   const asanaResults: Array<{ alertId: string; ok: boolean; gid?: string; error?: string }> = [];
   if (input.createAsanaOnCritical) {
-    const critical = allAlerts.filter((a) => a.severity === 'critical');
-    for (const alert of critical) {
+    const pageable = allAlerts.filter(
+      (a) => a.severity === 'critical' || a.severity === 'high'
+    );
+    for (const alert of pageable) {
       const res = await postCriticalAlertAsana(input.customerName, alert);
       asanaResults.push({ alertId: alert.alertId, ...res });
     }

--- a/screening-command.html
+++ b/screening-command.html
@@ -473,6 +473,178 @@
         margin-top: 6px;
         line-height: 1.5;
       }
+      /* List selector panels (mandatory vs enhanced) */
+      .list-tier {
+        border-left: 3px solid var(--gold);
+      }
+      .list-tier.enhanced {
+        border-left-color: var(--blue);
+      }
+      .list-tier h2 .tier-badge {
+        font-size: 9px;
+        padding: 2px 5px;
+        border-radius: 2px;
+        letter-spacing: 1px;
+        background: rgba(201, 168, 76, 0.2);
+        color: var(--gold);
+      }
+      .list-tier.enhanced h2 .tier-badge {
+        background: rgba(74, 144, 226, 0.2);
+        color: var(--blue);
+      }
+      .list-check {
+        display: flex;
+        align-items: flex-start;
+        gap: 10px;
+        padding: 8px 0;
+        border-top: 1px solid var(--border);
+        cursor: pointer;
+      }
+      .list-check:first-of-type {
+        border-top: none;
+      }
+      .list-check input[type='checkbox'] {
+        margin-top: 2px;
+        accent-color: var(--gold);
+        width: 16px;
+        height: 16px;
+        flex-shrink: 0;
+      }
+      .list-tier.enhanced .list-check input[type='checkbox'] {
+        accent-color: var(--blue);
+      }
+      .list-check.locked {
+        cursor: not-allowed;
+        opacity: 0.95;
+      }
+      .list-check.disabled {
+        opacity: 0.55;
+        cursor: not-allowed;
+      }
+      .list-check .list-label {
+        font-size: 13px;
+        line-height: 1.4;
+      }
+      .list-check .list-sub {
+        display: block;
+        font-size: 10px;
+        color: var(--muted);
+        margin-top: 2px;
+      }
+      .list-footnote {
+        color: var(--muted);
+        font-size: 10px;
+        margin-top: 10px;
+        line-height: 1.5;
+        padding-top: 8px;
+        border-top: 1px dashed var(--border);
+      }
+      /* Disposition section (hidden until a screening result is rendered) */
+      .disposition {
+        margin-top: 16px;
+        padding-top: 16px;
+        border-top: 1px dashed var(--border-strong);
+        display: none;
+      }
+      .disposition.active {
+        display: block;
+      }
+      .disposition h3 {
+        color: var(--gold);
+        font-size: 13px;
+        font-weight: 500;
+        margin-bottom: 10px;
+        text-transform: uppercase;
+        letter-spacing: 1px;
+      }
+      .outcome-grid {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 8px;
+        margin-top: 6px;
+      }
+      @media (min-width: 600px) {
+        .outcome-grid {
+          grid-template-columns: repeat(4, 1fr);
+        }
+      }
+      .outcome-btn {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        color: var(--text);
+        font-size: 11px;
+        font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        padding: 10px 8px;
+        border-radius: 3px;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 6px;
+        text-align: center;
+        line-height: 1.2;
+      }
+      .outcome-btn .dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        flex-shrink: 0;
+      }
+      .outcome-btn[data-outcome='negative_no_match'] .dot {
+        background: var(--green);
+      }
+      .outcome-btn[data-outcome='false_positive'] .dot {
+        background: var(--muted);
+      }
+      .outcome-btn[data-outcome='partial_match'] .dot {
+        background: var(--amber);
+      }
+      .outcome-btn[data-outcome='confirmed_match'] .dot {
+        background: var(--red);
+      }
+      .outcome-btn.selected[data-outcome='negative_no_match'] {
+        border-color: var(--green);
+        background: rgba(61, 168, 118, 0.15);
+      }
+      .outcome-btn.selected[data-outcome='false_positive'] {
+        border-color: var(--muted);
+        background: rgba(245, 240, 232, 0.06);
+      }
+      .outcome-btn.selected[data-outcome='partial_match'] {
+        border-color: var(--amber);
+        background: rgba(232, 160, 48, 0.15);
+      }
+      .outcome-btn.selected[data-outcome='confirmed_match'] {
+        border-color: var(--red);
+        background: rgba(217, 79, 79, 0.15);
+      }
+      .action-row {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 8px;
+        margin-top: 12px;
+      }
+      @media (min-width: 560px) {
+        .action-row {
+          grid-template-columns: 2fr 2fr 1fr;
+        }
+      }
+      button.btn-save {
+        background: var(--gold);
+        color: var(--bg);
+      }
+      button.btn-rerun {
+        background: rgba(74, 144, 226, 0.15);
+        color: var(--blue);
+        border: 1px solid var(--blue);
+      }
+      button.btn-cancel {
+        background: transparent;
+        color: var(--muted);
+        border: 1px solid var(--border);
+      }
     </style>
   </head>
   <body>
@@ -506,29 +678,159 @@
       >
     </div>
 
+    <!-- List selector ────────────────────────────────────────────── -->
+    <div class="grid grid-2" style="margin-top: 14px">
+      <div class="card list-tier mandatory">
+        <h2>Mandatory UAE Lists <span class="tier-badge">Required</span></h2>
+        <label class="list-check locked">
+          <input
+            type="checkbox"
+            data-list="UAE_EOCN"
+            data-tier="mandatory"
+            checked
+            disabled
+            aria-label="UAE Local Terrorist List (EOCN) — mandatory"
+          />
+          <span class="list-label"
+            >UAE Local Terrorist List — EOCN / Executive Office
+            <span class="list-sub">Executive Office for Control &amp; Non-Proliferation</span>
+          </span>
+        </label>
+        <label class="list-check locked">
+          <input
+            type="checkbox"
+            data-list="UN"
+            data-tier="mandatory"
+            checked
+            disabled
+            aria-label="UNSC Consolidated Sanctions List — mandatory"
+          />
+          <span class="list-label"
+            >UNSC Consolidated Sanctions List — UN Security Council
+            <span class="list-sub">Security Council resolutions + 1267/1988/1989/2253 sanctions</span>
+          </span>
+        </label>
+        <p class="list-footnote">
+          <strong>Cabinet Decision No.(74)/2020.</strong> These two lists are legally mandatory for
+          all UAE reporting entities (DPMS, DNFBP, FI). Failure to screen against either list
+          constitutes a regulatory offence under FDL No.10/2025 Art.35 and is subject to
+          administrative penalty under Cabinet Res 71/2024 (AED 10K–100M range).
+        </p>
+      </div>
+      <div class="card list-tier enhanced">
+        <h2>Enhanced Controls <span class="tier-badge">Not Legally Mandatory</span></h2>
+        <label class="list-check">
+          <input type="checkbox" data-list="OFAC" data-tier="enhanced" checked />
+          <span class="list-label"
+            >OFAC SDN — US unilateral sanctions
+            <span class="list-sub">US Treasury OFAC Specially Designated Nationals + Consolidated</span>
+          </span>
+        </label>
+        <label class="list-check">
+          <input type="checkbox" data-list="EU" data-tier="enhanced" checked />
+          <span class="list-label"
+            >EU Consolidated Sanctions
+            <span class="list-sub">European Union consolidated financial sanctions list (CFSP)</span>
+          </span>
+        </label>
+        <label class="list-check">
+          <input type="checkbox" data-list="UK_OFSI" data-tier="enhanced" checked />
+          <span class="list-label"
+            >UK OFSI Consolidated
+            <span class="list-sub">Office of Financial Sanctions Implementation (HMT)</span>
+          </span>
+        </label>
+        <label class="list-check disabled">
+          <input type="checkbox" data-list="INTERPOL" data-tier="enhanced" disabled />
+          <span class="list-label"
+            >Interpol Red Notices
+            <span class="list-sub">Integration pending — manual check at interpol.int/wanted</span>
+          </span>
+        </label>
+        <p class="list-footnote">
+          <strong>EOCN Guidance.</strong> For non-UAE unilateral / multilateral lists, consult your
+          supervisory authority for appropriate course of action. Opting out is permitted; every
+          opt-out is logged with the screening event (FDL Art.24 — 10-year retention).
+        </p>
+      </div>
+    </div>
+
     <div class="grid grid-2" style="margin-top: 14px">
       <!-- Screen subject ────────────────────────────────────────────── -->
       <div class="card">
         <h2>Screen a Subject <span class="tag">Sanctions + PEP + Adverse Media</span></h2>
         <p class="help-text">
           Runs multi-modal fuzzy matching (Jaro-Winkler + Levenshtein + Soundex + Double Metaphone +
-          token-set) against every candidate across six lists, searches adverse media, and computes
-          an explainable risk score. Regulatory basis: FDL Art.12-14, 20-21, 26-27, 29; Cabinet Res
+          token-set) against every selected list, searches adverse media, and computes an
+          explainable risk score. Regulatory basis: FDL Art.12-14, 20-21, 24, 26-27, 29; Cabinet Res
           134/2025 Art.7-10, 14, 19; Cabinet Res 74/2020 Art.4-7.
         </p>
-        <label for="subjectName">Full name or entity *</label>
+
+        <label for="subjectName">Name screened *</label>
         <input
           type="text"
           id="subjectName"
-          placeholder="e.g. Mohammed Al Rashid"
+          placeholder="Full legal name of individual or entity"
           autocomplete="off"
         />
 
         <div class="row-2">
           <div>
-            <label for="subjectId">Subject ID (optional)</label>
+            <label for="entityType">Entity type *</label>
+            <select id="entityType">
+              <option value="individual" selected>Individual</option>
+              <option value="legal_entity">Legal entity</option>
+            </select>
+          </div>
+          <div>
+            <label for="dob">Date of birth / registration</label>
+            <input type="text" id="dob" placeholder="dd/mm/yyyy" autocomplete="off" maxlength="10" />
+          </div>
+        </div>
+
+        <div class="row-2">
+          <div>
+            <label for="eventType">Screening event type *</label>
+            <select id="eventType">
+              <option value="new_customer_onboarding" selected>New customer onboarding</option>
+              <option value="periodic_review">Periodic review</option>
+              <option value="transaction_trigger">Transaction trigger</option>
+              <option value="name_change">Name change</option>
+              <option value="adverse_media_hit">Adverse media hit</option>
+              <option value="pep_change">PEP status change</option>
+              <option value="ad_hoc">Ad hoc</option>
+            </select>
+          </div>
+          <div>
+            <label for="country">Country</label>
+            <input
+              type="text"
+              id="country"
+              placeholder="e.g. UAE, Iran, Russia"
+              autocomplete="off"
+              maxlength="64"
+            />
+          </div>
+        </div>
+
+        <div class="row-2">
+          <div>
+            <label for="idNumber">ID / register no.</label>
+            <input
+              type="text"
+              id="idNumber"
+              placeholder="Passport, EID, Trade Licence"
+              autocomplete="off"
+              maxlength="64"
+            />
+          </div>
+          <div>
+            <label for="subjectId">Subject ID (system)</label>
             <input type="text" id="subjectId" placeholder="auto if blank" autocomplete="off" />
           </div>
+        </div>
+
+        <div class="row-2">
           <div>
             <label for="riskTier">Risk tier</label>
             <select id="riskTier">
@@ -537,9 +839,6 @@
               <option value="low">Low risk</option>
             </select>
           </div>
-        </div>
-
-        <div class="row-2">
           <div>
             <label for="jurisdiction">Jurisdiction (ISO-2)</label>
             <input
@@ -550,6 +849,9 @@
               maxlength="4"
             />
           </div>
+        </div>
+
+        <div class="row-2">
           <div>
             <label for="enrollInWatchlist">Enroll in daily monitoring</label>
             <select id="enrollInWatchlist">
@@ -557,14 +859,82 @@
               <option value="false">No</option>
             </select>
           </div>
+          <div>
+            <label for="notes">Notes</label>
+            <input type="text" id="notes" placeholder="Context for the MLRO" autocomplete="off" />
+          </div>
         </div>
-
-        <label for="notes">Notes (optional)</label>
-        <textarea id="notes" placeholder="Context for the MLRO"></textarea>
 
         <button id="screenBtn" type="button">Run Screening</button>
         <div id="screenMsg"></div>
         <div id="screenResult" style="margin-top: 14px"></div>
+
+        <!-- Disposition / MLRO attestation ─────────────────────────── -->
+        <div id="disposition" class="disposition">
+          <h3>MLRO Disposition &mdash; Attestation Required</h3>
+          <p class="help-text">
+            Every screening event must be closed out with a documented disposition. This record is
+            written to the screening-events blob store (10-year retention per FDL Art.24) and an
+            Asana task is created regardless of outcome so MoE audit can confirm the reviewer
+            actually looked.
+          </p>
+
+          <div class="row-2">
+            <div>
+              <label for="screeningDate">Screening date *</label>
+              <input
+                type="text"
+                id="screeningDate"
+                placeholder="dd/mm/yyyy"
+                autocomplete="off"
+                maxlength="10"
+              />
+            </div>
+            <div>
+              <label for="reviewedBy">Reviewed by *</label>
+              <input
+                type="text"
+                id="reviewedBy"
+                placeholder="Compliance Officer / MLRO name"
+                autocomplete="off"
+                maxlength="128"
+              />
+            </div>
+          </div>
+
+          <label>Screening outcome *</label>
+          <div class="outcome-grid" role="radiogroup" aria-label="Screening outcome">
+            <button type="button" class="outcome-btn" data-outcome="negative_no_match">
+              <span class="dot"></span>Negative &mdash; No match
+            </button>
+            <button type="button" class="outcome-btn" data-outcome="false_positive">
+              <span class="dot"></span>False positive
+            </button>
+            <button type="button" class="outcome-btn" data-outcome="partial_match">
+              <span class="dot"></span>Partial match
+            </button>
+            <button type="button" class="outcome-btn" data-outcome="confirmed_match">
+              <span class="dot"></span>Confirmed match
+            </button>
+          </div>
+
+          <label for="rationale" style="margin-top: 12px">Disposition rationale / notes *</label>
+          <textarea
+            id="rationale"
+            placeholder="Document the full basis for your screening decision. For false positives: state exactly how you differentiated. For confirmed/partial matches: describe the match and actions taken."
+            minlength="20"
+          ></textarea>
+          <span class="help-text"
+            >Minimum 20 characters. This text is the audit record seen by MoE / LBMA inspectors.</span
+          >
+
+          <div class="action-row">
+            <button id="saveBtn" class="btn-save" type="button">Save Screening Event</button>
+            <button id="rerunBtn" class="btn-rerun" type="button">Run Screening</button>
+            <button id="cancelBtn" class="btn-cancel" type="button">Cancel</button>
+          </div>
+          <div id="saveMsg" style="margin-top: 8px"></div>
+        </div>
       </div>
 
       <!-- Transaction monitor ────────────────────────────────────────────── -->

--- a/screening-command.html
+++ b/screening-command.html
@@ -6,6 +6,12 @@
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <title>Screening Command — Hawkeye Sterling</title>
     <link rel="icon" type="image/svg+xml" href="assets/logos/hawkeye-icon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;600;700&family=Montserrat:wght@200;300;400;500;600&family=DM+Mono:wght@400;500&display=swap"
+    />
     <style>
       :root {
         --gold: #c9a84c;
@@ -34,7 +40,8 @@
       body {
         background: var(--bg);
         color: var(--text);
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        font-weight: 300;
         max-width: 1100px;
         margin: 0 auto;
         padding: 20px 16px 60px;
@@ -54,9 +61,11 @@
       }
       h1 {
         color: var(--gold);
-        font-size: 24px;
+        font-family: 'Cinzel', serif;
+        font-size: 26px;
         font-weight: 600;
-        letter-spacing: 0.5px;
+        letter-spacing: 2px;
+        text-transform: uppercase;
       }
       h1 .badge {
         display: inline-block;
@@ -72,8 +81,11 @@
       }
       h2 {
         color: var(--gold);
-        font-size: 16px;
+        font-family: 'Cinzel', serif;
+        font-size: 15px;
         font-weight: 500;
+        letter-spacing: 1.5px;
+        text-transform: uppercase;
         margin-bottom: 6px;
         display: flex;
         align-items: center;

--- a/screening-command.js
+++ b/screening-command.js
@@ -18,11 +18,13 @@
   'use strict';
 
   const SCREENING_ENDPOINT = '/api/screening/run';
+  const SAVE_ENDPOINT = '/api/screening/save';
   const TM_ENDPOINT = '/api/transaction/monitor';
   const WATCHLIST_ENDPOINT = '/api/watchlist';
   const TOKEN_KEY = 'hawkeye.watchlist.adminToken';
   const TOKEN_MIN = 32;
   const TOKEN_HEX_RE = /^[a-f0-9]+$/i;
+  const RATIONALE_MIN = 20;
 
   const $ = (id) => document.getElementById(id);
 
@@ -162,6 +164,11 @@
   // ─── Screening flow ──────────────────────────────────────────────
   const subjectNameInput = $('subjectName');
   const subjectIdInput = $('subjectId');
+  const entityTypeSelect = $('entityType');
+  const dobInput = $('dob');
+  const countryInput = $('country');
+  const idNumberInput = $('idNumber');
+  const eventTypeSelect = $('eventType');
   const riskTierSelect = $('riskTier');
   const jurisdictionInput = $('jurisdiction');
   const enrollSelect = $('enrollInWatchlist');
@@ -169,6 +176,148 @@
   const screenBtn = $('screenBtn');
   const screenMsg = $('screenMsg');
   const screenResult = $('screenResult');
+
+  // Disposition fields
+  const dispositionBox = $('disposition');
+  const screeningDateInput = $('screeningDate');
+  const reviewedByInput = $('reviewedBy');
+  const rationaleInput = $('rationale');
+  const saveBtn = $('saveBtn');
+  const rerunBtn = $('rerunBtn');
+  const cancelBtn = $('cancelBtn');
+  const saveMsg = $('saveMsg');
+  const outcomeBtns = document.querySelectorAll('.outcome-btn');
+
+  // Last successful screening run — captured so we can attach the run
+  // provenance (lists screened, top score, anomalies) to the saved
+  // event. Cleared when the MLRO cancels or a new run starts.
+  let lastRun = null;
+  let currentOutcome = null;
+
+  // Collect enhanced-list opt-ins from the mandatory/enhanced selector.
+  // UAE_EOCN + UN are always screened server-side; we only POST the
+  // enhanced subset the MLRO has checked.
+  function collectSelectedLists() {
+    const out = [];
+    document.querySelectorAll('input[data-tier="enhanced"]').forEach((el) => {
+      if (el.disabled) return; // Interpol placeholder stays off until integrated
+      if (el.checked) out.push(el.getAttribute('data-list'));
+    });
+    return out;
+  }
+
+  function todayDdMmYyyy() {
+    const d = new Date();
+    const pad = (n) => String(n).padStart(2, '0');
+    return pad(d.getDate()) + '/' + pad(d.getMonth() + 1) + '/' + d.getFullYear();
+  }
+
+  function showDisposition() {
+    dispositionBox.classList.add('active');
+    if (!screeningDateInput.value) screeningDateInput.value = todayDdMmYyyy();
+    showMessage(saveMsg, '', 'info');
+  }
+
+  function hideDisposition() {
+    dispositionBox.classList.remove('active');
+    currentOutcome = null;
+    outcomeBtns.forEach((b) => b.classList.remove('selected'));
+    rationaleInput.value = '';
+    showMessage(saveMsg, '', 'info');
+  }
+
+  outcomeBtns.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      outcomeBtns.forEach((b) => b.classList.remove('selected'));
+      btn.classList.add('selected');
+      currentOutcome = btn.getAttribute('data-outcome');
+    });
+  });
+
+  cancelBtn.addEventListener('click', hideDisposition);
+  rerunBtn.addEventListener('click', () => {
+    hideDisposition();
+    runScreening();
+  });
+
+  async function saveScreeningEvent() {
+    if (!lastRun) {
+      showMessage(saveMsg, 'No screening run to save. Press Run Screening first.', 'error');
+      return;
+    }
+    if (!currentOutcome) {
+      showMessage(saveMsg, 'Pick an outcome — MLRO attestation is mandatory.', 'error');
+      return;
+    }
+    const reviewedBy = reviewedByInput.value.trim();
+    if (!reviewedBy) {
+      showMessage(saveMsg, 'Reviewed-by name is required (FDL Art.20-21).', 'error');
+      return;
+    }
+    const screeningDate = screeningDateInput.value.trim();
+    if (!/^\d{2}\/\d{2}\/\d{4}$/.test(screeningDate)) {
+      showMessage(saveMsg, 'Screening date must be dd/mm/yyyy.', 'error');
+      return;
+    }
+    const rationale = rationaleInput.value.trim();
+    if (rationale.length < RATIONALE_MIN) {
+      showMessage(
+        saveMsg,
+        'Rationale must be at least ' + RATIONALE_MIN + ' characters (auditor requirement).',
+        'error'
+      );
+      return;
+    }
+
+    saveBtn.disabled = true;
+    saveBtn.innerHTML = '<span class="spinner"></span>Saving…';
+
+    const body = {
+      subjectName: lastRun.subject.name,
+      subjectId: lastRun.subject.id,
+      entityType: lastRun.subject.entityType,
+      dob: lastRun.subject.dob || undefined,
+      country: lastRun.subject.country || undefined,
+      idNumber: lastRun.subject.idNumber || undefined,
+      eventType: lastRun.subject.eventType,
+      listsScreened: (lastRun.sanctions && lastRun.sanctions.listsChecked) || [],
+      overallTopScore: (lastRun.sanctions && lastRun.sanctions.topScore) || 0,
+      overallTopClassification:
+        (lastRun.sanctions && lastRun.sanctions.topClassification) || 'none',
+      anomalies: Array.isArray(lastRun.anomalies) ? lastRun.anomalies : [],
+      screeningDate: screeningDate,
+      reviewedBy: reviewedBy,
+      outcome: currentOutcome,
+      rationale: rationale,
+      runId: lastRun.ranAt,
+      riskTier: lastRun.subject.riskTier,
+      jurisdiction: lastRun.subject.jurisdiction || undefined,
+    };
+
+    const res = await apiPost(SAVE_ENDPOINT, body);
+    saveBtn.disabled = false;
+    saveBtn.textContent = 'Save Screening Event';
+
+    if (!res.ok) {
+      showMessage(saveMsg, res.error, 'error');
+      return;
+    }
+
+    const data = res.data || {};
+    const asana = data.asana || {};
+    const asanaMsg = asana.ok
+      ? 'Asana task created (gid ' + asana.gid + ').'
+      : asana.error
+        ? 'Asana notification failed: ' + asana.error
+        : 'Asana notification skipped.';
+    showMessage(
+      saveMsg,
+      'Saved event ' + data.eventId + '. ' + asanaMsg + ' MoE audit record locked.',
+      'success'
+    );
+  }
+
+  saveBtn.addEventListener('click', saveScreeningEvent);
 
   function renderScreeningResult(data) {
     if (!data || !data.ok) {
@@ -365,14 +514,39 @@
     saveToken();
     const name = subjectNameInput.value.trim();
     if (!name) {
-      showMessage(screenMsg, 'Subject name is required.', 'error');
+      showMessage(screenMsg, 'Name screened is required.', 'error');
       return;
     }
+    const entityType = entityTypeSelect.value;
+    if (entityType !== 'individual' && entityType !== 'legal_entity') {
+      showMessage(screenMsg, 'Entity type is required.', 'error');
+      return;
+    }
+    const eventType = eventTypeSelect.value;
+    if (!eventType) {
+      showMessage(screenMsg, 'Screening event type is required.', 'error');
+      return;
+    }
+    const dobRaw = dobInput.value.trim();
+    if (dobRaw && !/^\d{2}\/\d{2}\/\d{4}$/.test(dobRaw)) {
+      showMessage(screenMsg, 'DoB / registration must be dd/mm/yyyy.', 'error');
+      return;
+    }
+
+    // Hide any stale disposition while a fresh screen runs
+    hideDisposition();
+
     screenBtn.disabled = true;
     screenBtn.innerHTML = '<span class="spinner"></span>Screening…';
+
+    const selectedLists = collectSelectedLists();
+    const listBanner =
+      selectedLists.length > 0
+        ? 'UAE EOCN + UN (mandatory) + ' + selectedLists.join(', ')
+        : 'UAE EOCN + UN (mandatory) only';
     showMessage(
       screenMsg,
-      'Running multi-list screen (UN, OFAC SDN, OFAC Cons, EU, UK OFSI, UAE/EOCN) + adverse media…',
+      'Running multi-list screen: ' + listBanner + ' + adverse media…',
       'info'
     );
     screenResult.innerHTML = '';
@@ -380,9 +554,15 @@
     const body = {
       subjectName: name,
       subjectId: subjectIdInput.value.trim() || undefined,
+      entityType: entityType,
+      dob: dobRaw || undefined,
+      country: countryInput.value.trim() || undefined,
+      idNumber: idNumberInput.value.trim() || undefined,
+      eventType: eventType,
       riskTier: riskTierSelect.value,
       jurisdiction: jurisdictionInput.value.trim() || undefined,
       notes: notesInput.value.trim() || undefined,
+      selectedLists: selectedLists,
       enrollInWatchlist: enrollSelect.value === 'true',
       runAdverseMedia: true,
       createAsanaTask: true,
@@ -390,9 +570,12 @@
     const result = await apiPost(SCREENING_ENDPOINT, body);
     if (!result.ok) {
       showMessage(screenMsg, result.error, 'error');
+      lastRun = null;
     } else {
+      lastRun = result.data;
       const topClass =
         (result.data && result.data.sanctions && result.data.sanctions.topClassification) || 'none';
+      const anomalies = (result.data && result.data.anomalies) || [];
       const verb =
         topClass === 'confirmed'
           ? 'CONFIRMED sanctions match — freeze workflow triggered'
@@ -401,12 +584,17 @@
             : topClass === 'weak'
               ? 'Weak match — documented and dismissed if false positive'
               : 'No sanctions match';
+      const anomSuffix =
+        anomalies.length > 0
+          ? ' · ' + anomalies.length + ' anomaly(ies) routed to Asana'
+          : '';
       showMessage(
         screenMsg,
-        verb + '. See details below.',
-        topClass === 'none' ? 'success' : 'error'
+        verb + anomSuffix + '. Complete the disposition below to close the event.',
+        topClass === 'none' && anomalies.length === 0 ? 'success' : 'error'
       );
       renderScreeningResult(result.data);
+      showDisposition();
       refreshWatchlist();
     }
 

--- a/tests/screeningRunEndpoint.test.ts
+++ b/tests/screeningRunEndpoint.test.ts
@@ -30,6 +30,12 @@ const { validateInput, screenAgainstAllLists } = __test__ as {
 // validateInput
 // ---------------------------------------------------------------------------
 
+const baseInput = () => ({
+  subjectName: 'John Doe',
+  entityType: 'individual' as const,
+  eventType: 'new_customer_onboarding' as const,
+});
+
 describe('screening-run — validateInput', () => {
   it('rejects non-object body', () => {
     expect(validateInput(null).ok).toBe(false);
@@ -38,42 +44,96 @@ describe('screening-run — validateInput', () => {
   });
 
   it('rejects missing subjectName', () => {
-    const r = validateInput({});
+    const { subjectName: _s, ...rest } = baseInput();
+    void _s;
+    const r = validateInput(rest);
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.error).toContain('subjectName');
   });
 
   it('rejects empty subjectName', () => {
-    const r = validateInput({ subjectName: '   ' });
+    const r = validateInput({ ...baseInput(), subjectName: '   ' });
     expect(r.ok).toBe(false);
   });
 
   it('rejects oversized subjectName', () => {
-    const r = validateInput({ subjectName: 'x'.repeat(250) });
+    const r = validateInput({ ...baseInput(), subjectName: 'x'.repeat(250) });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.error).toContain('too long');
   });
 
   it('rejects invalid riskTier', () => {
-    const r = validateInput({ subjectName: 'John Doe', riskTier: 'legendary' });
+    const r = validateInput({ ...baseInput(), riskTier: 'legendary' });
     expect(r.ok).toBe(false);
   });
 
+  it('rejects missing entityType', () => {
+    const { entityType: _e, ...rest } = baseInput();
+    void _e;
+    const r = validateInput(rest);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('entityType');
+  });
+
+  it('rejects invalid entityType', () => {
+    const r = validateInput({ ...baseInput(), entityType: 'robot' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects missing eventType', () => {
+    const { eventType: _ev, ...rest } = baseInput();
+    void _ev;
+    const r = validateInput(rest);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('eventType');
+  });
+
+  it('rejects invalid eventType', () => {
+    const r = validateInput({ ...baseInput(), eventType: 'because-i-felt-like-it' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects bad dob format', () => {
+    const r = validateInput({ ...baseInput(), dob: '1990/13/45' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('dob');
+  });
+
+  it('accepts yyyy-mm-dd dob and converts to dd/mm/yyyy', () => {
+    const r = validateInput({ ...baseInput(), dob: '1990-05-12' });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.input.dob).toBe('12/05/1990');
+  });
+
+  it('rejects invalid selectedLists entry', () => {
+    const r = validateInput({ ...baseInput(), selectedLists: ['OFAC', 'NOT_A_LIST'] });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('selectedLists');
+  });
+
+  it('dedupes selectedLists', () => {
+    const r = validateInput({ ...baseInput(), selectedLists: ['OFAC', 'OFAC', 'EU'] });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.input.selectedLists).toEqual(['OFAC', 'EU']);
+  });
+
   it('rejects oversized subjectId', () => {
-    const r = validateInput({ subjectName: 'John', subjectId: 'x'.repeat(200) });
+    const r = validateInput({ ...baseInput(), subjectId: 'x'.repeat(200) });
     expect(r.ok).toBe(false);
   });
 
   it('rejects oversized notes', () => {
-    const r = validateInput({ subjectName: 'John', notes: 'x'.repeat(3000) });
+    const r = validateInput({ ...baseInput(), notes: 'x'.repeat(3000) });
     expect(r.ok).toBe(false);
   });
 
   it('accepts minimal valid input with defaults', () => {
-    const r = validateInput({ subjectName: 'John Doe' });
+    const r = validateInput(baseInput());
     expect(r.ok).toBe(true);
     if (r.ok) {
       expect(r.input.subjectName).toBe('John Doe');
+      expect(r.input.entityType).toBe('individual');
+      expect(r.input.eventType).toBe('new_customer_onboarding');
       expect(r.input.enrollInWatchlist).toBe(true);
       expect(r.input.runAdverseMedia).toBe(true);
       expect(r.input.createAsanaTask).toBe(true);
@@ -82,7 +142,7 @@ describe('screening-run — validateInput', () => {
 
   it('allows explicit opt-outs', () => {
     const r = validateInput({
-      subjectName: 'John Doe',
+      ...baseInput(),
       enrollInWatchlist: false,
       runAdverseMedia: false,
       createAsanaTask: false,
@@ -97,10 +157,12 @@ describe('screening-run — validateInput', () => {
 
   it('trims string fields', () => {
     const r = validateInput({
+      ...baseInput(),
       subjectName: '  John Doe  ',
       subjectId: '  CUS-1  ',
       jurisdiction: '  AE  ',
       notes: '  ctx  ',
+      country: '  UAE  ',
     });
     expect(r.ok).toBe(true);
     if (r.ok) {
@@ -108,6 +170,7 @@ describe('screening-run — validateInput', () => {
       expect(r.input.subjectId).toBe('CUS-1');
       expect(r.input.jurisdiction).toBe('AE');
       expect(r.input.notes).toBe('ctx');
+      expect(r.input.country).toBe('UAE');
     }
   });
 });
@@ -134,7 +197,8 @@ describe('screening-run — screenAgainstAllLists', () => {
     });
     expect(r.overallTopScore).toBe(0);
     expect(r.overallTopClassification).toBe('none');
-    expect(r.perList).toHaveLength(5);
+    // 5 supplied + INTERPOL placeholder auto-appended (selectedLists undefined)
+    expect(r.perList).toHaveLength(6);
     for (const l of r.perList) expect(l.hitCount).toBe(0);
   });
 

--- a/tests/screeningSaveEndpoint.test.ts
+++ b/tests/screeningSaveEndpoint.test.ts
@@ -1,0 +1,376 @@
+/**
+ * Tests for netlify/functions/screening-save.mts — exercises the pure
+ * validation + outcomeTag logic via __test__. No Netlify runtime, no
+ * HTTP, no Blobs, no Asana.
+ *
+ * Regulatory: FDL No.10/2025 Art.20-21, 24, 26-27, 29; Cabinet Res
+ * 134/2025 Art.14, 19; Cabinet Res 74/2020 Art.4-7; Cabinet Decision
+ * No.(74)/2020.
+ */
+import { describe, it, expect } from 'vitest';
+
+// @ts-expect-error — .mts file has no type declarations at test time
+import { __test__ } from '../netlify/functions/screening-save.mts';
+
+const { validateInput, outcomeTag } = __test__ as {
+  validateInput: (
+    input: unknown
+  ) => { ok: true; input: Record<string, unknown> } | { ok: false; error: string };
+  outcomeTag: (outcome: string) => string;
+};
+
+// ---------------------------------------------------------------------------
+// validateInput
+// ---------------------------------------------------------------------------
+
+const baseInput = () => ({
+  subjectName: 'John Doe',
+  entityType: 'individual' as const,
+  eventType: 'new_customer_onboarding' as const,
+  listsScreened: ['UAE_EOCN', 'UN'],
+  overallTopScore: 0,
+  overallTopClassification: 'none' as const,
+  screeningDate: '18/04/2026',
+  reviewedBy: 'Jane MLRO',
+  outcome: 'negative_no_match' as const,
+  rationale: 'No hits across the two mandatory lists; onboarding cleared.',
+});
+
+describe('screening-save — validateInput', () => {
+  // ---- Shape + subject identity ----
+
+  it('rejects non-object body', () => {
+    expect(validateInput(null).ok).toBe(false);
+    expect(validateInput('string').ok).toBe(false);
+    expect(validateInput(undefined).ok).toBe(false);
+  });
+
+  it('rejects missing subjectName', () => {
+    const { subjectName: _s, ...rest } = baseInput();
+    void _s;
+    const r = validateInput(rest);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('subjectName');
+  });
+
+  it('rejects oversized subjectName', () => {
+    const r = validateInput({ ...baseInput(), subjectName: 'x'.repeat(250) });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('too long');
+  });
+
+  it('rejects oversized subjectId', () => {
+    const r = validateInput({ ...baseInput(), subjectId: 'x'.repeat(200) });
+    expect(r.ok).toBe(false);
+  });
+
+  // ---- Entity type ----
+
+  it('rejects missing entityType', () => {
+    const { entityType: _e, ...rest } = baseInput();
+    void _e;
+    const r = validateInput(rest);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('entityType');
+  });
+
+  it('rejects invalid entityType', () => {
+    const r = validateInput({ ...baseInput(), entityType: 'robot' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('accepts legal_entity', () => {
+    const r = validateInput({ ...baseInput(), entityType: 'legal_entity' });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.input.entityType).toBe('legal_entity');
+  });
+
+  // ---- DoB ----
+
+  it('rejects bad dob format', () => {
+    const r = validateInput({ ...baseInput(), dob: '1990/13/45' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('dob');
+  });
+
+  it('accepts yyyy-mm-dd dob and converts to dd/mm/yyyy', () => {
+    const r = validateInput({ ...baseInput(), dob: '1990-05-12' });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.input.dob).toBe('12/05/1990');
+  });
+
+  it('accepts dd/mm/yyyy dob unchanged', () => {
+    const r = validateInput({ ...baseInput(), dob: '12/05/1990' });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.input.dob).toBe('12/05/1990');
+  });
+
+  it('allows omitted dob', () => {
+    const r = validateInput(baseInput());
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.input.dob).toBeUndefined();
+  });
+
+  // ---- Event type ----
+
+  it('rejects missing eventType', () => {
+    const { eventType: _ev, ...rest } = baseInput();
+    void _ev;
+    const r = validateInput(rest);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('eventType');
+  });
+
+  it('rejects invalid eventType', () => {
+    const r = validateInput({ ...baseInput(), eventType: 'because-the-moon' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('accepts all 7 allowed event types', () => {
+    for (const ev of [
+      'new_customer_onboarding',
+      'periodic_review',
+      'transaction_trigger',
+      'name_change',
+      'adverse_media_hit',
+      'pep_change',
+      'ad_hoc',
+    ]) {
+      const r = validateInput({ ...baseInput(), eventType: ev });
+      expect(r.ok, `eventType ${ev} should be accepted`).toBe(true);
+    }
+  });
+
+  // ---- listsScreened ----
+
+  it('rejects empty listsScreened', () => {
+    const r = validateInput({ ...baseInput(), listsScreened: [] });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('listsScreened');
+  });
+
+  it('rejects non-array listsScreened', () => {
+    const r = validateInput({ ...baseInput(), listsScreened: 'UAE_EOCN' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects non-string listsScreened entries', () => {
+    const r = validateInput({ ...baseInput(), listsScreened: ['UN', 42] });
+    expect(r.ok).toBe(false);
+  });
+
+  // ---- Scores + classification ----
+
+  it('rejects non-numeric overallTopScore', () => {
+    const r = validateInput({ ...baseInput(), overallTopScore: 'high' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects overallTopScore out of [0,1]', () => {
+    expect(validateInput({ ...baseInput(), overallTopScore: -0.1 }).ok).toBe(false);
+    expect(validateInput({ ...baseInput(), overallTopScore: 1.5 }).ok).toBe(false);
+  });
+
+  it('rejects invalid classification', () => {
+    const r = validateInput({ ...baseInput(), overallTopClassification: 'sus' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('overallTopClassification');
+  });
+
+  it('accepts all 4 classifications', () => {
+    for (const c of ['confirmed', 'potential', 'weak', 'none']) {
+      const r = validateInput({
+        ...baseInput(),
+        overallTopClassification: c,
+        overallTopScore: c === 'none' ? 0 : 0.5,
+      });
+      expect(r.ok, `classification ${c} should be accepted`).toBe(true);
+    }
+  });
+
+  // ---- Anomalies ----
+
+  it('accepts well-formed anomalies', () => {
+    const r = validateInput({
+      ...baseInput(),
+      anomalies: [{ list: 'OFAC', error: 'network timeout' }],
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.input.anomalies).toEqual([{ list: 'OFAC', error: 'network timeout' }]);
+    }
+  });
+
+  it('rejects non-array anomalies', () => {
+    const r = validateInput({ ...baseInput(), anomalies: 'boom' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects malformed anomaly entry', () => {
+    const r = validateInput({ ...baseInput(), anomalies: [{ list: 'OFAC' }] });
+    expect(r.ok).toBe(false);
+  });
+
+  // ---- Screening date ----
+
+  it('rejects missing screeningDate', () => {
+    const { screeningDate: _d, ...rest } = baseInput();
+    void _d;
+    const r = validateInput(rest);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('screeningDate');
+  });
+
+  it('rejects malformed screeningDate', () => {
+    const r = validateInput({ ...baseInput(), screeningDate: '2026.04.18' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('converts yyyy-mm-dd screeningDate to dd/mm/yyyy', () => {
+    const r = validateInput({ ...baseInput(), screeningDate: '2026-04-18' });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.input.screeningDate).toBe('18/04/2026');
+  });
+
+  // ---- Reviewer ----
+
+  it('rejects missing reviewedBy', () => {
+    const { reviewedBy: _r, ...rest } = baseInput();
+    void _r;
+    const r = validateInput(rest);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('reviewedBy');
+  });
+
+  it('rejects empty reviewedBy', () => {
+    const r = validateInput({ ...baseInput(), reviewedBy: '   ' });
+    expect(r.ok).toBe(false);
+  });
+
+  // ---- Outcome + rationale (the auditor attestation) ----
+
+  it('rejects missing outcome', () => {
+    const { outcome: _o, ...rest } = baseInput();
+    void _o;
+    const r = validateInput(rest);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('outcome');
+  });
+
+  it('rejects invalid outcome', () => {
+    const r = validateInput({ ...baseInput(), outcome: 'mostly_ok' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('accepts all 4 outcomes', () => {
+    for (const o of [
+      'negative_no_match',
+      'false_positive',
+      'partial_match',
+      'confirmed_match',
+    ]) {
+      const r = validateInput({ ...baseInput(), outcome: o });
+      expect(r.ok, `outcome ${o} should be accepted`).toBe(true);
+    }
+  });
+
+  it('rejects rationale shorter than 20 chars', () => {
+    const r = validateInput({ ...baseInput(), rationale: 'too short' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('20');
+  });
+
+  it('rejects missing rationale', () => {
+    const { rationale: _r, ...rest } = baseInput();
+    void _r;
+    const r = validateInput(rest);
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects oversized rationale', () => {
+    const r = validateInput({ ...baseInput(), rationale: 'x'.repeat(5000) });
+    expect(r.ok).toBe(false);
+  });
+
+  // ---- Optional fields ----
+
+  it('accepts optional riskTier + jurisdiction + runId', () => {
+    const r = validateInput({
+      ...baseInput(),
+      riskTier: 'high',
+      jurisdiction: 'AE',
+      runId: 'RUN-123',
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.input.riskTier).toBe('high');
+      expect(r.input.jurisdiction).toBe('AE');
+      expect(r.input.runId).toBe('RUN-123');
+    }
+  });
+
+  it('rejects invalid riskTier', () => {
+    const r = validateInput({ ...baseInput(), riskTier: 'legendary' });
+    expect(r.ok).toBe(false);
+  });
+
+  // ---- Trimming ----
+
+  it('trims string fields', () => {
+    const r = validateInput({
+      ...baseInput(),
+      subjectName: '  John Doe  ',
+      subjectId: '  CUS-1  ',
+      country: '  UAE  ',
+      idNumber: '  EID-9  ',
+      reviewedBy: '  Jane MLRO  ',
+      rationale: '  ' + 'x'.repeat(25) + '  ',
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.input.subjectName).toBe('John Doe');
+      expect(r.input.subjectId).toBe('CUS-1');
+      expect(r.input.country).toBe('UAE');
+      expect(r.input.idNumber).toBe('EID-9');
+      expect(r.input.reviewedBy).toBe('Jane MLRO');
+      expect((r.input.rationale as string).startsWith('x')).toBe(true);
+    }
+  });
+
+  // ---- Golden path ----
+
+  it('accepts a complete well-formed disposition', () => {
+    const r = validateInput(baseInput());
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.input.subjectName).toBe('John Doe');
+      expect(r.input.entityType).toBe('individual');
+      expect(r.input.eventType).toBe('new_customer_onboarding');
+      expect(r.input.outcome).toBe('negative_no_match');
+      expect(r.input.reviewedBy).toBe('Jane MLRO');
+      expect(r.input.listsScreened).toEqual(['UAE_EOCN', 'UN']);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// outcomeTag — prefixes used for the Asana task name
+// ---------------------------------------------------------------------------
+
+describe('screening-save — outcomeTag', () => {
+  it('prefixes confirmed_match with FREEZE-24H (Cabinet Res 74/2020 Art.4-7)', () => {
+    expect(outcomeTag('confirmed_match')).toBe('[CONFIRMED MATCH — FREEZE-24H]');
+  });
+
+  it('prefixes partial_match with ESCALATED', () => {
+    expect(outcomeTag('partial_match')).toBe('[PARTIAL MATCH — ESCALATED]');
+  });
+
+  it('prefixes false_positive with DISMISSED', () => {
+    expect(outcomeTag('false_positive')).toBe('[FALSE POSITIVE — DISMISSED]');
+  });
+
+  it('prefixes negative_no_match with NEGATIVE', () => {
+    expect(outcomeTag('negative_no_match')).toBe('[NEGATIVE — NO MATCH]');
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 of the Screening Command page. Adds MoE/LBMA-grade list gating + MLRO disposition attestation, and wires every screening anomaly or saved event to Asana.

- **Mandatory list gating** — UAE_EOCN + UN are always on, locked in UI, enforced server-side (Cabinet Decision No.(74)/2020).
- **Enhanced Controls panel** — opt-in OFAC / EU / UK_OFSI; INTERPOL placeholder disabled pending integration (EOCN guidance).
- **Expanded Screen-a-Subject form** — entityType, dob (dd/mm/yyyy with yyyy-mm-dd auto-convert), country, idNumber, 7-value eventType taxonomy per Cabinet Res 134/2025 Art.19.
- **MLRO disposition workflow** — `/api/screening/save` persists a full `ScreeningEvent` (CAS onlyIfNew, eventId bump on collision), requires named reviewer + ≥20-char rationale + 1-of-4 outcome. Every save creates an Asana task (including `negative_no_match`) so MoE/LBMA audit can confirm the reviewer actually looked.
- **Anomaly → Asana** — `/run` pages Asana when any mandatory-list fetch errors; `transaction-monitor` Asana trigger raised from `critical`-only to `critical || high`.

## Regulatory basis

- FDL No.10/2025 Art.12-14 (CDD), Art.20-21 (CO duties), Art.24 (10-yr record retention), Art.26-27 (STR filing), Art.29 (no tipping off), Art.35 (TFS)
- Cabinet Res 134/2025 Art.7-10 (CDD tiers), Art.14 (PEP/EDD), Art.19 (internal review / event taxonomy)
- Cabinet Res 74/2020 Art.4-7 (24h freeze — `confirmed_match` task prefixed `[FREEZE-24H]`)
- Cabinet Decision No.(74)/2020 (mandatory list screening — UAE_EOCN + UN)
- Cabinet Res 71/2024 (administrative penalties)
- FATF Rec 10 / 22 / 23
- MoE Circular 08/AML/2021

## Test plan

- [x] `npx vitest run tests/screeningRunEndpoint.test.ts tests/screeningSaveEndpoint.test.ts tests/transactionMonitorEndpoint.test.ts` — 90 pass
- [x] `npx tsc --noEmit` — clean
- [ ] QA: mandatory checkboxes are locked; enhanced checkboxes toggle; INTERPOL disabled
- [ ] QA: disposition form rejects rationale &lt;20 chars; reviewedBy required; outcome mutex
- [ ] QA: `confirmed_match` task in Asana carries `[FREEZE-24H]` prefix + Cabinet Res 74/2020 citation
- [ ] QA: mandatory-list fetch failure creates `[ANOMALY]` Asana task even on a negative screen

https://claude.ai/code/session_014AJc3FP33Xru5x6HSrjb9r