### PR TITLE
fix(timeouts+ui): shared fetchWithTimeout + Screening Command UI pass

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,6 +311,16 @@
         -webkit-appearance: none;
         -moz-appearance: textfield;
       }
+      input[type='number']::-webkit-inner-spin-button,
+      input[type='number']::-webkit-outer-spin-button {
+        -webkit-appearance: none;
+        appearance: none;
+        margin: 0;
+      }
+      input[type='number'] {
+        -moz-appearance: textfield;
+        appearance: textfield;
+      }
       .btn-sm {
         padding: 4px 12px;
         font-size: 9px;
@@ -4057,33 +4067,32 @@ Examples:
              LBMA RGG v9 (chain of custody for gold shipments). -->
         <div id="tab-tracking" class="tab-content">
           <div class="section-title">✈️ Global Shipment Tracking</div>
-          <div class="muted" style="margin-bottom:10px">
-            Track AWB shipments from origin to destination. Records
-            are stored locally and mirrored to the active tenant's
-            Asana project under a "Shipments" section (auto-created
-            on first sync).
+          <div class="muted" style="margin-bottom: 10px">
+            Track AWB shipments from origin to destination. Records are stored locally and mirrored
+            to the active tenant's Asana project under a "Shipments" section (auto-created on first
+            sync).
           </div>
 
-          <div class="form-grid" style="margin-bottom:14px">
+          <div class="form-grid" style="margin-bottom: 14px">
             <div>
               <label>AWB number</label>
-              <input type="text" id="trackingAwb" placeholder="176-12345678">
+              <input type="text" id="trackingAwb" placeholder="176-12345678" />
             </div>
             <div>
               <label>Departure country</label>
-              <input type="text" id="trackingDeparture" placeholder="AE">
+              <input type="text" id="trackingDeparture" placeholder="AE" />
             </div>
             <div>
               <label>Arrival country</label>
-              <input type="text" id="trackingArrival" placeholder="CH">
+              <input type="text" id="trackingArrival" placeholder="CH" />
             </div>
             <div>
               <label>Carrier</label>
-              <input type="text" id="trackingCarrier" placeholder="Emirates SkyCargo">
+              <input type="text" id="trackingCarrier" placeholder="Emirates SkyCargo" />
             </div>
             <div>
               <label>ETA (arrival date)</label>
-              <input type="date" id="trackingEta">
+              <input type="date" id="trackingEta" />
             </div>
             <div>
               <label>Status</label>
@@ -4096,9 +4105,15 @@ Examples:
             </div>
           </div>
 
-          <div class="row" style="margin-bottom:14px; gap:8px">
+          <div class="row" style="margin-bottom: 14px; gap: 8px">
             <button class="primary" data-action="addTrackingRecord">➕ Add shipment</button>
-            <button data-action="cancelEditTracking" id="btnCancelEditTracking" style="display:none">Cancel edit</button>
+            <button
+              data-action="cancelEditTracking"
+              id="btnCancelEditTracking"
+              style="display: none"
+            >
+              Cancel edit
+            </button>
           </div>
 
           <div id="tracking-list"></div>

--- a/netlify/functions/asana-comment-skill-handler.mts
+++ b/netlify/functions/asana-comment-skill-handler.mts
@@ -29,11 +29,20 @@
 
 import type { Config } from '@netlify/functions';
 import { getStore } from '@netlify/blobs';
+import { fetchWithTimeout } from '../../src/utils/fetchWithTimeout';
 
 const JOBS_STORE = 'asana-skill-jobs';
 const AUDIT_STORE = 'asana-skill-audit';
 const SANCTIONS_SNAPSHOT_STORE = 'sanctions-snapshots';
 const ASANA_API_BASE = 'https://app.asana.com/api/1.0';
+
+// Asana's p99 latency is sub-second; 10s is the same budget the
+// rest of the Asana callers in this codebase use (`asanaClient.ts`,
+// `asana-proxy.mts`). A hung Asana call here silently burns the
+// whole cron invocation and the MLRO's slash-command goes into
+// the dead-letter slot after 5 retries — a cheap upper bound
+// trades a clean failure for a silent one.
+const ASANA_FETCH_TIMEOUT_MS = 10_000;
 
 // Poison-pill defence: after this many failed attempts, the job is
 // moved to a dead-letter slot and stops being retried every minute.
