### PR TITLE
style(screening): pink gradient on Hawkeye Sterling V2 header

### DIFF
--- a/screening-command.html
+++ b/screening-command.html
@@ -115,7 +115,7 @@
         font-weight: 600;
         letter-spacing: 3px;
         text-transform: uppercase;
-        background: var(--gold-grad);
+        background: linear-gradient(135deg, #ff3d8a 0%, #ff7ab0 45%, #ffb3d1 100%);
         -webkit-background-clip: text;
         background-clip: text;
         color: transparent;


### PR DESCRIPTION
## Summary

Swap the gold gradient on the Screening Command page `<h1>` to a pink gradient (`#ff3d8a → #ff7ab0 → #ffb3d1`).

Scope is limited to `screening-command.html`:
- The global `--gold-grad` CSS variable is unchanged.
- Every other header on the site (main tool, cards) is unchanged.

## Test plan
- [ ] Load `/screening-command.html` — title renders in the pink gradient
- [ ] Main page `index.html` still shows gold header

https://claude.ai/code/session_014AJc3FP33Xru5x6HSrjb9r