### PR TITLE
feat(screening): in-page Generate / Show / Copy token buttons

### DIFF
--- a/screening-command.html
+++ b/screening-command.html
@@ -384,6 +384,45 @@
         color: var(--muted);
         font-size: 11px;
       }
+      .token-hint code {
+        font-family: 'DM Mono', monospace;
+        font-size: 10.5px;
+        color: var(--accent);
+      }
+      .token-row {
+        display: flex;
+        gap: 6px;
+        align-items: stretch;
+      }
+      .token-row input {
+        flex: 1;
+        min-width: 0;
+      }
+      .token-gen-btn {
+        padding: 0 12px;
+        font-family: 'DM Mono', monospace;
+        font-size: 11px;
+        letter-spacing: 1px;
+        text-transform: uppercase;
+        background: transparent;
+        color: var(--accent);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        cursor: pointer;
+        white-space: nowrap;
+      }
+      .token-gen-btn:hover {
+        background: rgba(255, 255, 255, 0.04);
+      }
+      .token-msg {
+        margin-top: 6px;
+        font-size: 11px;
+        color: var(--accent);
+        min-height: 14px;
+      }
+      .token-msg.err {
+        color: #ff6b6b;
+      }
       .stat {
         display: flex;
         gap: 10px;
@@ -1259,17 +1298,46 @@
     <div class="card" style="margin-top: 14px">
       <h2>Authentication <span class="tag">Required</span></h2>
       <label for="token">Hawkeye brain token</label>
-      <input
-        type="password"
-        id="token"
-        placeholder="Paste your HAWKEYE_BRAIN_TOKEN"
-        autocomplete="off"
-        spellcheck="false"
-      />
+      <div class="token-row">
+        <input
+          type="password"
+          id="token"
+          placeholder="Paste your HAWKEYE_BRAIN_TOKEN"
+          autocomplete="off"
+          spellcheck="false"
+        />
+        <button
+          type="button"
+          id="tokenGenBtn"
+          class="token-gen-btn"
+          title="Generate a fresh 32-byte CSPRNG token (local only)"
+        >
+          Generate
+        </button>
+        <button
+          type="button"
+          id="tokenRevealBtn"
+          class="token-gen-btn token-reveal-btn"
+          title="Show / hide the token"
+        >
+          Show
+        </button>
+        <button
+          type="button"
+          id="tokenCopyBtn"
+          class="token-gen-btn"
+          title="Copy token to clipboard"
+        >
+          Copy
+        </button>
+      </div>
       <span class="token-hint"
-        >Saved locally in this browser only. Never sent anywhere except to your own compliance
-        API.</span
+        >Saved locally in this browser only. Never sent anywhere except to your own compliance API.
+        <b>Generate</b> produces a 64-char hex token using <code>window.crypto</code> &mdash; paste
+        the same string into <code>HAWKEYE_BRAIN_TOKEN</code> on Netlify (Site settings &rarr;
+        Environment variables) and redeploy.</span
       >
+      <div id="tokenMsg" class="token-msg"></div>
     </div>
 
     <!-- Data coverage contract ────────────────────────────────────── -->

--- a/screening-command.js
+++ b/screening-command.js
@@ -54,6 +54,87 @@
   tokenInput.addEventListener('input', saveToken);
   window.addEventListener('beforeunload', saveToken);
 
+  // ─── Token generator / reveal / copy ─────────────────────────────
+  //
+  // Generates a 32-byte CSPRNG value via window.crypto.getRandomValues
+  // and formats it as 64 lowercase hex chars — the exact format the
+  // server's auth middleware expects (TOKEN_MIN=32, ^[a-f0-9]+$).
+  // Never leaves the browser. The user must paste the same value into
+  // HAWKEYE_BRAIN_TOKEN on Netlify and redeploy.
+  const tokenGenBtn = $('tokenGenBtn');
+  const tokenRevealBtn = $('tokenRevealBtn');
+  const tokenCopyBtn = $('tokenCopyBtn');
+  const tokenMsg = $('tokenMsg');
+
+  function setTokenMsg(text, isError) {
+    if (!tokenMsg) return;
+    tokenMsg.textContent = text || '';
+    tokenMsg.classList.toggle('err', !!isError);
+  }
+
+  function generateToken() {
+    if (!window.crypto || !window.crypto.getRandomValues) {
+      setTokenMsg(
+        'window.crypto unavailable in this browser — cannot generate a secure token.',
+        true
+      );
+      return;
+    }
+    const bytes = new Uint8Array(32);
+    window.crypto.getRandomValues(bytes);
+    let hex = '';
+    for (let i = 0; i < bytes.length; i++) {
+      hex += bytes[i].toString(16).padStart(2, '0');
+    }
+    tokenInput.value = hex;
+    saveToken();
+    setTokenMsg(
+      'New 64-char hex token generated + saved in this browser. Paste the same value into HAWKEYE_BRAIN_TOKEN on Netlify and redeploy.',
+      false
+    );
+  }
+
+  async function copyToken() {
+    const value = tokenInput.value.trim();
+    if (!value) {
+      setTokenMsg('Nothing to copy — token field is empty.', true);
+      return;
+    }
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        await navigator.clipboard.writeText(value);
+        setTokenMsg('Token copied to clipboard.', false);
+      } else {
+        // Fallback for older / restricted browsers — select the input
+        const wasPassword = tokenInput.type === 'password';
+        if (wasPassword) tokenInput.type = 'text';
+        tokenInput.select();
+        const ok = document.execCommand && document.execCommand('copy');
+        if (wasPassword) tokenInput.type = 'password';
+        setTokenMsg(
+          ok ? 'Token copied to clipboard.' : 'Copy failed — select the field and copy manually.',
+          !ok
+        );
+      }
+    } catch (_err) {
+      setTokenMsg('Copy failed — select the field and copy manually.', true);
+    }
+  }
+
+  function toggleReveal() {
+    if (tokenInput.type === 'password') {
+      tokenInput.type = 'text';
+      if (tokenRevealBtn) tokenRevealBtn.textContent = 'Hide';
+    } else {
+      tokenInput.type = 'password';
+      if (tokenRevealBtn) tokenRevealBtn.textContent = 'Show';
+    }
+  }
+
+  if (tokenGenBtn) tokenGenBtn.addEventListener('click', generateToken);
+  if (tokenRevealBtn) tokenRevealBtn.addEventListener('click', toggleReveal);
+  if (tokenCopyBtn) tokenCopyBtn.addEventListener('click', copyToken);
+
   // ─── MLRO identity (main + deputy, persisted; screener = Main MLRO) ───
   const mlroMainNameInput = $('mlroMainName');
   const mlroDeputyNameInput = $('mlroDeputyName');


