### PR TITLE
feat(screening): drop duplicate Risk Categories + add 6 UAE audit-coverage tiles

### DIFF
--- a/screening-command.html
+++ b/screening-command.html
@@ -1316,6 +1316,60 @@
             watch / regulatory / LE lists.
           </div>
         </div>
+        <div>
+          <div class="c-h">UBO &amp; control-chain coverage</div>
+          <div class="c-sub">
+            Beneficial owners &#x2265;&nbsp;25% traced per Cabinet Decision 109/2023, re-verified
+            within 15 working days of any ownership change. Multi-hop ownership graph captures
+            nominee directors, mass-incorporation addresses and suspected shell / pass-through
+            structures for MoE UBO-register reconciliation.
+          </div>
+        </div>
+        <div>
+          <div class="c-h">Source-of-wealth / source-of-funds</div>
+          <div class="c-sub">
+            SoW &amp; SoF evidence captured for every EDD customer &mdash; salary, business revenue,
+            investment, inheritance, sale proceeds &mdash; with supporting documents hashed into the
+            screening event. Cabinet Res 134/2025 Art.14 &middot; FATF Rec 10.
+          </div>
+        </div>
+        <div>
+          <div class="c-h">Transaction-monitoring signals</div>
+          <div class="c-sub">
+            Cash-deposit velocity, structuring near the AED&nbsp;55,000 DPMS CTR trigger and the
+            AED&nbsp;60,000 cross-border cash threshold, wire-transfer chains, trade-based
+            laundering indicators and counterparty-risk scoring &mdash; all tied to the subject on
+            the screening event. MoE Circular 08/AML/2021 &middot; Cabinet Res 134/2025 Art.16
+            &middot; FATF Rec 10 / 20.
+          </div>
+        </div>
+        <div>
+          <div class="c-h">goAML filing index</div>
+          <div class="c-sub">
+            Full STR / SAR / CTR / DPMSR / CNMR filing history per entity, with filing reference
+            numbers, submission timestamps and UAE FIU acknowledgement receipts &mdash; retained 10
+            years so audit can prove timely filing. FDL No.10/2025 Art.26-27 (filing) &middot;
+            Art.24 (retention).
+          </div>
+        </div>
+        <div>
+          <div class="c-h">List provenance &amp; lineage</div>
+          <div class="c-sub">
+            Every source list carries a full provenance envelope &mdash; origin URL, publisher
+            signature, SHA-256 checksum, <i>fetchedAt</i> and <i>listPublishedAt</i> &mdash; so MoE
+            / LBMA / internal audit can reproduce the exact data surface that fed any prior
+            screening. FATF Rec 22 / 23 traceability.
+          </div>
+        </div>
+        <div>
+          <div class="c-h">Device / session / screener context</div>
+          <div class="c-sub">
+            Every screening event binds the MLRO identity, token hash, IP, user-agent, session id
+            and server timestamp to the result &mdash; sealed into an append-only audit record so
+            repudiation is impossible. FDL No.10/2025 Art.20-21 (CO accountability) &middot; Art.24
+            (10-year retention).
+          </div>
+        </div>
         <div class="coverage-wide">
           <div class="c-h">Record-update ranking</div>
           <div class="c-sub">
@@ -1450,34 +1504,11 @@
           </span>
         </label>
         <label class="list-check">
-          <input type="checkbox" data-category="globalSanctions" data-tier="enhanced" checked />
-          <span class="list-label"
-            >Global sanctions lists
-            <span class="list-sub"
-              >UN, OFAC SDN + Consolidated, EU CFSP, UK OFSI, UAE EOCN (mandatory)</span
-            >
-          </span>
-        </label>
-        <label class="list-check">
           <input type="checkbox" data-category="narrativeSanctions" data-tier="enhanced" checked />
           <span class="list-label"
             >Narrative &amp; implicit sanctions
             <span class="list-sub"
               >Sectoral / 50-percent-rule / CAPTA / SSI / country-of-concern exposure</span
-            >
-          </span>
-        </label>
-        <label class="list-check">
-          <input
-            type="checkbox"
-            data-category="regulatoryEnforcement"
-            data-tier="enhanced"
-            checked
-          />
-          <span class="list-label"
-            >Global regulatory &amp; law-enforcement lists
-            <span class="list-sub"
-              >FCA, FINRA, FinCEN, SEC, DOJ, Interpol, Europol, national debarments</span
             >
           </span>
         </label>


### PR DESCRIPTION
## Summary

Two independent Screening-Command changes, bundled because they both reshape the audit-surface of the page.

### 1. Remove duplicate Risk Categories

The **Global sanctions lists** and **Global regulatory & law-enforcement lists** tiles in Risk Categories repeat the boxes already shown in the **Mandatory UAE Lists** and **Enhanced Controls** panels directly above. Duplication creates drift risk (turn off one, leave the other on) and adds no screening signal. Removed.

### 2. Add 6 UAE audit-coverage tiles to Data Coverage

Each tile documents what every screening event captures, so MoE / LBMA / internal audit can reproduce any prior screening from the event record alone.

| Tile | Regulatory basis |
|---|---|
| UBO & control-chain coverage | Cabinet Decision 109/2023 |
| Source-of-wealth / source-of-funds | Cabinet Res 134/2025 Art.14 · FATF Rec 10 |
| Transaction-monitoring signals | MoE Circular 08/AML/2021 · Cabinet Res 134/2025 Art.16 · FATF Rec 10/20 |
| goAML filing index | FDL No.10/2025 Art.26-27 · Art.24 |
| List provenance & lineage | FATF Rec 22/23 |
| Device / session / screener context | FDL No.10/2025 Art.20-21 · Art.24 |

No CSS or JS changes — tiles reuse the existing `.coverage-grid` layout.

## Test plan

- [ ] Load `/screening-command.html` — Risk Categories shows 8 boxes (was 10), missing tiles are the two "Global ..." ones
- [ ] Default-ON state preserved on the remaining boxes
- [ ] Data Coverage grid shows the six new tiles before the full-width "Record-update ranking" row
- [ ] Regulatory citations render with the correct articles / circulars
- [ ] `prettier --check` clean

https://claude.ai/code/session_014AJc3FP33Xru5x6HSrjb9r