### PR TITLE
feat(screening): drop Active-Officer picker; add Terrorism Financing + Tax Evasion categories

### DIFF
--- a/screening-command.html
+++ b/screening-command.html
@@ -1224,9 +1224,9 @@
     <div class="card" style="margin-top: 14px">
       <h2>MLRO Identity <span class="tag">Who is screening</span></h2>
       <p class="help-text" style="margin-top: -4px">
-        The UAE reporting entity has two authorised officers. Pick the one on duty before running a
-        screening — the name is written to the event as <i>Screened by</i> and auto-fills the MLRO
-        Disposition &gt; Reviewed by field. Saved locally (FDL Art.24 — 10-year audit trail).
+        The UAE reporting entity has two authorised officers. The Main MLRO name is written to every
+        screening event as <i>Screened by</i> and auto-fills the MLRO Disposition &gt; Reviewed by
+        field. Saved locally (FDL Art.24 — 10-year audit trail).
       </p>
       <div class="row-2">
         <div>
@@ -1240,7 +1240,7 @@
           />
         </div>
         <div>
-          <label for="mlroDeputyName">Deputy MLRO — full legal name *</label>
+          <label for="mlroDeputyName">Deputy MLRO — full legal name</label>
           <input
             type="text"
             id="mlroDeputyName"
@@ -1249,40 +1249,6 @@
             maxlength="128"
           />
         </div>
-      </div>
-      <label style="margin-top: 8px">Active officer for this session *</label>
-      <div
-        class="outcome-grid"
-        role="radiogroup"
-        aria-label="Active MLRO"
-        style="grid-template-columns: repeat(2, 1fr); gap: 8px"
-      >
-        <button
-          type="button"
-          class="outcome-btn mlro-role-btn"
-          data-role="main"
-          role="radio"
-          aria-checked="true"
-        >
-          <span class="outcome-head">
-            <span class="glyph" aria-hidden="true">&#9733;</span>
-            <span class="label">Main MLRO</span>
-          </span>
-          <span class="impact" id="mlroMainLabel">—</span>
-        </button>
-        <button
-          type="button"
-          class="outcome-btn mlro-role-btn"
-          data-role="deputy"
-          role="radio"
-          aria-checked="false"
-        >
-          <span class="outcome-head">
-            <span class="glyph" aria-hidden="true">&#9734;</span>
-            <span class="label">Deputy MLRO</span>
-          </span>
-          <span class="impact" id="mlroDeputyLabel">—</span>
-        </button>
       </div>
       <p class="help-text" style="margin-top: 8px">
         <b>Screened by:</b> <span id="mlroActiveBadge" class="tag">—</span>
@@ -1557,6 +1523,29 @@
             >
           </span>
         </label>
+        <label class="list-check">
+          <input type="checkbox" data-category="terrorismFinancing" data-tier="enhanced" checked />
+          <span class="list-label"
+            >Terrorism financing &amp; designated terrorist entities
+            <span class="list-sub"
+              >TF risk screen — UNSCR 1267 / 1373 / 2462 designations, terrorist organisations,
+              foreign terrorist fighters, NPO / charity abuse channels, hawala / informal-value
+              routes. FDL No.10/2025 Art.35 · Cabinet Res 74/2020 · FATF Rec 5 / 6 / 8.</span
+            >
+          </span>
+        </label>
+        <label class="list-check">
+          <input type="checkbox" data-category="taxEvasion" data-tier="enhanced" checked />
+          <span class="list-label"
+            >Tax evasion &amp; tax crimes
+            <span class="list-sub"
+              >Tax-crime predicate screen — direct / indirect tax evasion, VAT carousel fraud,
+              customs undervaluation, trade-based laundering, OECD CRS / FATCA non-compliance, UAE
+              Federal Tax Authority enforcement. FDL No.10/2025 Art.2 (predicate offence) · FATF Rec
+              3.</span
+            >
+          </span>
+        </label>
       </div>
     </div>
 
@@ -1732,9 +1721,6 @@
 
         <p class="help-text" style="margin-top: 6px">
           <b>Screened by:</b> <span id="mlroActiveBadgeRun" class="tag">—</span>
-          <span class="token-hint"
-            >&nbsp;Change the active officer in the <i>MLRO Identity</i> card above.</span
-          >
         </p>
         <button id="screenBtn" type="button">Run Screening</button>
         <div id="screenMsg"></div>

--- a/screening-command.js
+++ b/screening-command.js
@@ -24,7 +24,6 @@
   const TOKEN_KEY = 'hawkeye.watchlist.adminToken';
   const MLRO_MAIN_KEY = 'hawkeye.mlro.main';
   const MLRO_DEPUTY_KEY = 'hawkeye.mlro.deputy';
-  const MLRO_ACTIVE_KEY = 'hawkeye.mlro.active';
   const TOKEN_MIN = 32;
   const TOKEN_HEX_RE = /^[a-f0-9]+$/i;
   const RATIONALE_MIN = 20;
@@ -55,13 +54,10 @@
   tokenInput.addEventListener('input', saveToken);
   window.addEventListener('beforeunload', saveToken);
 
-  // ─── MLRO identity (main + deputy, persisted + active-officer toggle) ───
+  // ─── MLRO identity (main + deputy, persisted; screener = Main MLRO) ───
   const mlroMainNameInput = $('mlroMainName');
   const mlroDeputyNameInput = $('mlroDeputyName');
-  const mlroMainLabel = $('mlroMainLabel');
-  const mlroDeputyLabel = $('mlroDeputyLabel');
   const mlroActiveBadge = $('mlroActiveBadge');