### PR DESCRIPTION
## Summary

Adds three buttons next to the Hawkeye brain token field on the Screening Command page:

- **Generate** — `window.crypto.getRandomValues(32 bytes)` → 64-char lowercase hex, matches the server's `TOKEN_MIN=32` + `/^[a-f0-9]+$/` auth rule. Value is auto-saved to localStorage, never leaves the browser.
- **Show / Hide** — toggles the password input so operators can read the token they just generated.
- **Copy** — `navigator.clipboard.writeText` with a select-and-`execCommand('copy')` fallback for locked-down browsers.

On-screen hint spells out the next step — paste the same value into `HAWKEYE_BRAIN_TOKEN` on Netlify (Site settings → Environment variables) and redeploy.

Replaces the previous need to open the DevTools console or use `openssl rand -hex 32` from a terminal for operators who don't have either available.

## Security

- No new network call — all three operations are local to the browser.
- CSP-compliant: no inline scripts, no `eval`, no external CDN.
- Clipboard failure falls back to selecting the input so the user can copy manually.

## Regulatory basis

- **FDL No.10/2025 Art.20-21** — CO accountability requires the MLRO to be able to independently rotate the screening API secret without depending on third-party sites that might log the generated value.

## Test plan

- [ ] Click Generate → input fills with 64 lowercase hex chars; status message confirms
- [ ] Click Show → token becomes visible; click Hide → hidden again
- [ ] Click Copy → clipboard contains the token (paste into another field to verify)
- [ ] Generated token, when pasted into Netlify and the page both, makes `Run Screening` succeed
- [ ] In an iframe / very old browser (no `navigator.clipboard`), Copy still works via fallback

https://claude.ai/code/session_014AJc3FP33Xru5x6HSrjb9r