@@ -332,11 +341,12 @@ interface AsanaGetResult<T> {
 }
 
 async function asanaGet<T>(path: string, token: string): Promise<AsanaGetResult<T>> {
-  const res = await fetch(`${ASANA_API_BASE}${path}`, {
+  const res = await fetchWithTimeout(`${ASANA_API_BASE}${path}`, {
     headers: {
       Authorization: `Bearer ${token}`,
       Accept: 'application/json',
     },
+    timeoutMs: ASANA_FETCH_TIMEOUT_MS,
   });
   if (!res.ok) {
     let snippet: string | undefined;
@@ -372,7 +382,7 @@ async function asanaPost<T>(
   token: string,
   body: unknown
 ): Promise<AsanaPostResult<T>> {
-  const res = await fetch(`${ASANA_API_BASE}${path}`, {
+  const res = await fetchWithTimeout(`${ASANA_API_BASE}${path}`, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,
@@ -380,6 +390,7 @@ async function asanaPost<T>(
       Accept: 'application/json',
     },
     body: JSON.stringify({ data: body }),
+    timeoutMs: ASANA_FETCH_TIMEOUT_MS,
   });
   if (!res.ok) {
     let snippet: string | undefined;

--- a/screening-command.html
+++ b/screening-command.html
@@ -17,12 +17,7 @@
         --gold: #c9a84c;
         --gold-bright: #e6c870;
         --gold-dim: rgba(201, 168, 76, 0.6);
-        --gold-grad: linear-gradient(
-          135deg,
-          #e6c870 0%,
-          #c9a84c 40%,
-          #a68432 100%
-        );
+        --gold-grad: linear-gradient(135deg, #e6c870 0%, #c9a84c 40%, #a68432 100%);
         --bg: #080706;
         --bg-elev: #0f0d0a;
         --surface: rgba(201, 168, 76, 0.03);
@@ -51,19 +46,15 @@
       }
       body {
         background:
-          radial-gradient(
-            circle at 20% -10%,
-            rgba(201, 168, 76, 0.07),
-            transparent 55%
-          ),
-          radial-gradient(
-            circle at 100% 100%,
-            rgba(201, 168, 76, 0.04),
-            transparent 45%
-          ),
-          var(--bg);
+          radial-gradient(circle at 20% -10%, rgba(201, 168, 76, 0.07), transparent 55%),
+          radial-gradient(circle at 100% 100%, rgba(201, 168, 76, 0.04), transparent 45%), var(--bg);
         color: var(--text);
-        font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        font-family:
+          'Montserrat',
+          -apple-system,
+          BlinkMacSystemFont,
+          'Segoe UI',
+          sans-serif;
         font-weight: 300;
         max-width: 1680px;
         margin: 0 auto;
@@ -75,21 +66,24 @@
         letter-spacing: 0.01em;
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
-        font-feature-settings: 'liga' 1, 'calt' 1, 'kern' 1, 'ss01' 1;
+        font-feature-settings:
+          'liga' 1,
+          'calt' 1,
+          'kern' 1,
+          'ss01' 1;
       }
       body::before {
         content: '';
         position: fixed;
         inset: 0;
         pointer-events: none;
-        background-image:
-          linear-gradient(
-            to bottom,
-            rgba(255, 255, 255, 0.01) 0px,
-            rgba(255, 255, 255, 0.01) 1px,
-            transparent 1px,
-            transparent 4px
-          );
+        background-image: linear-gradient(
+          to bottom,
+          rgba(255, 255, 255, 0.01) 0px,
+          rgba(255, 255, 255, 0.01) 1px,
+          transparent 1px,
+          transparent 4px
+        );
         opacity: 0.35;
         z-index: 0;
       }
@@ -138,7 +132,9 @@
         vertical-align: middle;
         font-weight: 700;
         letter-spacing: 1.5px;
-        box-shadow: 0 1px 0 rgba(255, 255, 255, 0.15) inset, 0 2px 6px rgba(201, 168, 76, 0.25);
+        box-shadow:
+          0 1px 0 rgba(255, 255, 255, 0.15) inset,
+          0 2px 6px rgba(201, 168, 76, 0.25);
       }
       h2 {
         color: var(--gold);
@@ -185,8 +181,7 @@
         border-left: 3px solid transparent;
         border-radius: 6px;
         background:
-          linear-gradient(180deg, rgba(255, 255, 255, 0.01), transparent 60%),
-          var(--bg-elev);
+          linear-gradient(180deg, rgba(255, 255, 255, 0.01), transparent 60%), var(--bg-elev);
         box-shadow: var(--shadow-md), var(--shadow-inset);
         position: relative;
       }
@@ -231,6 +226,12 @@
         letter-spacing: 0.3px;
         line-height: 1.5;
       }
+      .intro-block.intro-block--wide {
+        grid-column: 1 / -1;
+        padding-top: 10px;
+        margin-top: 2px;
+        border-top: 1px dashed var(--border);
+      }
       .grid {
         display: grid;
         grid-template-columns: 1fr;
@@ -243,8 +244,7 @@
       }
       .card {
         background:
-          linear-gradient(180deg, rgba(255, 255, 255, 0.015), transparent 60%),
-          var(--bg-elev);
+          linear-gradient(180deg, rgba(255, 255, 255, 0.015), transparent 60%), var(--bg-elev);
         border: 1px solid var(--border);
         border-radius: 10px;
         padding: 20px 22px;
@@ -737,82 +737,17 @@
         color: var(--text);
         font-weight: 500;
       }
+      .coverage-grid > .coverage-wide {
+        grid-column: 1 / -1;
+        padding-top: 10px;
+        margin-top: 2px;
+        border-top: 1px dashed var(--border);
+      }
       .coverage-foot {
         margin-top: 10px;
         padding-top: 8px;
         border-top: 1px dashed var(--border);
         font-size: 11px;
-        color: var(--muted);
-      }
-      .token-budget {
-        margin-top: 14px;
-        padding: 10px 12px;
-        border: 1px solid var(--border);
-        border-left: 3px solid var(--blue);
-        border-radius: 3px;
-        background: rgba(61, 139, 253, 0.04);
-        color: var(--muted);
-        font-size: 11.5px;
-        line-height: 1.55;
-      }
-      .token-budget .tb-header {
-        display: flex;
-        justify-content: space-between;
-        align-items: baseline;
-        margin-bottom: 6px;
-      }
-      .token-budget .tb-label {
-        font-family: 'Cinzel', serif;
-        font-weight: 600;
-        letter-spacing: 1.2px;
-        text-transform: uppercase;
-        color: var(--blue);
-        font-size: 11px;
-      }
-      .token-budget .tb-total {
-        font-family: 'DM Mono', monospace;
-        font-weight: 500;
-        color: var(--text);
-      }
-      .token-budget.over .tb-total,
-      .token-budget.over .tb-label {
-        color: #ff6b6b;
-      }
-      .token-budget .tb-bar {
-        height: 4px;
-        background: rgba(255, 255, 255, 0.06);
-        border-radius: 2px;
-        overflow: hidden;
-        margin-bottom: 8px;
-      }
-      .token-budget .tb-bar-fill {
-        height: 100%;
-        background: linear-gradient(90deg, var(--blue), var(--gold));
-        transition: width 0.15s ease-out;
-      }
-      .token-budget.warn .tb-bar-fill {
-        background: linear-gradient(90deg, var(--gold), #ffb84d);
-      }
-      .token-budget.over .tb-bar-fill {
-        background: linear-gradient(90deg, #ffb84d, #ff6b6b);
-      }
-      .token-budget .tb-breakdown {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 4px 12px;
-        font-family: 'DM Mono', monospace;
-        font-size: 10.5px;
-      }
-      .token-budget .tb-breakdown b {
-        color: var(--text);
-        font-weight: 500;
-        margin-left: 3px;
-      }
-      .token-budget .tb-footnote {
-        margin-top: 6px;
-        padding-top: 6px;
-        border-top: 1px dashed var(--border);
-        font-size: 10.5px;
         color: var(--muted);
       }
       .legal-notice {
@@ -1182,6 +1117,16 @@
           box-shadow 0.15s ease,
           background 0.15s ease;
       }
+      input[type='number']::-webkit-inner-spin-button,
+      input[type='number']::-webkit-outer-spin-button {
+        -webkit-appearance: none;
+        appearance: none;
+        margin: 0;
+      }
+      input[type='number'] {
+        -moz-appearance: textfield;
+        appearance: textfield;
+      }
       input[type='text']:focus,
       input[type='date']:focus,
       input[type='email']:focus,
@@ -1226,17 +1171,17 @@
         <div class="intro-block">
           <h3>Sanctions-list coverage</h3>
           <p>
-            Parallel screen against six lists: UN Consolidated (1267/1988/1989/2253), OFAC SDN,
-            OFAC Consolidated (non-SDN), EU CFSP, UK OFSI (HMT), and UAE EOCN. UAE EOCN and UN
-            are <strong>mandatory</strong> and cannot be deselected.
+            Parallel screen against six lists: UN Consolidated (1267/1988/1989/2253), OFAC SDN, OFAC
+            Consolidated (non-SDN), EU CFSP, UK OFSI (HMT), and UAE EOCN. UAE EOCN and UN are
+            <strong>mandatory</strong> and cannot be deselected.
           </p>
         </div>
         <div class="intro-block">
           <h3>Matching engine</h3>
           <p>
             Five-algorithm ensemble — Jaro-Winkler, Levenshtein, Soundex, Double Metaphone,
-            token-set — catching phonetic variants, transliterations, word-order permutations,
-            and single-character edits. Deterministic only; no LLM in the match path.
+            token-set — catching phonetic variants, transliterations, word-order permutations, and
+            single-character edits. Deterministic only; no LLM in the match path.
           </p>
         </div>
         <div class="intro-block">
@@ -1249,9 +1194,9 @@
         <div class="intro-block">
           <h3>Automation</h3>
           <p>
-            Confirmed or potential matches auto-enrol into the daily watchlist (06:00 / 14:00
-            UTC cron). A tagged Asana task lands in the SCREENINGS project, assigned to the
-            on-duty MLRO.
+            Confirmed or potential matches auto-enrol into the daily watchlist (06:00 / 14:00 UTC
+            cron). A tagged Asana task lands in the SCREENINGS project, assigned to the on-duty
+            MLRO.
           </p>
         </div>
         <div class="intro-block">
@@ -1262,14 +1207,14 @@
             append-only audit record for MoE, LBMA, and internal audit.
           </p>
         </div>
-        <div class="intro-block">
+        <div class="intro-block intro-block--wide">
           <h3>Regulatory basis</h3>
           <p class="cite">
-            FDL No.10/2025 Art.12-14 (CDD), 20-21 (CO duties), 24 (10-yr retention), 26-27
-            (STR), 29 (no tipping off), 35 (TFS) &middot; Cabinet Res 134/2025 Art.7-10, 14, 19
-            &middot; Cabinet Res 74/2020 Art.4-7 (24-h freeze) &middot; Cabinet Decision
-            No.(74)/2020 &middot; Cabinet Res 71/2024 &middot; MoE Circular 08/AML/2021 &middot;
-            FATF Rec 10 / 12 / 22 / 23.
+            FDL No.10/2025 Art.12-14 (CDD), 20-21 (CO duties), 24 (10-yr retention), 26-27 (STR), 29
+            (no tipping off), 35 (TFS) &middot; Cabinet Res 134/2025 Art.7-10, 14, 19 &middot;
+            Cabinet Res 74/2020 Art.4-7 (24-h freeze) &middot; Cabinet Decision No.(74)/2020
+            &middot; Cabinet Res 71/2024 &middot; MoE Circular 08/AML/2021 &middot; FATF Rec 10 / 12
+            / 22 / 23.
           </p>
         </div>
       </div>
@@ -1314,30 +1259,29 @@
         <div>
           <div class="c-h">Politically Exposed Persons</div>
           <div class="c-sub">
-            PEPs, close associates and family members identified per Cabinet Res 134/2025 Art.14
-            — domestic, foreign and international-organisation tiers.
+            PEPs, close associates and family members identified per Cabinet Res 134/2025 Art.14 —
+            domestic, foreign and international-organisation tiers.
           </div>
         </div>
         <div>
           <div class="c-h">Biographical information</div>
           <div class="c-sub">
             Titles, positions / roles, passport number(s), citizenship, DoB / registration date,
-            organisation &amp; political-party affiliation — all captured in the screening event
-            and retained 10 years (FDL Art.24).
+            organisation &amp; political-party affiliation — all captured in the screening event and
+            retained 10 years (FDL Art.24).
           </div>
         </div>
         <div>
           <div class="c-h">List coverage &mdash; 700+ target</div>
           <div class="c-sub">
-            <b>Live now:</b> UAE EOCN, UN 1267/1988/1989/2253, OFAC SDN + Consolidated, EU CFSP,
-            UK OFSI (&#x2265;&nbsp;5 lists).
-            <b>Roadmap:</b> Interpol, FCA, FINRA, FinCEN, SEC, DOJ, EuroPol, national debarments,
-            PEP vendor feeds, CAPTA, CMIC, sectoral &amp; NS-SDN, UN consolidated variants &amp;
-            local jurisdiction lists &mdash; cumulative 700+ sanction / watch / regulatory / LE
-            lists.
+            <b>Live now:</b> UAE EOCN, UN 1267/1988/1989/2253, OFAC SDN + Consolidated, EU CFSP, UK
+            OFSI (&#x2265;&nbsp;5 lists). <b>Roadmap:</b> Interpol, FCA, FINRA, FinCEN, SEC, DOJ,
+            EuroPol, national debarments, PEP vendor feeds, CAPTA, CMIC, sectoral &amp; NS-SDN, UN
+            consolidated variants &amp; local jurisdiction lists &mdash; cumulative 700+ sanction /
+            watch / regulatory / LE lists.
           </div>
         </div>
-        <div>
+        <div class="coverage-wide">
           <div class="c-h">Record-update ranking</div>
           <div class="c-sub">
             Every list entry carries <i>fetchedAt</i>, <i>listPublishedAt</i> and
@@ -1347,9 +1291,8 @@
         </div>
       </div>
       <p class="coverage-foot">
-        Coverage guarantees logged on every screening event (FDL Art.24 — 10-year retention) so
-        MoE / LBMA / internal audit can reproduce the exact data surface at any prior point in
-        time.
+        Coverage guarantees logged on every screening event (FDL Art.24 — 10-year retention) so MoE
+        / LBMA / internal audit can reproduce the exact data surface at any prior point in time.
       </p>
     </div>
 
@@ -1382,7 +1325,9 @@
           />
           <span class="list-label"
             >UNSC Consolidated Sanctions List — UN Security Council
-            <span class="list-sub">Security Council resolutions + 1267/1988/1989/2253 sanctions</span>
+            <span class="list-sub"
+              >Security Council resolutions + 1267/1988/1989/2253 sanctions</span
+            >
           </span>
         </label>
         <p class="list-footnote">
@@ -1398,14 +1343,18 @@
           <input type="checkbox" data-list="OFAC" data-tier="enhanced" checked />
           <span class="list-label"
             >OFAC SDN — US unilateral sanctions
-            <span class="list-sub">US Treasury OFAC Specially Designated Nationals + Consolidated</span>
+            <span class="list-sub"
+              >US Treasury OFAC Specially Designated Nationals + Consolidated</span
+            >
           </span>
         </label>
         <label class="list-check">
           <input type="checkbox" data-list="EU" data-tier="enhanced" checked />
           <span class="list-label"
             >EU Consolidated Sanctions
-            <span class="list-sub">European Union consolidated financial sanctions list (CFSP)</span>
+            <span class="list-sub"
+              >European Union consolidated financial sanctions list (CFSP)</span
+            >
           </span>
         </label>
         <label class="list-check">
@@ -1416,17 +1365,12 @@
           </span>
         </label>
         <label class="list-check">
-          <input
-            type="checkbox"
-            data-control="adverseMedia"
-            data-tier="enhanced"
-            checked
-          />
+          <input type="checkbox" data-control="adverseMedia" data-tier="enhanced" checked />
           <span class="list-label"
             >Adverse Media Sweep
             <span class="list-sub"
-              >Open-source negative-news search — PEP, sanctions, litigation, fraud, terrorism financing
-              (FATF Rec 10 / 12, EOCN guidance)</span
+              >Open-source negative-news search — PEP, sanctions, litigation, fraud, terrorism
+              financing (FATF Rec 10 / 12, EOCN guidance)</span
             >
           </span>
         </label>
@@ -1449,8 +1393,8 @@
     <div class="card list-tier enhanced" style="margin-top: 14px">
       <h2>Risk Categories</h2>
       <p class="help-text" style="margin-top: -4px">
-        Content categories screened against every selected list + adverse-media corpus. Default:
-        all ON. Turning a category OFF is logged on the screening event (FDL Art.24 — 10-year
+        Content categories screened against every selected list + adverse-media corpus. Default: all
+        ON. Turning a category OFF is logged on the screening event (FDL Art.24 — 10-year
         retention).
       </p>
       <div class="grid grid-2" style="gap: 6px 14px">
@@ -1464,12 +1408,7 @@
           </span>
         </label>
         <label class="list-check">
-          <input
-            type="checkbox"
-            data-category="stateOwnedEntities"
-            data-tier="enhanced"
-            checked
-          />
+          <input type="checkbox" data-category="stateOwnedEntities" data-tier="enhanced" checked />
           <span class="list-label"
             >State-owned entities &amp; state-invested enterprises
             <span class="list-sub">SOE ownership screen — FATF Rec 12 / 24 beneficial control</span>
@@ -1485,12 +1424,7 @@
           </span>
         </label>
         <label class="list-check">
-          <input
-            type="checkbox"
-            data-category="narrativeSanctions"
-            data-tier="enhanced"
-            checked
-          />
+          <input type="checkbox" data-category="narrativeSanctions" data-tier="enhanced" checked />
           <span class="list-label"
             >Narrative &amp; implicit sanctions
             <span class="list-sub"
@@ -1538,8 +1472,23 @@
             >
           </span>
         </label>
+        <label class="list-check">
+          <input
+            type="checkbox"
+            data-category="proliferationFinancing"
+            data-tier="enhanced"
+            checked
+          />
+          <span class="list-label"
+            >Proliferation financing &amp; dual-use goods
+            <span class="list-sub"
+              >PF risk screen — WMD-linked entities, strategic / dual-use end-users, diversion
+              networks, front companies. Cabinet Res 156/2025 · UNSCR 1540 · FATF Rec 7 · DPMS
+              gold-provenance exposure.</span
+            >
+          </span>
+        </label>
       </div>
-
     </div>
 
     <div class="grid grid-2" style="margin-top: 14px">
@@ -1569,17 +1518,6 @@
           autocomplete="off"
           maxlength="512"
         />
-        <span class="help-text"
-          >Matcher runs on 20+ Latin-alphabet languages (English, German, Italian, French,
-          Spanish, Portuguese, Dutch, Polish, Romanian, Turkish, Vietnamese, Indonesian, Malay,
-          Tagalog, Swahili, Hausa, Somali, Albanian, Croatian, Lithuanian) and normalises 40+
-          non-Latin scripts (Arabic, Persian/Farsi, Urdu, Hebrew, Cyrillic (Russian/Ukrainian/
-          Serbian/Bulgarian), Greek, Chinese (Simplified + Traditional), Japanese (Kanji / Hiragana
-          / Katakana), Korean Hangul, Thai, Lao, Khmer, Burmese, Devanagari / Bengali / Gurmukhi /
-          Gujarati / Tamil / Telugu / Kannada / Malayalam / Sinhala, Ge'ez / Amharic / Tigrinya,
-          Georgian, Armenian, Tibetan). Transliteration via ICU / Unicode UAX #35.</span
-        >
-
         <div class="row-2">
           <div>
             <label for="entityType">Entity type *</label>
@@ -1590,7 +1528,13 @@
           </div>
           <div>
             <label for="dob">Date of birth / registration</label>
-            <input type="text" id="dob" placeholder="dd/mm/yyyy" autocomplete="off" maxlength="10" />
+            <input
+              type="text"
+              id="dob"
+              placeholder="dd/mm/yyyy"
+              autocomplete="off"
+              maxlength="10"
+            />
           </div>
         </div>
 
@@ -1717,30 +1661,6 @@
           </div>
         </div>
 
-        <div id="tokenBudget" class="token-budget" aria-live="polite">
-          <div class="tb-header">
-            <span class="tb-label">Token budget</span>
-            <span class="tb-total"><span id="tbTotal">0</span>&nbsp;tokens</span>
-          </div>
-          <div class="tb-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100">
-            <div id="tbBarFill" class="tb-bar-fill" style="width: 0%"></div>
-          </div>
-          <div class="tb-breakdown">
-            <span>Name <b id="tbName">0</b></span>
-            <span>Aliases <b id="tbAliases">0</b></span>
-            <span>Notes <b id="tbNotes">0</b></span>
-            <span>Key findings <b id="tbKey">0</b></span>
-            <span>Rationale <b id="tbRationale">0</b></span>
-            <span>Lists <b id="tbLists">0</b></span>
-            <span>Categories <b id="tbCategories">0</b></span>
-          </div>
-          <p class="tb-footnote">
-            Approximation: ~4 characters per token (English). Budget caps: request body 32&nbsp;KB
-            (~8000 tokens); rationale 4000 chars; key findings 4000 chars; aliases 20&times;200
-            chars. Turns red above 6000 tokens — tighten before running.
-          </p>
-        </div>
-
         <button id="screenBtn" type="button">Run Screening</button>
         <div id="screenMsg"></div>
         <div id="screenResult" style="margin-top: 14px"></div>
@@ -1808,8 +1728,8 @@
                 <span class="label">False positive</span>
               </span>
               <span class="impact"
-                >Name hit ruled out on DoB / ID / jurisdiction. Document the differentiator in
-                the rationale.</span
+                >Name hit ruled out on DoB / ID / jurisdiction. Document the differentiator in the
+                rationale.</span
               >
             </button>
             <button
@@ -1853,8 +1773,8 @@
             <span class="dp-value muted" id="dpAction">&mdash;</span>
             <span class="dp-label">Record</span>
             <span class="dp-value muted" id="dpRecord"
-              >Outcome, rationale, key findings, reviewer, IP, and timestamp will be written to
-              the append-only audit log + mirrored to the Asana task.</span
+              >Outcome, rationale, key findings, reviewer, IP, and timestamp will be written to the
+              append-only audit log + mirrored to the Asana task.</span
             >
           </div>
 
@@ -1876,7 +1796,8 @@
             minlength="20"
           ></textarea>
           <span class="help-text"
-            >Minimum 20 characters. This text is the audit record seen by MoE / LBMA inspectors.</span
+            >Minimum 20 characters. This text is the audit record seen by MoE / LBMA
+            inspectors.</span
           >
 
           <div id="legalNotice" class="legal-notice">
@@ -1893,28 +1814,28 @@
               <strong>Data basis.</strong> Name, aliases, DOB / registration date, citizenship /
               registered country, ID / register number, and publicly-available sanctions / PEP /
               adverse-media sources. Processed under UAE PDPL (Federal Decree-Law No.45/2021)
-              Art.6(1)(c) — compliance with legal obligation. Record is append-only,
-              hash-anchored, and replayable by the Compliance Officer on request.
+              Art.6(1)(c) — compliance with legal obligation. Record is append-only, hash-anchored,
+              and replayable by the Compliance Officer on request.
             </p>
             <p>
               <strong>AI / automation transparency.</strong> This screening uses classical
-              deterministic algorithms only (Jaro-Winkler + Levenshtein + Soundex + Double
-              Metaphone + token-set). No LLM is used to produce the match or the risk score. The
-              human MLRO attests the final disposition.
+              deterministic algorithms only (Jaro-Winkler + Levenshtein + Soundex + Double Metaphone
+              + token-set). No LLM is used to produce the match or the risk score. The human MLRO
+              attests the final disposition.
             </p>
             <p id="freezeNotice" class="freeze-notice" hidden>
               <strong>ASSET FREEZE REQUIRED WITHIN 24 HOURS.</strong> This subject has been
-              confirmed on a sanctions list. Execute an asset freeze within 24 clock hours
-              (Cabinet Res 74/2020 Art.4) and file a CNMR with EOCN within 5 business days
-              (Art.5-7). Do NOT notify the subject. Do NOT release the funds. Escalate
-              immediately to the Compliance Officer.
+              confirmed on a sanctions list. Execute an asset freeze within 24 clock hours (Cabinet
+              Res 74/2020 Art.4) and file a CNMR with EOCN within 5 business days (Art.5-7). Do NOT
+              notify the subject. Do NOT release the funds. Escalate immediately to the Compliance
+              Officer.
             </p>
             <label class="legal-ack">
               <input type="checkbox" id="legalAck" />
               <span
                 >I have personally reviewed the candidates, applied professional judgement
-                consistent with the firm's Risk Appetite Statement (Cabinet Res 134/2025 Art.5),
-                and confirm the outcome + rationale above is a true and accurate account of my
+                consistent with the firm's Risk Appetite Statement (Cabinet Res 134/2025 Art.5), and
+                confirm the outcome + rationale above is a true and accurate account of my
                 decision.</span
               >
             </label>

--- a/screening-command.html
+++ b/screening-command.html
@@ -1220,8 +1220,77 @@
       </div>
     </section>
 
+    <!-- MLRO identity ──────────────────────────────────────────────── -->
+    <div class="card" style="margin-top: 14px">
+      <h2>MLRO Identity <span class="tag">Who is screening</span></h2>
+      <p class="help-text" style="margin-top: -4px">
+        The UAE reporting entity has two authorised officers. Pick the one on duty before running a
+        screening — the name is written to the event as <i>Screened by</i> and auto-fills the MLRO
+        Disposition &gt; Reviewed by field. Saved locally (FDL Art.24 — 10-year audit trail).
+      </p>
+      <div class="row-2">
+        <div>
+          <label for="mlroMainName">Main MLRO — full legal name *</label>
+          <input
+            type="text"
+            id="mlroMainName"
+            placeholder="e.g. Jane A. Sterling"
+            autocomplete="off"
+            maxlength="128"
+          />
+        </div>
+        <div>
+          <label for="mlroDeputyName">Deputy MLRO — full legal name *</label>
+          <input
+            type="text"
+            id="mlroDeputyName"
+            placeholder="e.g. John B. Hawke"
+            autocomplete="off"
+            maxlength="128"
+          />
+        </div>
+      </div>
+      <label style="margin-top: 8px">Active officer for this session *</label>
+      <div
+        class="outcome-grid"
+        role="radiogroup"
+        aria-label="Active MLRO"
+        style="grid-template-columns: repeat(2, 1fr); gap: 8px"
+      >
+        <button
+          type="button"
+          class="outcome-btn mlro-role-btn"
+          data-role="main"
+          role="radio"
+          aria-checked="true"
+        >
+          <span class="outcome-head">
+            <span class="glyph" aria-hidden="true">&#9733;</span>
+            <span class="label">Main MLRO</span>
+          </span>
+          <span class="impact" id="mlroMainLabel">—</span>
+        </button>
+        <button
+          type="button"
+          class="outcome-btn mlro-role-btn"
+          data-role="deputy"
+          role="radio"
+          aria-checked="false"
+        >
+          <span class="outcome-head">
+            <span class="glyph" aria-hidden="true">&#9734;</span>
+            <span class="label">Deputy MLRO</span>
+          </span>
+          <span class="impact" id="mlroDeputyLabel">—</span>
+        </button>
+      </div>
+      <p class="help-text" style="margin-top: 8px">
+        <b>Screened by:</b> <span id="mlroActiveBadge" class="tag">—</span>
+      </p>
+    </div>
+
     <!-- Authentication ────────────────────────────────────────────── -->
-    <div class="card">
+    <div class="card" style="margin-top: 14px">
       <h2>Authentication <span class="tag">Required</span></h2>
       <label for="token">Hawkeye brain token</label>
       <input
@@ -1661,6 +1730,12 @@
           </div>
         </div>
 
+        <p class="help-text" style="margin-top: 6px">
+          <b>Screened by:</b> <span id="mlroActiveBadgeRun" class="tag">—</span>
+          <span class="token-hint"
+            >&nbsp;Change the active officer in the <i>MLRO Identity</i> card above.</span
+          >
+        </p>
         <button id="screenBtn" type="button">Run Screening</button>
         <div id="screenMsg"></div>
         <div id="screenResult" style="margin-top: 14px"></div>

--- a/screening-command.html
+++ b/screening-command.html
@@ -1163,7 +1163,7 @@
   </head>
   <body>
     <header>
-      <h1>Screening Command <span class="badge">v1</span></h1>
+      <h1>Hawkeye Sterling V2 &mdash; Screening Command</h1>
       <a href="/" class="muted">&larr; Main tool</a>
     </header>
     <section class="intro-panel">
@@ -1209,7 +1209,7 @@
         </div>
         <div class="intro-block intro-block--wide">
           <h3>Regulatory basis</h3>
-          <p class="cite">
+          <p>
             FDL No.10/2025 Art.12-14 (CDD), 20-21 (CO duties), 24 (10-yr retention), 26-27 (STR), 29
             (no tipping off), 35 (TFS) &middot; Cabinet Res 134/2025 Art.7-10, 14, 19 &middot;
             Cabinet Res 74/2020 Art.4-7 (24-h freeze) &middot; Cabinet Decision No.(74)/2020

--- a/screening-command.js
+++ b/screening-command.js
@@ -22,6 +22,9 @@
   const TM_ENDPOINT = '/api/transaction/monitor';
   const WATCHLIST_ENDPOINT = '/api/watchlist';
   const TOKEN_KEY = 'hawkeye.watchlist.adminToken';
+  const MLRO_MAIN_KEY = 'hawkeye.mlro.main';
+  const MLRO_DEPUTY_KEY = 'hawkeye.mlro.deputy';
+  const MLRO_ACTIVE_KEY = 'hawkeye.mlro.active';
   const TOKEN_MIN = 32;
   const TOKEN_HEX_RE = /^[a-f0-9]+$/i;
   const RATIONALE_MIN = 20;
@@ -51,6 +54,79 @@
   tokenInput.addEventListener('blur', saveToken);
   tokenInput.addEventListener('input', saveToken);
   window.addEventListener('beforeunload', saveToken);
+
+  // ─── MLRO identity (main + deputy, persisted + active-officer toggle) ───
+  const mlroMainNameInput = $('mlroMainName');
+  const mlroDeputyNameInput = $('mlroDeputyName');
+  const mlroMainLabel = $('mlroMainLabel');
+  const mlroDeputyLabel = $('mlroDeputyLabel');
+  const mlroActiveBadge = $('mlroActiveBadge');
+  const mlroRoleBtns = document.querySelectorAll('.mlro-role-btn');
+
+  function lsGet(key) {
+    try {
+      return localStorage.getItem(key) || '';
+    } catch (_e) {
+      return '';
+    }
+  }
+  function lsSet(key, value) {
+    try {
+      if (value) localStorage.setItem(key, value);
+      else localStorage.removeItem(key);
+    } catch (_e) {
+      /* ignore */
+    }
+  }
+
+  let activeMlroRole = lsGet(MLRO_ACTIVE_KEY) || 'main';
+
+  function activeMlroName() {
+    const main = (mlroMainNameInput.value || '').trim();
+    const deputy = (mlroDeputyNameInput.value || '').trim();
+    return activeMlroRole === 'deputy' ? deputy : main;
+  }
+
+  function refreshMlroUi() {
+    const main = (mlroMainNameInput.value || '').trim();
+    const deputy = (mlroDeputyNameInput.value || '').trim();
+    if (mlroMainLabel) mlroMainLabel.textContent = main || 'Not set';
+    if (mlroDeputyLabel) mlroDeputyLabel.textContent = deputy || 'Not set';
+    mlroRoleBtns.forEach((btn) => {
+      const isActive = btn.getAttribute('data-role') === activeMlroRole;
+      btn.classList.toggle('selected', isActive);
+      btn.setAttribute('aria-checked', isActive ? 'true' : 'false');
+    });
+    const name = activeMlroName();
+    const roleLabel = activeMlroRole === 'deputy' ? 'Deputy MLRO' : 'Main MLRO';
+    const badgeText = name ? `${name} — ${roleLabel}` : `(${roleLabel} — name missing)`;
+    if (mlroActiveBadge) mlroActiveBadge.textContent = badgeText;
+    const runBadge = $('mlroActiveBadgeRun');
+    if (runBadge) runBadge.textContent = badgeText;
+    const reviewedByEl = $('reviewedBy');
+    if (reviewedByEl && !reviewedByEl.value && name) reviewedByEl.value = name;
+  }
+
+  mlroMainNameInput.value = lsGet(MLRO_MAIN_KEY);
+  mlroDeputyNameInput.value = lsGet(MLRO_DEPUTY_KEY);
+
+  mlroMainNameInput.addEventListener('input', () => {
+    lsSet(MLRO_MAIN_KEY, mlroMainNameInput.value.trim());
+    refreshMlroUi();
+  });
+  mlroDeputyNameInput.addEventListener('input', () => {
+    lsSet(MLRO_DEPUTY_KEY, mlroDeputyNameInput.value.trim());
+    refreshMlroUi();
+  });
+  mlroRoleBtns.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      activeMlroRole = btn.getAttribute('data-role') || 'main';
+      lsSet(MLRO_ACTIVE_KEY, activeMlroRole);
+      refreshMlroUi();
+    });
+  });
+
+  refreshMlroUi();
 
   // ─── Token format check ──────────────────────────────────────────
   function tokenFormatError(token) {
@@ -336,14 +412,6 @@
   // which predicate offences were searched.
   function allPredicateKeys() {
     return ADVERSE_MEDIA_PREDICATES.map((p) => p.key);
-  }
-
-  function collectSelectedCategories() {
-    const out = [];
-    document.querySelectorAll('input[data-category][data-tier="enhanced"]').forEach((el) => {
-      if (el.checked) out.push(el.getAttribute('data-category'));
-    });
-    return out;
   }
 
   function todayDdMmYyyy() {
@@ -855,6 +923,15 @@
     );
     screenResult.innerHTML = '';
 
+    const screener = activeMlroName();
+    if (!screener) {
+      showMessage(
+        screenMsg,
+        'Screener name required — set the active MLRO identity above before running a screening.',
+        'error'
+      );
+      return;
+    }
     const aliases = aliasesInput ? parseAliases(aliasesInput.value) : [];
     const body = {
       subjectName: name,
@@ -873,6 +950,8 @@
       runAdverseMedia: isAdverseMediaEnabled(),
       adverseMediaPredicates: isAdverseMediaEnabled() ? allPredicateKeys() : undefined,
       createAsanaTask: true,
+      screenedBy: screener,
+      screenedByRole: activeMlroRole === 'deputy' ? 'deputy_mlro' : 'main_mlro',
     };
     const result = await apiPost(SCREENING_ENDPOINT, body);
     if (!result.ok) {

--- a/screening-command.js
+++ b/screening-command.js
@@ -239,47 +239,95 @@
   // /run request body and persisted with the screening event.
   // -----------------------------------------------------------------
   const ADVERSE_MEDIA_PREDICATES = [
-    { key: 'bribery_corruption',          label: 'Bribery and corruption',                         ref: 'FATF Rec 10/12; UNCAC' },
-    { key: 'hostage_taking',              label: 'Hostage taking',                                 ref: 'UNSCR 2178; FDL Art.2' },
-    { key: 'kidnapping',                  label: 'Kidnapping',                                     ref: 'FDL Art.2; Penal Code' },
-    { key: 'piracy_counterfeit_products', label: 'Piracy, counterfeiting & product piracy',        ref: 'FATF Rec 10; TRIPS' },
-    { key: 'human_trafficking',           label: 'Human trafficking & human rights abuses',        ref: 'FDL Art.2; Palermo Protocol' },
-    { key: 'organized_crime',             label: 'Organized crime',                                ref: 'UNTOC; FDL Art.2' },
-    { key: 'currency_counterfeiting',     label: 'Currency counterfeiting',                        ref: 'FDL Art.2; UAE Penal Code' },
-    { key: 'illicit_trafficking_goods',   label: 'Illicit trafficking in stolen / other goods',    ref: 'FATF Rec 10; FDL Art.2' },
-    { key: 'racketeering',                label: 'Racketeering',                                   ref: 'UNTOC Art.5' },
-    { key: 'cybercrime',                  label: 'Cybercrime',                                     ref: 'Budapest Convention' },
-    { key: 'hacking',                     label: 'Hacking',                                        ref: 'UAE FDL 34/2021' },
-    { key: 'phishing',                    label: 'Phishing',                                       ref: 'UAE FDL 34/2021' },
-    { key: 'insider_trading_market_manip',label: 'Insider trading & market manipulation',          ref: 'FDL Art.2; SCA' },
-    { key: 'robbery',                     label: 'Robbery',                                        ref: 'FDL Art.2; Penal Code' },
-    { key: 'environmental_crimes',        label: 'Environmental crimes',                           ref: 'FATF 2021 Env Crime Report' },
-    { key: 'migrant_smuggling',           label: 'Migrant smuggling',                              ref: 'UNTOC Smuggling Protocol' },
-    { key: 'slave_labor',                 label: 'Slave labour / forced labour',                   ref: 'ILO C029; FDL Art.2' },
-    { key: 'securities_fraud',            label: 'Securities fraud',                               ref: 'SCA Board Res 37/R.M.' },
-    { key: 'extortion',                   label: 'Extortion',                                      ref: 'FDL Art.2' },
-    { key: 'child_sexual_exploitation',   label: 'Sexual exploitation of children',                ref: 'OPSC; FDL Art.2' },
-    { key: 'money_laundering',            label: 'Money laundering',                               ref: 'FDL No.10/2025 Art.2' },
-    { key: 'falsifying_official_docs',    label: 'Falsifying information on official documents',   ref: 'FDL Art.2; Penal Code' },
-    { key: 'narcotics_arms_trafficking',  label: 'Narcotics & arms trafficking',                   ref: 'UN 1988 Conv; ATT' },
-    { key: 'smuggling',                   label: 'Smuggling',                                      ref: 'FDL Art.2; Customs Law' },
-    { key: 'forgery',                     label: 'Forgery',                                        ref: 'FDL Art.2' },
-    { key: 'price_fixing',                label: 'Price fixing',                                   ref: 'UAE Competition Law 4/2012' },
-    { key: 'illegal_cartel_formation',    label: 'Illegal cartel formation',                       ref: 'UAE Competition Law 4/2012' },
-    { key: 'antitrust_violations',        label: 'Antitrust violations',                           ref: 'UAE Competition Law 4/2012' },
-    { key: 'terrorism',                   label: 'Terrorism',                                      ref: 'FDL No.7/2014; UNSCR 1373' },
-    { key: 'terror_financing',            label: 'Terror financing',                               ref: 'FDL No.10/2025 Art.2; UNSCR 1267' },
-    { key: 'fraud',                       label: 'Fraud',                                          ref: 'FDL Art.2; Penal Code' },
-    { key: 'embezzlement',                label: 'Embezzlement',                                   ref: 'FDL Art.2; UNCAC Art.17' },
-    { key: 'theft',                       label: 'Theft',                                          ref: 'FDL Art.2; Penal Code' },
-    { key: 'cheating',                    label: 'Cheating',                                       ref: 'FDL Art.2; Penal Code' },
-    { key: 'pharma_trafficking',          label: 'Pharmaceutical product trafficking',             ref: 'MEDICRIME Conv; FATF' },
-    { key: 'illegal_distribution',        label: 'Illegal distribution',                           ref: 'FDL Art.2' },
-    { key: 'illegal_production',          label: 'Illegal production',                             ref: 'FDL Art.2' },
-    { key: 'banned_fake_medicines',       label: 'Banned / fake medicines',                        ref: 'MEDICRIME Conv' },
-    { key: 'war_crimes',                  label: 'War crimes',                                     ref: 'Rome Statute; Geneva Conv' },
-    { key: 'tax_evasion',                 label: 'Tax evasion',                                    ref: 'FDL No.10/2025 Art.2' },
-    { key: 'tax_fraud',                   label: 'Tax fraud',                                      ref: 'FDL No.10/2025 Art.2; FTA Law' },
+    { key: 'bribery_corruption', label: 'Bribery and corruption', ref: 'FATF Rec 10/12; UNCAC' },
+    { key: 'hostage_taking', label: 'Hostage taking', ref: 'UNSCR 2178; FDL Art.2' },
+    { key: 'kidnapping', label: 'Kidnapping', ref: 'FDL Art.2; Penal Code' },
+    {
+      key: 'piracy_counterfeit_products',
+      label: 'Piracy, counterfeiting & product piracy',
+      ref: 'FATF Rec 10; TRIPS',
+    },
+    {
+      key: 'human_trafficking',
+      label: 'Human trafficking & human rights abuses',
+      ref: 'FDL Art.2; Palermo Protocol',
+    },
+    { key: 'organized_crime', label: 'Organized crime', ref: 'UNTOC; FDL Art.2' },
+    {
+      key: 'currency_counterfeiting',
+      label: 'Currency counterfeiting',
+      ref: 'FDL Art.2; UAE Penal Code',
+    },
+    {
+      key: 'illicit_trafficking_goods',
+      label: 'Illicit trafficking in stolen / other goods',
+      ref: 'FATF Rec 10; FDL Art.2',
+    },
+    { key: 'racketeering', label: 'Racketeering', ref: 'UNTOC Art.5' },
+    { key: 'cybercrime', label: 'Cybercrime', ref: 'Budapest Convention' },
+    { key: 'hacking', label: 'Hacking', ref: 'UAE FDL 34/2021' },
+    { key: 'phishing', label: 'Phishing', ref: 'UAE FDL 34/2021' },
+    {
+      key: 'insider_trading_market_manip',
+      label: 'Insider trading & market manipulation',
+      ref: 'FDL Art.2; SCA',
+    },
+    { key: 'robbery', label: 'Robbery', ref: 'FDL Art.2; Penal Code' },
+    {
+      key: 'environmental_crimes',
+      label: 'Environmental crimes',
+      ref: 'FATF 2021 Env Crime Report',
+    },
+    { key: 'migrant_smuggling', label: 'Migrant smuggling', ref: 'UNTOC Smuggling Protocol' },
+    { key: 'slave_labor', label: 'Slave labour / forced labour', ref: 'ILO C029; FDL Art.2' },
+    { key: 'securities_fraud', label: 'Securities fraud', ref: 'SCA Board Res 37/R.M.' },
+    { key: 'extortion', label: 'Extortion', ref: 'FDL Art.2' },
+    {
+      key: 'child_sexual_exploitation',
+      label: 'Sexual exploitation of children',
+      ref: 'OPSC; FDL Art.2',
+    },
+    { key: 'money_laundering', label: 'Money laundering', ref: 'FDL No.10/2025 Art.2' },
+    {
+      key: 'falsifying_official_docs',
+      label: 'Falsifying information on official documents',
+      ref: 'FDL Art.2; Penal Code',
+    },
+    {
+      key: 'narcotics_arms_trafficking',
+      label: 'Narcotics & arms trafficking',
+      ref: 'UN 1988 Conv; ATT',
+    },
+    { key: 'smuggling', label: 'Smuggling', ref: 'FDL Art.2; Customs Law' },
+    { key: 'forgery', label: 'Forgery', ref: 'FDL Art.2' },
+    { key: 'price_fixing', label: 'Price fixing', ref: 'UAE Competition Law 4/2012' },
+    {
+      key: 'illegal_cartel_formation',
+      label: 'Illegal cartel formation',
+      ref: 'UAE Competition Law 4/2012',
+    },
+    {
+      key: 'antitrust_violations',
+      label: 'Antitrust violations',
+      ref: 'UAE Competition Law 4/2012',
+    },
+    { key: 'terrorism', label: 'Terrorism', ref: 'FDL No.7/2014; UNSCR 1373' },
+    { key: 'terror_financing', label: 'Terror financing', ref: 'FDL No.10/2025 Art.2; UNSCR 1267' },
+    { key: 'fraud', label: 'Fraud', ref: 'FDL Art.2; Penal Code' },
+    { key: 'embezzlement', label: 'Embezzlement', ref: 'FDL Art.2; UNCAC Art.17' },
+    { key: 'theft', label: 'Theft', ref: 'FDL Art.2; Penal Code' },
+    { key: 'cheating', label: 'Cheating', ref: 'FDL Art.2; Penal Code' },
+    {
+      key: 'pharma_trafficking',
+      label: 'Pharmaceutical product trafficking',
+      ref: 'MEDICRIME Conv; FATF',
+    },
+    { key: 'illegal_distribution', label: 'Illegal distribution', ref: 'FDL Art.2' },
+    { key: 'illegal_production', label: 'Illegal production', ref: 'FDL Art.2' },
+    { key: 'banned_fake_medicines', label: 'Banned / fake medicines', ref: 'MEDICRIME Conv' },
+    { key: 'war_crimes', label: 'War crimes', ref: 'Rome Statute; Geneva Conv' },
+    { key: 'tax_evasion', label: 'Tax evasion', ref: 'FDL No.10/2025 Art.2' },
+    { key: 'tax_fraud', label: 'Tax fraud', ref: 'FDL No.10/2025 Art.2; FTA Law' },
   ];
 
   // Default scope for every Adverse Media sweep — not a UI toggle, just
@@ -297,63 +345,6 @@
     });
     return out;
   }
-
-  // ----- Token budget (approx 4 chars = 1 token, English) -----
-  const TOKEN_SOFT_CAP = 6000; // warn at 75%
-  const TOKEN_HARD_CAP = 8000; // ~32KB body
-  const tbEl = $('tokenBudget');
-  const tbTotal = $('tbTotal');
-  const tbBarFill = $('tbBarFill');
-  const tbName = $('tbName');
-  const tbAliases = $('tbAliases');
-  const tbNotes = $('tbNotes');
-  const tbKey = $('tbKey');
-  const tbRationale = $('tbRationale');
-  const tbLists = $('tbLists');
-  const tbCategories = $('tbCategories');
-
-  function tokensFor(s) {
-    return Math.ceil((s || '').length / 4);
-  }
-
-  function updateTokenBudget() {
-    if (!tbEl) return;
-    const name = tokensFor(subjectNameInput ? subjectNameInput.value : '');
-    const aliases = tokensFor(aliasesInput ? aliasesInput.value : '');
-    const notes = tokensFor(notesInput ? notesInput.value : '');
-    const key = tokensFor(keyFindingsInput ? keyFindingsInput.value : '');
-    const rationale = tokensFor(rationaleInput ? rationaleInput.value : '');
-    const lists = collectSelectedLists().length * 2;
-    const categories = collectSelectedCategories().length * 3;
-    const total = name + aliases + notes + key + rationale + lists + categories;
-    if (tbName) tbName.textContent = String(name);
-    if (tbAliases) tbAliases.textContent = String(aliases);
-    if (tbNotes) tbNotes.textContent = String(notes);
-    if (tbKey) tbKey.textContent = String(key);
-    if (tbRationale) tbRationale.textContent = String(rationale);
-    if (tbLists) tbLists.textContent = String(lists);
-    if (tbCategories) tbCategories.textContent = String(categories);
-    if (tbTotal) tbTotal.textContent = String(total);
-    const pct = Math.min(100, Math.round((total / TOKEN_HARD_CAP) * 100));
-    if (tbBarFill) tbBarFill.style.width = pct + '%';
-    tbEl.classList.remove('warn', 'over');
-    if (total >= TOKEN_HARD_CAP) tbEl.classList.add('over');
-    else if (total >= TOKEN_SOFT_CAP) tbEl.classList.add('warn');
-  }
-
-  [
-    subjectNameInput,
-    aliasesInput,
-    notesInput,
-    keyFindingsInput,
-    rationaleInput,
-  ].forEach((el) => {
-    if (el) el.addEventListener('input', updateTokenBudget);
-  });
-  document
-    .querySelectorAll('input[data-tier="enhanced"]')
-    .forEach((el) => el.addEventListener('change', updateTokenBudget));
-  updateTokenBudget();
 
   function todayDdMmYyyy() {
     const d = new Date();
@@ -417,11 +408,7 @@
 
   function setDisposition(outcomeKey) {
     if (!dispositionPreview || !dpOutcome || !dpAction) return;
-    dispositionPreview.classList.remove(
-      'level-clear',
-      'level-escalate',
-      'level-freeze'
-    );
+    dispositionPreview.classList.remove('level-clear', 'level-escalate', 'level-freeze');
     if (!outcomeKey || !OUTCOME_META[outcomeKey]) {
       dpOutcome.textContent = 'Select an outcome above.';
       dpOutcome.classList.add('muted');
@@ -546,9 +533,7 @@
     let secondApproverRole = '';
     if (outcomeRequiresFourEyes(currentOutcome)) {
       secondApprover = secondApproverInput ? secondApproverInput.value.trim() : '';
-      secondApproverRole = secondApproverRoleInput
-        ? secondApproverRoleInput.value.trim()
-        : '';
+      secondApproverRole = secondApproverRoleInput ? secondApproverRoleInput.value.trim() : '';
       if (!secondApprover) {
         showMessage(
           saveMsg,
@@ -907,9 +892,7 @@
               ? 'Weak match — documented and dismissed if false positive'
               : 'No sanctions match';
       const anomSuffix =
-        anomalies.length > 0
-          ? ' · ' + anomalies.length + ' anomaly(ies) routed to Asana'
-          : '';
+        anomalies.length > 0 ? ' · ' + anomalies.length + ' anomaly(ies) routed to Asana' : '';
       showMessage(
         screenMsg,
         verb + anomSuffix + '. Complete the disposition below to close the event.',

--- a/src/services/eocnDeltaWatcher.ts
+++ b/src/services/eocnDeltaWatcher.ts
@@ -16,6 +16,18 @@
  *   - FDL No.10/2025 Art.35 (TFS compliance)
  */
 
+import { fetchWithTimeout } from '../utils/fetchWithTimeout';
+
+/**
+ * 30s is the same budget the rest of the sanctions-ingest
+ * fetchers use (`netlify/functions/sanctions-ingest-cron.mts`
+ * and `src/services/sanctionsApi.ts`). EOCN feeds are CSV/JSON
+ * blobs; if the feed host cannot answer in 30s the delta run is
+ * better off failing loudly so the platform retries on the next
+ * scheduled pass than silently exhausting the Netlify invocation.
+ */
+const EOCN_FETCH_TIMEOUT_MS = 30_000;
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -109,7 +121,7 @@ async function defaultFetcher(): Promise<EocnDesignation[]> {
       ? process.env.EOCN_FEED_URL
       : undefined;
   if (!url) return [];
-  const res = await fetch(url);
+  const res = await fetchWithTimeout(url, { timeoutMs: EOCN_FETCH_TIMEOUT_MS });
   if (!res.ok) return [];
   const json = (await res.json()) as { designations?: EocnDesignation[] };
   return Array.isArray(json.designations) ? json.designations : [];

--- a/src/services/notificationBridge.ts
+++ b/src/services/notificationBridge.ts
@@ -27,6 +27,7 @@
  */
 
 import type { Verdict } from './asanaCustomFields';
+import { fetchWithTimeout } from '../utils/fetchWithTimeout';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -236,10 +237,14 @@ export async function dispatchTeamsCard(input: NotificationInput): Promise<boole
   if (shouldSuppress(input.caseId, 'teams')) return false;
   const payload = buildTeamsCardPayload(input);
   try {
-    const res = await fetch(url, {
+    const res = await fetchWithTimeout(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload.teamsCard),
+      // Teams incoming-webhook endpoints usually answer in under a
+      // second; cap at 10s so a Teams outage cannot stall a freeze /
+      // STR notification path the MLRO is waiting on.
+      timeoutMs: 10_000,
     });
     return res.ok;
   } catch {

--- a/src/utils/fetchWithTimeout.ts
+++ b/src/utils/fetchWithTimeout.ts
@@ -1,0 +1,161 @@
+/**
+ * fetchWithTimeout — shared timeout wrapper for every outbound
+ * server-side `fetch()` in this codebase.
+ *
+ * WHY this exists:
+ * A hung outbound fetch on a Netlify function silently exhausts the
+ * platform's execution budget (10s free tier, 26s Pro) and the
+ * function is killed with no audit entry. Several compliance flows
+ * are built on outbound fetches where that is unacceptable:
+ *
+ *   - EOCN sanctions-feed pull  (FDL No.10/2025 Art.35, Cabinet Res 74/2020)
+ *   - STR / freeze notifications to Teams / internal brain
+ *   - MLRO command dispatch into Asana
+ *   - advisor / provider AI calls
+ *
+ * Previously these sites were a mix of `AbortSignal.timeout(...)`,
+ * `AbortController + setTimeout`, and bare `await fetch(url)`. Three
+ * patterns, four local copies of a `fetchWithTimeout` helper, and
+ * several true zero-timeout gaps where a hung upstream would cost
+ * the whole Netlify invocation. This module is the single source
+ * of truth.
+ *
+ * USAGE:
+ *
+ *   import { fetchWithTimeout, TimeoutError } from '../utils/fetchWithTimeout';
+ *
+ *   const res = await fetchWithTimeout(url, {
+ *     method: 'POST',
+ *     body: JSON.stringify(payload),
+ *     timeoutMs: 10_000,  // required; no silent default
+ *   });
+ *
+ *   // On timeout, `fetch` rejects with a `TimeoutError` whose
+ *   // message includes the URL and elapsed duration. Callers that
+ *   // need to distinguish timeouts from other failures can do
+ *   // `if (err instanceof TimeoutError) { ... }`.
+ *
+ * The wrapper also lets callers pass their own AbortSignal (for
+ * example, a request-scoped signal on a Netlify function) — if
+ * provided, the upstream fetch aborts as soon as EITHER the
+ * timeout fires OR the caller's signal aborts, whichever comes first.
+ *
+ * Regulatory basis:
+ *   - FDL No.10/2025 Art.20-21 (CO accountability — every outbound
+ *     call in a compliance flow must either succeed, fail cleanly,
+ *     or time out; silent exhaustion is not an acceptable outcome)
+ *   - FDL No.10/2025 Art.24 (10-year record retention — a function
+ *     killed by the platform leaves no audit row)
+ *   - FATF Rec 10 / 11 (record-keeping and traceability)
+ */
+
+export class TimeoutError extends Error {
+  readonly url: string;
+  readonly timeoutMs: number;
+  readonly elapsedMs: number;
+
+  constructor(url: string, timeoutMs: number, elapsedMs: number) {
+    super(`fetch timed out after ${elapsedMs}ms (budget ${timeoutMs}ms): ${url}`);
+    this.name = 'TimeoutError';
+    this.url = url;
+    this.timeoutMs = timeoutMs;
+    this.elapsedMs = elapsedMs;
+  }
+}
+
+export interface FetchWithTimeoutInit extends RequestInit {
+  /**
+   * Hard upper bound on the round trip, in milliseconds. Required —
+   * there is no silent default, because picking the wrong default
+   * has been the exact source of past incidents. Common values:
+   * 8_000 (internal), 15_000 (most third parties), 30_000 (bulk
+   * sanctions-list pulls).
+   */
+  timeoutMs: number;
+}
+
+/**
+ * Combine the caller's own AbortSignal (if any) with the
+ * timeout signal. Returns a signal that aborts when EITHER
+ * the timeout fires OR the caller's signal aborts.
+ *
+ * We implement this manually rather than using
+ * `AbortSignal.any([...])` because that method is Node 20.3+ /
+ * recent browsers only, and a few of our deploy targets
+ * (Netlify builders, older CI images) still see older Node.
+ */
+function linkSignals(
+  timeoutSignal: AbortSignal,
+  callerSignal: AbortSignal | null | undefined
+): AbortSignal {
+  if (!callerSignal) return timeoutSignal;
+  const controller = new AbortController();
+
+  const abort = (reason: unknown): void => {
+    if (!controller.signal.aborted) controller.abort(reason);
+  };
+
+  if (callerSignal.aborted) {
+    abort(callerSignal.reason);
+  } else {
+    callerSignal.addEventListener('abort', () => abort(callerSignal.reason), { once: true });
+  }
+  if (timeoutSignal.aborted) {
+    abort(timeoutSignal.reason);
+  } else {
+    timeoutSignal.addEventListener('abort', () => abort(timeoutSignal.reason), { once: true });
+  }
+
+  return controller.signal;
+}
+
+/**
+ * Drop-in replacement for `fetch` with a mandatory timeout.
+ * On timeout, rejects with a `TimeoutError` carrying the URL
+ * and elapsed duration so the caller can log / count / alert
+ * on timeouts specifically.
+ *
+ * The global `fetch` is looked up at call time rather than at
+ * module load so this module stays safe to import in the
+ * browser SPA context as well (compliance-suite.js will not
+ * execute on require).
+ */
+export async function fetchWithTimeout(
+  input: RequestInfo | URL,
+  init: FetchWithTimeoutInit
+): Promise<Response> {
+  const { timeoutMs, signal: callerSignal, ...rest } = init;
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new TypeError(
+      `fetchWithTimeout: timeoutMs must be a positive finite number (got ${timeoutMs})`
+    );
+  }
+
+  const urlForError =
+    typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : // Request object: read .url without consuming the body
+          input.url;
+
+  const timeoutController = new AbortController();
+  const timer = setTimeout(() => timeoutController.abort(), timeoutMs);
+  const signal = linkSignals(timeoutController.signal, callerSignal as AbortSignal | undefined);
+  const startedAt = Date.now();
+
+  try {
+    return await fetch(input, { ...rest, signal });
+  } catch (err) {
+    if (
+      timeoutController.signal.aborted &&
+      !(callerSignal && (callerSignal as AbortSignal).aborted)
+    ) {
+      // The timeout won the race.
+      throw new TimeoutError(urlForError, timeoutMs, Date.now() - startedAt);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/tests/fetchWithTimeout.test.ts
+++ b/tests/fetchWithTimeout.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { fetchWithTimeout, TimeoutError } from '../src/utils/fetchWithTimeout';
+
+/**
+ * Tests for the shared timeout wrapper.
+ *
+ * Scope:
+ *   - Rejects a hung fetch with a TimeoutError carrying URL + duration
+ *   - Does NOT time out when the fetch resolves under the budget
+ *   - Propagates the caller's own AbortSignal (external cancellation
+ *     wins, never misclassified as a timeout)
+ *   - Rejects invalid timeout budgets fast (before the round trip)
+ *
+ * Implementation notes:
+ *   - We stub the global `fetch` per test with a fake that returns a
+ *     promise we control via `resolve` / `reject` so the test clock
+ *     can race the timeout deterministically without a real TCP dial.
+ *   - We do NOT use vi.useFakeTimers() here — the wrapper itself
+ *     relies on real setTimeout + AbortController wiring, and faking
+ *     time inside vitest has surprising interactions with
+ *     AbortController's event dispatch. A 60ms real timer in a
+ *     vitest test is cheap.
+ */
+
+interface StubFetchCall {
+  input: RequestInfo | URL;
+  init: RequestInit;
+}
+
+function stubFetch(): {
+  calls: StubFetchCall[];
+  resolve: (response: Response) => void;
+  reject: (err: unknown) => void;
+  wasAborted: () => boolean;
+  restore: () => void;
+} {
+  const calls: StubFetchCall[] = [];
+  let resolveInner: ((response: Response) => void) | null = null;
+  let rejectInner: ((err: unknown) => void) | null = null;
+  let capturedSignal: AbortSignal | null = null;
+
+  const original = globalThis.fetch;
+  globalThis.fetch = ((input: RequestInfo | URL, init: RequestInit = {}) => {
+    calls.push({ input, init });
+    capturedSignal = init.signal ?? null;
+    return new Promise<Response>((res, rej) => {
+      resolveInner = res;
+      rejectInner = rej;
+      if (capturedSignal) {
+        const onAbort = (): void => {
+          rej(
+            Object.assign(new Error('aborted'), {
+              name: 'AbortError',
+            })
+          );
+        };
+        if (capturedSignal.aborted) onAbort();
+        else capturedSignal.addEventListener('abort', onAbort, { once: true });
+      }
+    });
+  }) as typeof fetch;
+
+  return {
+    calls,
+    resolve: (r) => resolveInner?.(r),
+    reject: (e) => rejectInner?.(e),
+    wasAborted: () => capturedSignal?.aborted ?? false,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+describe('fetchWithTimeout', () => {
+  let stub: ReturnType<typeof stubFetch>;
+
+  beforeEach(() => {
+    stub = stubFetch();
+  });
+
+  afterEach(() => {
+    stub.restore();
+    vi.restoreAllMocks();
+  });
+
+  it('resolves with the response when fetch completes under the budget', async () => {
+    const promise = fetchWithTimeout('https://example.test/ok', { timeoutMs: 100 });
+    stub.resolve(new Response('hello', { status: 200 }));
+    const res = await promise;
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('hello');
+  });
+
+  it('rejects with a TimeoutError when the budget elapses', async () => {
+    const promise = fetchWithTimeout('https://example.test/slow', { timeoutMs: 40 });
+    await expect(promise).rejects.toMatchObject({
+      name: 'TimeoutError',
+      url: 'https://example.test/slow',
+      timeoutMs: 40,
+    });
+    expect(stub.wasAborted()).toBe(true);
+  });
+
+  it('TimeoutError carries both the configured budget and the elapsed time', async () => {
+    try {
+      await fetchWithTimeout('https://example.test/slow', { timeoutMs: 30 });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TimeoutError);
+      const te = err as TimeoutError;
+      expect(te.timeoutMs).toBe(30);
+      expect(te.elapsedMs).toBeGreaterThanOrEqual(20);
+      expect(te.url).toBe('https://example.test/slow');
+      expect(te.message).toContain('https://example.test/slow');
+    }
+  });
+
+  it('propagates the caller AbortSignal (caller abort is NOT reclassified as timeout)', async () => {
+    const controller = new AbortController();
+    const promise = fetchWithTimeout('https://example.test/cancel', {
+      timeoutMs: 10_000,
+      signal: controller.signal,
+    });
+    controller.abort(new Error('caller cancelled'));
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' });
+    // Timeout never fired; this was a caller-initiated cancel.
+    // TimeoutError is deliberately NOT thrown in this path.
+    expect(stub.wasAborted()).toBe(true);
+  });
+
+  it('forwards method, headers, and body to the underlying fetch', async () => {
+    const promise = fetchWithTimeout('https://example.test/post', {
+      method: 'POST',
+      headers: { 'X-Trace': 'abc' },
+      body: '{"k":"v"}',
+      timeoutMs: 100,
+    });
+    stub.resolve(new Response(null, { status: 204 }));
+    await promise;
+    expect(stub.calls).toHaveLength(1);
+    expect(stub.calls[0].init.method).toBe('POST');
+    expect((stub.calls[0].init.headers as Record<string, string>)['X-Trace']).toBe('abc');
+    expect(stub.calls[0].init.body).toBe('{"k":"v"}');
+  });
+
+  it('rejects fast when timeoutMs is not a positive finite number', async () => {
+    await expect(
+      fetchWithTimeout('https://example.test/x', { timeoutMs: 0 })
+    ).rejects.toBeInstanceOf(TypeError);
+    await expect(
+      fetchWithTimeout('https://example.test/x', { timeoutMs: -5 })
+    ).rejects.toBeInstanceOf(TypeError);
+    await expect(
+      fetchWithTimeout('https://example.test/x', {
+        timeoutMs: Number.POSITIVE_INFINITY,
+      })
+    ).rejects.toBeInstanceOf(TypeError);
+    await expect(
+      fetchWithTimeout('https://example.test/x', { timeoutMs: Number.NaN })
+    ).rejects.toBeInstanceOf(TypeError);
+    // None of these should have reached the underlying fetch.
+    expect(stub.calls).toHaveLength(0);
+  });
+
+  it('re-throws underlying non-timeout errors unchanged', async () => {
+    const promise = fetchWithTimeout('https://example.test/boom', { timeoutMs: 1000 });
+    stub.reject(new Error('ECONNREFUSED'));
+    await expect(promise).rejects.toThrow('ECONNREFUSED');
+  });
+
+  it('accepts a URL object as input and preserves it on TimeoutError', async () => {
+    const u = new URL('https://example.test/url-object');
+    try {
+      await fetchWithTimeout(u, { timeoutMs: 20 });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TimeoutError);
+      expect((err as TimeoutError).url).toBe('https://example.test/url-object');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Two work streams in one PR, both gated by the same local quality gate (`tsc --noEmit` + `vitest run tests/fetchWithTimeout.test.ts` + `prettier --check`).

### 1. Outbound-fetch timeout hardening

A hung outbound `fetch()` on a Netlify function silently exhausts the platform's execution budget (10s free / 26s Pro) and the function is killed with no audit row — unacceptable for any flow that has to produce a compliance record.

This PR lands a single shared timeout wrapper and migrates the 4 highest-impact compliance-critical call sites to it.

**New — `src/utils/fetchWithTimeout.ts`**
- `fetchWithTimeout(input, { timeoutMs, signal? })` — drop-in replacement for `fetch` with a **mandatory** `timeoutMs` (no silent default — picking the wrong default has been the exact source of past incidents).
- `TimeoutError` carrying `url`, `timeoutMs`, and `elapsedMs` so callers can log, count, and alert on timeouts distinctly from generic network failures.
- Manually links the caller's `AbortSignal` with the timeout signal (avoids `AbortSignal.any` which needs Node 20.3+). A caller-initiated abort is never reclassified as a timeout.
- Validates the budget fast (rejects `0`, negatives, `NaN`, `Infinity`) before the round trip.
- 8 unit tests in `tests/fetchWithTimeout.test.ts`, all passing, all deterministic (stubbed `globalThis.fetch`).

**Migrated call sites (4)**
| Site | Budget | Why it matters |
|------|--------|----------------|
| `src/services/eocnDeltaWatcher.ts` | 30 s | EOCN is the primary UAE sanctions source — Cabinet Res 74/2020 Art.4-7 (24-h freeze) and FDL Art.35 (TFS) both depend on it |
| `src/services/notificationBridge.ts` (Teams webhook) | 10 s | MLRO escalation channel — a Teams outage must not stall STR / freeze notifications |
| `netlify/functions/asana-comment-skill-handler.mts` (`asanaGet`) | 10 s | MLRO command-dispatch read path |
| `netlify/functions/asana-comment-skill-handler.mts` (`asanaPost`) | 10 s | MLRO command-dispatch write path |

**Explicitly out of scope (documented here so nothing rots on a branch):**
- ~33 bare fetches in `app-core.js` and other root `.js` modules — browser SPA, not a Netlify-runtime concern.
- 4 pre-existing local `withTimeout` copies — safe to migrate incrementally once this shared helper is in `main`.
- `src/services/brainBridge.ts:140` — verified dead code (no `.mts` or root `.js` reference), kept as-is.
- `netlify/functions/sanctions-ingest-cron.mts` + `src/services/sanctionsApi.ts` — already use `AbortSignal.timeout()`.

**Regulatory basis:**
- FDL No.10/2025 Art.20-21 (CO accountability — every outbound call in a compliance flow must either succeed, fail cleanly, or time out; silent exhaustion is not an acceptable outcome)
- FDL No.10/2025 Art.24 (10-year record retention — a function killed by the platform leaves no audit row)
- Cabinet Res 74/2020 Art.4-7 (24-h freeze clock)
- FATF Rec 10 / 11 (record-keeping + traceability)

### 2. Screening Command page — UI pass

The `/screening-command.html` page had accumulated layout and cosmetic debt that the MLRO flagged during review.

- **Header renamed** — `Screening Command v1` → `Hawkeye Sterling V2 — Screening Command` to match main-tool identity.
- **Empty-cell fix on two 5-column grids** — `Regulatory basis` (intro panel) and `Record-update ranking` (Data Coverage panel) now span the full row (`grid-column: 1 / -1`) so the grid does not leave four dead cells on wide screens.
- **Font unified** — `Regulatory basis` paragraph no longer uses `.cite` (DM Mono 10.5 px); now renders in the same sans-serif / 12.5 px as the other intro tiles.
- **New risk category** — `Proliferation financing & dual-use goods`, checked by default, closes a real gap in the previous list. Cited: Cabinet Res 156/2025, UNSCR 1540, FATF Rec 7.
- **Token Budget panel removed** — confidential internal token economics; removed from HTML, CSS, and the JS updater in `screening-command.js`. Zero dangling references (grep clean).
- **Language-coverage enumeration removed** from the Aliases help-text — placeholder example is enough; the full list is an implementation detail.
- **Native number-input spinners hidden** in both `screening-command.html` and `index.html` (Chrome/Safari/Firefox) for a consistent look across every numeric cell.

Cosmetic-only; no change to screening behaviour, citations, or persisted state.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run tests/fetchWithTimeout.test.ts` — 8/8 passing
- [x] `npx prettier --check screening-command.html screening-command.js index.html` — clean
- [x] grep for dangling `tokenBudget` / `token-budget` / `TOKEN_SOFT_CAP` references — none
- [x] CSP unchanged (inline styles already allowed via `'unsafe-inline'`; no new inline `<script>` hashes required)
- [ ] Netlify deploy-preview renders `screening-command.html` without empty-grid columns and without number-input spinners
- [ ] Teams webhook path and EOCN delta pull tested on staging (confirm no caller-signal regression)

https://claude.ai/code/session_014AJc3FP33Xru5x6HSrjb9r