-  const mlroRoleBtns = document.querySelectorAll('.mlro-role-btn');
 
   function lsGet(key) {
     try {
@@ -79,27 +75,13 @@
     }
   }
 
-  let activeMlroRole = lsGet(MLRO_ACTIVE_KEY) || 'main';
-
   function activeMlroName() {
-    const main = (mlroMainNameInput.value || '').trim();
-    const deputy = (mlroDeputyNameInput.value || '').trim();
-    return activeMlroRole === 'deputy' ? deputy : main;
+    return (mlroMainNameInput.value || '').trim();
   }
 
   function refreshMlroUi() {
-    const main = (mlroMainNameInput.value || '').trim();
-    const deputy = (mlroDeputyNameInput.value || '').trim();
-    if (mlroMainLabel) mlroMainLabel.textContent = main || 'Not set';
-    if (mlroDeputyLabel) mlroDeputyLabel.textContent = deputy || 'Not set';
-    mlroRoleBtns.forEach((btn) => {
-      const isActive = btn.getAttribute('data-role') === activeMlroRole;
-      btn.classList.toggle('selected', isActive);
-      btn.setAttribute('aria-checked', isActive ? 'true' : 'false');
-    });
     const name = activeMlroName();
-    const roleLabel = activeMlroRole === 'deputy' ? 'Deputy MLRO' : 'Main MLRO';
-    const badgeText = name ? `${name} — ${roleLabel}` : `(${roleLabel} — name missing)`;
+    const badgeText = name ? `${name} — Main MLRO` : '(Main MLRO — name missing)';
     if (mlroActiveBadge) mlroActiveBadge.textContent = badgeText;
     const runBadge = $('mlroActiveBadgeRun');
     if (runBadge) runBadge.textContent = badgeText;
@@ -116,14 +98,6 @@
   });
   mlroDeputyNameInput.addEventListener('input', () => {
     lsSet(MLRO_DEPUTY_KEY, mlroDeputyNameInput.value.trim());
-    refreshMlroUi();
-  });
-  mlroRoleBtns.forEach((btn) => {
-    btn.addEventListener('click', () => {
-      activeMlroRole = btn.getAttribute('data-role') || 'main';
-      lsSet(MLRO_ACTIVE_KEY, activeMlroRole);
-      refreshMlroUi();
-    });
   });
 
   refreshMlroUi();
@@ -927,7 +901,7 @@
     if (!screener) {
       showMessage(
         screenMsg,
-        'Screener name required — set the active MLRO identity above before running a screening.',
+        'Main MLRO name required — fill it in above before running a screening.',
         'error'
       );
       return;
@@ -951,7 +925,7 @@
       adverseMediaPredicates: isAdverseMediaEnabled() ? allPredicateKeys() : undefined,
       createAsanaTask: true,
       screenedBy: screener,
-      screenedByRole: activeMlroRole === 'deputy' ? 'deputy_mlro' : 'main_mlro',
+      screenedByRole: 'main_mlro',
     };
     const result = await apiPost(SCREENING_ENDPOINT, body);
     if (!result.ok) {


### PR DESCRIPTION
## Summary

- MLRO Identity card: remove the "Active officer for this session" radiogroup. Main MLRO is always the screener; Deputy name is still captured in the audit blob but not used as session screener. Both names are persisted in localStorage (FDL Art.24 — 10-year audit trail).
- Risk Categories: add two new default-ON categories, each with full regulatory citations:
  - **Terrorism financing & designated terrorist entities** — UNSCR 1267 / 1373 / 2462, NPO / charity abuse, hawala channels. FDL No.10/2025 Art.35 · Cabinet Res 74/2020 · FATF Rec 5 / 6 / 8.
  - **Tax evasion & tax crimes** — VAT carousel fraud, customs undervaluation, trade-based laundering, OECD CRS / FATCA non-compliance, UAE FTA enforcement. FDL No.10/2025 Art.2 (predicate offence) · FATF Rec 3.
- JS cleanup: drop `MLRO_ACTIVE_KEY`, `activeMlroRole`, `mlroMainLabel`, `mlroDeputyLabel`, `mlroRoleBtns`, and all role-toggle handlers. `screenedByRole` is now hard-coded to `main_mlro` in the screening payload.

## Regulatory basis

- FDL No.10/2025 Art.2 (predicate offences — tax crimes included)
- FDL No.10/2025 Art.24 (10-year record retention for MLRO identity + screening events)
- FDL No.10/2025 Art.35 (TFS — terrorist financing screening obligation)
- Cabinet Res 74/2020 (TFS execution — UNSCR 1267/1373/2462)
- FATF Rec 3 (ML offence — tax crimes as predicate)
- FATF Rec 5 / 6 / 8 (CFT — NPO sector abuse + financial-sector TF controls)

## Test plan

- [ ] Load `screening-command.html` locally — MLRO Identity card shows only two name inputs + "Screened by" badge (no toggle buttons)
- [ ] Type into Main MLRO field → badge in card and near Run button updates to `{name} — Main MLRO`
- [ ] Clear Main MLRO name → Run Screening shows the "Main MLRO name required" error instead of silently posting
- [ ] Risk Categories grid shows 10 boxes, all checked on first load
- [ ] Terrorism Financing and Tax Evasion appear at the end of the list with their full citations
- [ ] `prettier --check` + `eslint screening-command.js` clean

https://claude.ai/code/session_014AJc3FP33Xru5x6HSrjb9r