### PR TITLE
fix(timeouts): consolidate fetch call sites onto shared fetchWithTimeout helper

### DIFF
--- a/netlify/functions/asana-migrate-schema.mts
+++ b/netlify/functions/asana-migrate-schema.mts
@@ -29,6 +29,7 @@ import {
   type FieldDelta,
   type FieldType,
 } from '../../src/services/asanaSchemaMigrator';
+import { fetchWithTimeout } from '../../src/utils/fetchWithTimeout';
 
 const AUDIT_STORE = 'asana-schema-migrations';
 const ASANA_BASE_URL = 'https://app.asana.com/api/1.0';
@@ -51,10 +52,10 @@ async function fetchExistingFields(
   token: string
 ): Promise<ExistingField[]> {
   const url = `${ASANA_BASE_URL}/workspaces/${workspaceGid}/custom_fields?opt_fields=name,type,enum_options.name`;
-  const res = await fetch(url, {
+  const res = await fetchWithTimeout(url, {
     method: 'GET',
     headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' },
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    timeoutMs: FETCH_TIMEOUT_MS,
   });
   if (!res.ok) {
     throw new Error(`Asana fetch failed: ${res.status} ${res.statusText}`);
@@ -86,10 +87,10 @@ async function fetchExistingFieldsWithGids(
   token: string
 ): Promise<AsanaFieldFull[]> {
   const url = `${ASANA_BASE_URL}/workspaces/${workspaceGid}/custom_fields?opt_fields=name,type,resource_subtype,enum_options.gid,enum_options.name`;
-  const res = await fetch(url, {
+  const res = await fetchWithTimeout(url, {
     method: 'GET',
     headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' },
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    timeoutMs: FETCH_TIMEOUT_MS,
   });
   if (!res.ok) {
     throw new Error(`Asana fetch failed: ${res.status} ${res.statusText}`);
@@ -117,7 +118,7 @@ async function createCustomField(
   if (delta.type === 'enum' && delta.missingOptions && delta.missingOptions.length > 0) {
     data.enum_options = delta.missingOptions.map((name) => ({ name }));
   }
-  const res = await fetch(`${ASANA_BASE_URL}/custom_fields`, {
+  const res = await fetchWithTimeout(`${ASANA_BASE_URL}/custom_fields`, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,
@@ -125,7 +126,7 @@ async function createCustomField(
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({ data }),
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    timeoutMs: FETCH_TIMEOUT_MS,
   });
   if (!res.ok) {
     const text = await res.text().catch(() => '');
@@ -147,7 +148,7 @@ async function addEnumOptions(
 ): Promise<number> {
   let added = 0;
   for (const name of optionNames) {
-    const res = await fetch(
+    const res = await fetchWithTimeout(
       `${ASANA_BASE_URL}/custom_fields/${fieldGid}/enum_options`,
       {
         method: 'POST',
@@ -157,7 +158,7 @@ async function addEnumOptions(
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ data: { name } }),
-        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        timeoutMs: FETCH_TIMEOUT_MS,
       }
     );
     if (!res.ok) {

--- a/netlify/functions/asana-proxy.mts
+++ b/netlify/functions/asana-proxy.mts
@@ -30,6 +30,7 @@
 import type { Config, Context } from '@netlify/functions';
 import { authenticate } from './middleware/auth.mts';
 import { checkRateLimit } from './middleware/rate-limit.mts';
+import { fetchWithTimeout } from '../../src/utils/fetchWithTimeout';
 
 const ASANA_BASE_URL = 'https://app.asana.com/api/1.0';
 // Pathname of ASANA_BASE_URL, cached. Used by the normalisation-bypass
@@ -187,11 +188,11 @@ export default async (req: Request, context: Context): Promise<Response> => {
 
   let upstream: Response;
   try {
-    upstream = await fetch(target.toString(), {
+    upstream = await fetchWithTimeout(target.toString(), {
       method,
       headers: upstreamHeaders,
       body: upstreamBody,
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      timeoutMs: FETCH_TIMEOUT_MS,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/netlify/functions/brain.mts
+++ b/netlify/functions/brain.mts
@@ -25,6 +25,7 @@ import { getStore } from "@netlify/blobs";
 import { randomUUID } from "node:crypto";
 import { checkRateLimit } from "./middleware/rate-limit.mts";
 import { authenticate } from "./middleware/auth.mts";
+import { fetchWithTimeout } from "../../src/utils/fetchWithTimeout";
 
 // CORS headers applied to both preflight and actual responses. Single
 // allow-origin per env var so cross-site requests can't forge identity.
@@ -256,7 +257,7 @@ async function publishCachet(event: BrainEvent, decision: RouteDecision): Promis
 
   const status = event.severity === "critical" ? 2 /* Identified */ : 1 /* Investigating */;
   try {
-    const res = await fetch(`${base.replace(/\/+$/, "")}/api/v1/incidents`, {
+    const res = await fetchWithTimeout(`${base.replace(/\/+$/, "")}/api/v1/incidents`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -268,7 +269,7 @@ async function publishCachet(event: BrainEvent, decision: RouteDecision): Promis
         status,
         visible: 1,
       }),
-      signal: AbortSignal.timeout(8000),
+      timeoutMs: 8000,
     });
     if (!res.ok) {
       return { published: false, reason: `cachet_http_${res.status}` };

--- a/netlify/functions/cbuae-fx-cron.mts
+++ b/netlify/functions/cbuae-fx-cron.mts
@@ -20,6 +20,7 @@
 import type { Config } from '@netlify/functions';
 import { getStore } from '@netlify/blobs';
 import { USD_TO_AED } from '../../src/domain/constants';
+import { fetchWithTimeout } from '../../src/utils/fetchWithTimeout';
 
 const FX_STORE = 'fx-rates';
 const FX_AUDIT_STORE = 'fx-rates-audit';
@@ -80,7 +81,7 @@ export default async (): Promise<Response> => {
   let snapshot: FxSnapshot;
 
   try {
-    const response = await fetch(CBUAE_URL, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+    const response = await fetchWithTimeout(CBUAE_URL, { timeoutMs: FETCH_TIMEOUT_MS });
     if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
     const html = await response.text();
     const rates = parseCBUAERates(html);

--- a/netlify/functions/expiry-scan-cron.mts
+++ b/netlify/functions/expiry-scan-cron.mts
@@ -38,6 +38,7 @@ import { getStore } from '@netlify/blobs';
 import { checkRateLimit } from './middleware/rate-limit.mts';
 import { authenticate } from './middleware/auth.mts';
 import type { CustomerProfileV2 } from '../../src/domain/customerProfile';
+import { fetchWithTimeout } from '../../src/utils/fetchWithTimeout';
 import { scanExpiries, type ExpiryReport } from '../../src/services/customerExpiryAlerter';
 import {
   buildExpiryEmitReport,
@@ -222,11 +223,11 @@ export default async (req: Request, context: Context): Promise<Response> => {
     // Step 1: list existing sections to resolve section names → GIDs.
     let sectionMap: Map<string, string>;
     try {
-      const sectionsRes = await fetch(
+      const sectionsRes = await fetchWithTimeout(
         `https://app.asana.com/api/1.0/projects/${encodeURIComponent(kycProjectGid)}/sections?opt_fields=gid,name&limit=100`,
         {
           headers: { Authorization: `Bearer ${asanaToken}`, Accept: 'application/json' },
-          signal: AbortSignal.timeout(20_000),
+          timeoutMs: 20_000,
         }
       );
       if (!sectionsRes.ok) throw new Error(`HTTP ${sectionsRes.status}`);
@@ -253,9 +254,9 @@ export default async (req: Request, context: Context): Promise<Response> => {
       let nextUrl: string | null =
         `https://app.asana.com/api/1.0/projects/${encodeURIComponent(kycProjectGid)}/tasks?opt_fields=name&limit=100`;
       while (nextUrl) {
-        const tasksRes = await fetch(nextUrl, {
+        const tasksRes = await fetchWithTimeout(nextUrl, {
           headers: { Authorization: `Bearer ${asanaToken}`, Accept: 'application/json' },
-          signal: AbortSignal.timeout(20_000),
+          timeoutMs: 20_000,
         });
         if (!tasksRes.ok) throw new Error(`HTTP ${tasksRes.status}`);
         const tasksJson = (await tasksRes.json()) as {
@@ -288,7 +289,7 @@ export default async (req: Request, context: Context): Promise<Response> => {
       const dueOn = dueParts ? `${dueParts[3]}-${dueParts[2]}-${dueParts[1]}` : undefined;
 
       try {
-        const createRes = await fetch('https://app.asana.com/api/1.0/tasks', {
+        const createRes = await fetchWithTimeout('https://app.asana.com/api/1.0/tasks', {
           method: 'POST',
           headers: {
             Authorization: `Bearer ${asanaToken}`,
@@ -305,7 +306,7 @@ export default async (req: Request, context: Context): Promise<Response> => {
               tags: [],
             },
           }),
-          signal: AbortSignal.timeout(15_000),
+          timeoutMs: 15_000,
         });
         if (!createRes.ok) {
           // HTTP error (400, 401, 429, 500 etc.) — count as dispatch error.

--- a/netlify/functions/regulatory-horizon-cron.mts
+++ b/netlify/functions/regulatory-horizon-cron.mts
@@ -34,6 +34,7 @@
 
 import type { Config } from '@netlify/functions';
 import { getStore } from '@netlify/blobs';
+import { fetchWithTimeout } from '../../src/utils/fetchWithTimeout';
 
 const HORIZON_STORE = 'regulatory-horizon';
 const SEEN_STORE = 'regulatory-horizon-seen';
@@ -136,9 +137,9 @@ interface HorizonItem {
   triggersPolicyDeadline: boolean;
 }
 
-async function fetchWithTimeout(url: string, timeoutMs: number): Promise<string> {
-  const res = await fetch(url, {
-    signal: AbortSignal.timeout(timeoutMs),
+async function fetchFeedBody(url: string, timeoutMs: number): Promise<string> {
+  const res = await fetchWithTimeout(url, {
+    timeoutMs,
     headers: { 'user-agent': 'compliance-analyzer regulatory-horizon-cron/1.0' },
   });
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
@@ -188,7 +189,7 @@ async function sha256(input: string): Promise<string> {
 
 async function processFeed(feed: RegulatoryFeed, seen: Set<string>): Promise<HorizonItem[]> {
   try {
-    const body = await fetchWithTimeout(feed.url, FETCH_TIMEOUT_MS);
+    const body = await fetchFeedBody(feed.url, FETCH_TIMEOUT_MS);
     const items: HorizonItem[] = [];
 
     if (feed.kind === 'rss') {

--- a/netlify/functions/sanctions-feed-debug.mts
+++ b/netlify/functions/sanctions-feed-debug.mts
@@ -26,6 +26,7 @@
  */
 
 import type { Config } from '@netlify/functions';
+import { fetchWithTimeout } from '../../src/utils/fetchWithTimeout';
 
 const INGEST_USER_AGENT =
   'Mozilla/5.0 (compatible; HawkeyeSterlingComplianceBot/1.0; +https://github.com/trex0092/compliance-analyzer)';
@@ -85,8 +86,8 @@ export default async (req: Request): Promise<Response> => {
   const startedAt = new Date().toISOString();
 
   try {
-    const res = await fetch(targetUrl, {
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    const res = await fetchWithTimeout(targetUrl, {
+      timeoutMs: FETCH_TIMEOUT_MS,
       headers: {
         'User-Agent': INGEST_USER_AGENT,
         Accept: 'text/csv, application/xml, text/xml, */*',

--- a/netlify/functions/sanctions-ingest-cron.mts
+++ b/netlify/functions/sanctions-ingest-cron.mts
@@ -40,6 +40,7 @@ import {
   type NormalisedSanction,
   type SanctionsDelta,
 } from '../../src/services/sanctionsIngest';
+import { fetchWithTimeout } from '../../src/utils/fetchWithTimeout';
 
 const SNAPSHOT_STORE = 'sanctions-snapshots';
 const DELTA_STORE = 'sanctions-deltas';
@@ -68,9 +69,9 @@ interface IngestResult {
 const INGEST_USER_AGENT =
   'Mozilla/5.0 (compatible; HawkeyeSterlingComplianceBot/1.0; +https://github.com/trex0092/compliance-analyzer)';
 
-async function fetchWithTimeout(url: string, timeoutMs: number): Promise<string> {
-  const response = await fetch(url, {
-    signal: AbortSignal.timeout(timeoutMs),
+async function fetchSourceBody(url: string, timeoutMs: number): Promise<string> {
+  const response = await fetchWithTimeout(url, {
+    timeoutMs,
     headers: {
       'User-Agent': INGEST_USER_AGENT,
       Accept: 'text/csv, application/xml, text/xml, */*',
@@ -163,7 +164,7 @@ async function ingestOne(source: SanctionsSource): Promise<IngestResult> {
   const started = Date.now();
   const url = SANCTIONS_SOURCES[source].url;
   try {
-    const body = await fetchWithTimeout(url, FETCH_TIMEOUT_MS);
+    const body = await fetchSourceBody(url, FETCH_TIMEOUT_MS);
     const entries = parseSource(source, body);
     const previous = await loadPreviousSnapshot(source);
     const delta = computeDelta(previous, entries);

--- a/netlify/functions/scan-lumped-tasks.mts
+++ b/netlify/functions/scan-lumped-tasks.mts
@@ -44,6 +44,7 @@ import {
   scanForLumpedTasks,
   type ExistingTask,
 } from '../../src/services/asana/entityLumpingLinter';
+import { fetchWithTimeout } from '../../src/utils/fetchWithTimeout';
 
 const ASANA_BASE = 'https://app.asana.com/api/1.0';
 
@@ -84,12 +85,12 @@ async function fetchAllTasks(projectGid: string, token: string): Promise<Existin
     if (offset) params.set('offset', offset);
 
     const url = `${ASANA_BASE}/projects/${encodeURIComponent(projectGid)}/tasks?${params.toString()}`;
-    const res = await fetch(url, {
+    const res = await fetchWithTimeout(url, {
       headers: {
         Authorization: `Bearer ${token}`,
         Accept: 'application/json',
       },
-      signal: AbortSignal.timeout(25_000),
+      timeoutMs: 25_000,
     });
     if (!res.ok) {
       const text = await res.text().catch(() => '');

--- a/netlify/functions/send-alert.mts
+++ b/netlify/functions/send-alert.mts
@@ -10,6 +10,7 @@
 import type { Config, Context } from "@netlify/functions";
 import { checkRateLimit } from "./middleware/rate-limit.mts";
 import { authenticate } from "./middleware/auth.mts";
+import { fetchWithTimeout } from "../../src/utils/fetchWithTimeout";
 
 interface AlertPayload {
   subject: string;
@@ -111,11 +112,11 @@ export default async (req: Request, context: Context) => {
       ].join("\n"),
     };
 
-    const response = await fetch(emailServiceUrl, {
+    const response = await fetchWithTimeout(emailServiceUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(emailBody),
-      signal: AbortSignal.timeout(10000),
+      timeoutMs: 10000,
     });
 
     if (!response.ok) {

--- a/netlify/functions/setup-asana-bootstrap-all.mts
+++ b/netlify/functions/setup-asana-bootstrap-all.mts
@@ -41,6 +41,7 @@ import {
   type AsanaProvisionDispatcher,
   type CustomFieldSpec,
 } from '../../src/services/asana/tenantProvisioner';
+import { fetchWithTimeout } from '../../src/utils/fetchWithTimeout';
 
 const ASANA_BASE = 'https://app.asana.com/api/1.0';
 
@@ -88,10 +89,10 @@ function makeAsanaDispatcher(accessToken: string): AsanaProvisionDispatcher {
   };
 
   async function asanaRequest<T>(path: string, init: RequestInit = {}): Promise<T> {
-    const res = await fetch(ASANA_BASE + path, {
+    const res = await fetchWithTimeout(ASANA_BASE + path, {
       ...init,
       headers: { ...headers, ...(init.headers ?? {}) },
-      signal: AbortSignal.timeout(30_000),
+      timeoutMs: 30_000,
     });
     if (!res.ok) {
       const text = await res.text().catch(() => '');

--- a/netlify/functions/setup-asana-bootstrap.mts
+++ b/netlify/functions/setup-asana-bootstrap.mts
@@ -41,6 +41,7 @@ import {
   type AsanaProvisionDispatcher,
   type CustomFieldSpec,
 } from '../../src/services/asana/tenantProvisioner';
+import { fetchWithTimeout } from '../../src/utils/fetchWithTimeout';
 
 const ASANA_BASE = 'https://app.asana.com/api/1.0';
 
@@ -72,10 +73,10 @@ function makeAsanaDispatcher(accessToken: string): AsanaProvisionDispatcher {
   };
 
   async function asanaRequest<T>(path: string, init: RequestInit = {}): Promise<T> {
-    const res = await fetch(ASANA_BASE + path, {
+    const res = await fetchWithTimeout(ASANA_BASE + path, {
       ...init,
       headers: { ...headers, ...(init.headers ?? {}) },
-      signal: AbortSignal.timeout(30_000),
+      timeoutMs: 30_000,
     });
     if (!res.ok) {
       const text = await res.text().catch(() => '');

--- a/netlify/functions/setup-kyc-cdd-tracker-sections.mts
+++ b/netlify/functions/setup-kyc-cdd-tracker-sections.mts
@@ -54,6 +54,7 @@ import {
   diffSections,
   type ExistingSection,
 } from '../../src/services/asana/kycCddTrackerSections';
+import { fetchWithTimeout } from '../../src/utils/fetchWithTimeout';
 
 const ASANA_BASE = 'https://app.asana.com/api/1.0';
 
@@ -78,12 +79,12 @@ function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
 // ---------------------------------------------------------------------------
 
 async function asanaGet<T>(path: string, token: string): Promise<T> {
-  const res = await fetch(ASANA_BASE + path, {
+  const res = await fetchWithTimeout(ASANA_BASE + path, {
     headers: {
       Authorization: `Bearer ${token}`,
       Accept: 'application/json',
     },
-    signal: AbortSignal.timeout(20_000),
+    timeoutMs: 20_000,
   });
   if (!res.ok) {
     const text = await res.text().catch(() => '');
@@ -94,7 +95,7 @@ async function asanaGet<T>(path: string, token: string): Promise<T> {
 }
 
 async function asanaPost<T>(path: string, body: unknown, token: string): Promise<T> {
-  const res = await fetch(ASANA_BASE + path, {
+  const res = await fetchWithTimeout(ASANA_BASE + path, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,
@@ -102,7 +103,7 @@ async function asanaPost<T>(path: string, body: unknown, token: string): Promise
       Accept: 'application/json',
     },
     body: JSON.stringify(body),
-    signal: AbortSignal.timeout(20_000),
+    timeoutMs: 20_000,
   });
   if (!res.ok) {
     const text = await res.text().catch(() => '');
@@ -113,10 +114,10 @@ async function asanaPost<T>(path: string, body: unknown, token: string): Promise
 }
 
 async function asanaDelete(path: string, token: string): Promise<void> {
-  const res = await fetch(ASANA_BASE + path, {
+  const res = await fetchWithTimeout(ASANA_BASE + path, {
     method: 'DELETE',
     headers: { Authorization: `Bearer ${token}` },
-    signal: AbortSignal.timeout(20_000),
+    timeoutMs: 20_000,
   });
   if (!res.ok) {
     const text = await res.text().catch(() => '');

--- a/netlify/functions/tm-scan-cron.mts
+++ b/netlify/functions/tm-scan-cron.mts
@@ -34,6 +34,7 @@ import { checkRateLimit } from './middleware/rate-limit.mts';
 import { authenticate } from './middleware/auth.mts';
 import type { Transaction, TmVerdictRecord } from '../../src/domain/transaction';
 import { runTmBrainAllCustomers, type TmBrainOptions } from '../../src/services/txMonitoringBrain';
+import { fetchWithTimeout } from '../../src/utils/fetchWithTimeout';
 
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin':
@@ -278,9 +279,9 @@ export default async (req: Request, context: Context): Promise<Response> => {
       let nextUrl: string | null =
         `https://app.asana.com/api/1.0/projects/${encodeURIComponent(tmProjectGid)}/tasks?opt_fields=name&limit=100`;
       while (nextUrl) {
-        const tasksRes = await fetch(nextUrl, {
+        const tasksRes = await fetchWithTimeout(nextUrl, {
           headers: { Authorization: `Bearer ${asanaToken}`, Accept: 'application/json' },
-          signal: AbortSignal.timeout(20_000),
+          timeoutMs: 20_000,
         });
         if (!tasksRes.ok) throw new Error(`HTTP ${tasksRes.status}`);
         const tasksJson = (await tasksRes.json()) as {
@@ -335,7 +336,7 @@ export default async (req: Request, context: Context): Promise<Response> => {
         : undefined;
 
       try {
-        const createRes = await fetch('https://app.asana.com/api/1.0/tasks', {
+        const createRes = await fetchWithTimeout('https://app.asana.com/api/1.0/tasks', {
           method: 'POST',
           headers: {
             Authorization: `Bearer ${asanaToken}`,
@@ -351,7 +352,7 @@ export default async (req: Request, context: Context): Promise<Response> => {
               tags: [],
             },
           }),
-          signal: AbortSignal.timeout(15_000),
+          timeoutMs: 15_000,
         });
         if (!createRes.ok) {
           dispatchErrors++;

--- a/scripts/scheduled-screening.ts
+++ b/scripts/scheduled-screening.ts
@@ -69,6 +69,7 @@
 
 import { searchAdverseMedia, type AdverseMediaHit } from '../src/services/adverseMediaSearch';
 import { normalizeBrainUrl } from '../src/utils/normalizeBrainUrl';
+import { fetchWithTimeout } from '../src/utils/fetchWithTimeout';
 import {
   deserialiseWatchlist,
   listDueSubjects,
@@ -119,10 +120,10 @@ async function fetchWatchlist(cfg: RunConfig): Promise<SerialisedWatchlist> {
     throw new Error('HAWKEYE_BRAIN_TOKEN is not set — cannot fetch watchlist');
   }
   const url = `${cfg.brainUrl.replace(/\/+$/, '')}/api/watchlist`;
-  const res = await fetch(url, {
+  const res = await fetchWithTimeout(url, {
     method: 'GET',
     headers: { Authorization: `Bearer ${cfg.brainToken}` },
-    signal: AbortSignal.timeout(15_000),
+    timeoutMs: 15_000,
   });
   if (!res.ok) {
     const body = await res.text();
@@ -142,14 +143,14 @@ async function fetchWatchlist(cfg: RunConfig): Promise<SerialisedWatchlist> {
 async function saveWatchlist(cfg: RunConfig, watchlist: SerialisedWatchlist): Promise<void> {
   if (!cfg.brainToken) throw new Error('HAWKEYE_BRAIN_TOKEN is not set');
   const url = `${cfg.brainUrl.replace(/\/+$/, '')}/api/watchlist`;
-  const res = await fetch(url, {
+  const res = await fetchWithTimeout(url, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${cfg.brainToken}`,
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({ action: 'replace', watchlist }),
-    signal: AbortSignal.timeout(15_000),
+    timeoutMs: 15_000,
   });
   if (!res.ok) {
     const body = await res.text();
@@ -198,13 +199,13 @@ async function uploadScreeningAttachment(
   form.append('file', new Blob([content], { type: contentType }), fileName);
 
   try {
-    const res = await fetch(
+    const res = await fetchWithTimeout(
       `https://app.asana.com/api/1.0/tasks/${encodeURIComponent(taskGid)}/attachments`,
       {
         method: 'POST',
         headers: { Authorization: `Bearer ${cfg.asanaToken}` },
         body: form,
-        signal: AbortSignal.timeout(30_000),
+        timeoutMs: 30_000,
       }
     );
     if (!res.ok) {
@@ -247,14 +248,14 @@ async function createScreeningTask(
   if (dueOn) payload.due_on = dueOn;
 
   try {
-    const res = await fetch('https://app.asana.com/api/1.0/tasks', {
+    const res = await fetchWithTimeout('https://app.asana.com/api/1.0/tasks', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${cfg.asanaToken}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ data: payload }),
-      signal: AbortSignal.timeout(15_000),
+      timeoutMs: 15_000,
     });
     if (!res.ok) {
       const body = await res.text();
@@ -277,10 +278,10 @@ async function resolveAssigneeGid(cfg: RunConfig): Promise<string | undefined> {
   }
   try {
     const url = `https://app.asana.com/api/1.0/workspaces/${encodeURIComponent(cfg.asanaWorkspaceGid)}/users?opt_fields=gid,name,email`;
-    const res = await fetch(url, {
+    const res = await fetchWithTimeout(url, {
       method: 'GET',
       headers: { Authorization: `Bearer ${cfg.asanaToken}` },
-      signal: AbortSignal.timeout(15_000),
+      timeoutMs: 15_000,
     });
     if (!res.ok) {
       console.warn(`[resolveAssignee] HTTP ${res.status} — alert tasks will be unassigned`);
@@ -473,7 +474,7 @@ async function emitBrainEvent(cfg: RunConfig, summary: RunSummary): Promise<void
 
   const url = `${cfg.brainUrl.replace(/\/+$/, '')}/api/brain`;
   try {
-    await fetch(url, {
+    await fetchWithTimeout(url, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${cfg.brainToken}`,
@@ -492,7 +493,7 @@ async function emitBrainEvent(cfg: RunConfig, summary: RunSummary): Promise<void
           errorCount: summary.subjectsWithErrors.length,
         },
       }),
-      signal: AbortSignal.timeout(15_000),
+      timeoutMs: 15_000,
     });
   } catch (err) {
     console.warn(`[emitBrainEvent] failed (non-fatal): ${(err as Error).message}`);

--- a/src/services/adverseMediaSearch.ts
+++ b/src/services/adverseMediaSearch.ts
@@ -19,6 +19,8 @@
  * Cabinet Res 134/2025 Art.14 (EDD for high-risk).
  */
 
+import { fetchWithTimeout } from '../utils/fetchWithTimeout';
+
 // ---------------------------------------------------------------------------
 // Prompt builder
 // ---------------------------------------------------------------------------
@@ -259,9 +261,9 @@ async function searchViaBrave(query: string): Promise<AdverseMediaHit[]> {
   const key = process.env.BRAVE_SEARCH_API_KEY;
   if (!key) return [];
   const url = `https://api.search.brave.com/res/v1/web/search?q=${encodeURIComponent(query)}&count=20`;
-  const res = await fetch(url, {
+  const res = await fetchWithTimeout(url, {
     headers: { 'X-Subscription-Token': key, Accept: 'application/json' },
-    signal: AbortSignal.timeout(15_000),
+    timeoutMs: 15_000,
   });
   if (!res.ok) return [];
   const data = (await res.json()) as {
@@ -288,7 +290,7 @@ async function searchViaSerpApi(query: string): Promise<AdverseMediaHit[]> {
   const key = process.env.SERPAPI_KEY;
   if (!key) return [];
   const url = `https://serpapi.com/search.json?engine=google&q=${encodeURIComponent(query)}&api_key=${key}`;
-  const res = await fetch(url, { signal: AbortSignal.timeout(15_000) });
+  const res = await fetchWithTimeout(url, { timeoutMs: 15_000 });
   if (!res.ok) return [];
   const data = (await res.json()) as {
     organic_results?: Array<{
@@ -313,7 +315,7 @@ async function searchViaGoogleCse(query: string): Promise<AdverseMediaHit[]> {
   const cx = process.env.GOOGLE_CSE_CX;
   if (!key || !cx) return [];
   const url = `https://www.googleapis.com/customsearch/v1?key=${key}&cx=${cx}&q=${encodeURIComponent(query)}`;
-  const res = await fetch(url, { signal: AbortSignal.timeout(15_000) });
+  const res = await fetchWithTimeout(url, { timeoutMs: 15_000 });
   if (!res.ok) return [];
   const data = (await res.json()) as {
     items?: Array<{ title: string; link: string; snippet: string; displayLink: string }>;

--- a/src/services/cbuaeRates.ts
+++ b/src/services/cbuaeRates.ts
@@ -12,6 +12,7 @@
  */
 
 import { USD_TO_AED } from '../domain/constants';
+import { fetchWithTimeout } from '../utils/fetchWithTimeout';
 
 export interface ExchangeRates {
   baseCurrency: 'AED';
@@ -35,7 +36,7 @@ export async function fetchCBUAERates(proxyUrl?: string): Promise<ExchangeRates>
   try {
     const url = proxyUrl ? `${proxyUrl}/proxy?url=${encodeURIComponent(CBUAE_URL)}` : CBUAE_URL;
 
-    const response = await fetch(url, { signal: AbortSignal.timeout(15000) });
+    const response = await fetchWithTimeout(url, { timeoutMs: 15000 });
     if (!response.ok) throw new Error(`CBUAE returned ${response.status}`);
 
     const html = await response.text();

--- a/src/services/geminiComplianceAnalyzer.ts
+++ b/src/services/geminiComplianceAnalyzer.ts
@@ -24,6 +24,7 @@ import {
   UBO_OWNERSHIP_THRESHOLD_PCT,
   RECORD_RETENTION_YEARS,
 } from '../domain/constants';
+import { fetchWithTimeout, TimeoutError } from '../utils/fetchWithTimeout';
 
 // ─── Configuration ──────────────────────────────────────────────────────────
 
@@ -333,7 +334,7 @@ export async function analyzeCompliance(
 
   let response: Response;
   try {
-    response = await fetch(url, {
+    response = await fetchWithTimeout(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -345,11 +346,11 @@ export async function analyzeCompliance(
           responseMimeType: 'application/json',
         },
       }),
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      timeoutMs: REQUEST_TIMEOUT_MS,
     });
   } catch (err) {
     const elapsed = Date.now() - startTime;
-    if (err instanceof DOMException && err.name === 'TimeoutError') {
+    if (err instanceof TimeoutError) {
       throw new Error(`Gemini API request timed out after ${elapsed}ms`);
     }
     throw new Error(`Gemini API network error: ${(err as Error).message}`);

--- a/src/services/multiModelScreening.ts
+++ b/src/services/multiModelScreening.ts
@@ -18,6 +18,7 @@
 import { RISK_THRESHOLDS } from '../domain/constants';
 import type { ScreeningRun } from '../domain/screening';
 import type { SanctionsMatch } from './sanctionsApi';
+import { fetchWithTimeout } from '../utils/fetchWithTimeout';
 
 // ─── Configuration ─────────────────────────────────────────────────────────
 
@@ -142,7 +143,7 @@ async function queryModel(
 ): Promise<ModelOpinion> {
   const startTime = Date.now();
 
-  const response = await fetch(OPENROUTER_BASE_URL, {
+  const response = await fetchWithTimeout(OPENROUTER_BASE_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -160,7 +161,7 @@ async function queryModel(
       max_tokens: 1024,
       response_format: { type: 'json_object' },
     }),
-    signal: AbortSignal.timeout(RACE_TIMEOUT_MS),
+    timeoutMs: RACE_TIMEOUT_MS,
   });
 
   if (!response.ok) {

--- a/src/services/sanctionsApi.ts
+++ b/src/services/sanctionsApi.ts
@@ -13,6 +13,7 @@
  */
 
 import { normalize, similarity, FUZZY_MATCH_THRESHOLD } from '../utils/fuzzyMatch';
+import { fetchWithTimeout } from '../utils/fetchWithTimeout';
 
 export interface SanctionsEntry {
   id: string;
@@ -50,7 +51,7 @@ export async function fetchUNSanctionsList(proxyUrl?: string): Promise<Sanctions
   const UN_URL = 'https://scsanctions.un.org/resources/xml/en/consolidated.xml';
   const url = proxyUrl ? `${proxyUrl}/proxy?url=${encodeURIComponent(UN_URL)}` : UN_URL;
 
-  const response = await fetch(url, { signal: AbortSignal.timeout(30000) });
+  const response = await fetchWithTimeout(url, { timeoutMs: 30_000 });
   if (!response.ok) throw new Error(`UN API returned ${response.status}`);
 
   const xmlText = await response.text();
@@ -182,7 +183,7 @@ export async function fetchOFACSanctionsList(proxyUrl?: string): Promise<Sanctio
     'https://sanctionslistservice.ofac.treas.gov/api/PublicationPreview/exports/SDN.XML';
   const url = proxyUrl ? `${proxyUrl}/proxy?url=${encodeURIComponent(OFAC_URL)}` : OFAC_URL;
 
-  const response = await fetch(url, { signal: AbortSignal.timeout(30000) });
+  const response = await fetchWithTimeout(url, { timeoutMs: 30_000 });
   if (!response.ok) throw new Error(`OFAC API returned ${response.status}`);
 
   const xmlText = await response.text();
@@ -243,7 +244,7 @@ export async function fetchEUSanctionsList(proxyUrl?: string): Promise<Sanctions
     'https://webgate.ec.europa.eu/fsd/fsf/public/files/xmlFullSanctionsList_1_1/content?token=dG9rZW4tMjAxNw';
   const url = proxyUrl ? `${proxyUrl}/proxy?url=${encodeURIComponent(EU_URL)}` : EU_URL;
 
-  const response = await fetch(url, { signal: AbortSignal.timeout(30000) });
+  const response = await fetchWithTimeout(url, { timeoutMs: 30_000 });
   if (!response.ok) throw new Error(`EU API returned ${response.status}`);
 
   const xmlText = await response.text();
@@ -327,7 +328,7 @@ export async function fetchUKSanctionsList(proxyUrl?: string): Promise<Sanctions
   const UK_URL = 'https://ofsistorage.blob.core.windows.net/publishlive/2022format/ConList.csv';
   const url = proxyUrl ? `${proxyUrl}/proxy?url=${encodeURIComponent(UK_URL)}` : UK_URL;
 
-  const res = await fetch(url, { signal: AbortSignal.timeout(30_000) });
+  const res = await fetchWithTimeout(url, { timeoutMs: 30_000 });
   if (!res.ok) throw new Error(`UK OFSI API returned ${res.status}`);
 
   const csv = await res.text();


### PR DESCRIPTION
## Summary

Consolidates ~38 outbound `fetch()` call sites across 20 files onto
the single-source-of-truth `src/utils/fetchWithTimeout.ts` helper so
every upstream timeout yields a typed `TimeoutError` (carrying `url`
+ `timeoutMs` + `elapsedMs`) instead of an anonymous `DOMException`.

Also drops two local `fetchWithTimeout` duplicates that were
drifting from the shared helper's semantics.

## Regulatory basis

- **FDL No.10/2025 Art.20-21** — Compliance Officer accountability. A
  timed-out sanctions-list pull, goAML push, or Cachet publish now
  records *which* URL and *how long* it ran before the budget
  expired, so the MLRO can explain the gap.
- **FDL No.10/2025 Art.24** — 10-year record retention. The audit
  trail now carries structured `TimeoutError` context at every
  upstream hop.
- **FATF Rec 10 / Rec 11** — CDD record-keeping + traceability.
- **Cabinet Res 74/2020 Art.4-7** — 24h TFS freeze window relies on
  prompt detection of upstream slowdowns; structured timeout surface
  makes the gap auditable.

## What changed

**Dropped local duplicates:**
- `netlify/functions/sanctions-ingest-cron.mts` — inner wrapper
  renamed to `fetchSourceBody`, imports shared helper.
- `netlify/functions/regulatory-horizon-cron.mts` — inner wrapper
  renamed to `fetchFeedBody`, imports shared helper.

**Netlify functions migrated (14 files):** `asana-migrate-schema`,
`asana-proxy`, `brain` (Cachet publisher), `cbuae-fx-cron`,
`expiry-scan-cron`, `regulatory-horizon-cron`, `sanctions-feed-debug`,
`sanctions-ingest-cron`, `scan-lumped-tasks`, `send-alert`,
`setup-asana-bootstrap`, `setup-asana-bootstrap-all`,
`setup-kyc-cdd-tracker-sections`, `tm-scan-cron`.

**`src/services/` migrated (5 files):** `adverseMediaSearch`,
`cbuaeRates`, `geminiComplianceAnalyzer`, `multiModelScreening`,
`sanctionsApi`.

**Scripts migrated (1 file):** `scripts/scheduled-screening.ts` —
watchlist IO, attachment upload, task creation, assignee
resolution, brain event emit.

`geminiComplianceAnalyzer.ts` also gets a small type upgrade: the
old `err instanceof DOMException && err.name === 'TimeoutError'`
check is replaced with `err instanceof TimeoutError` now that the
shared class is in scope.

## Intentionally NOT migrated

These sites require explicit `AbortController` ownership for
streaming or injected-fetch patterns — wrapping them would break
the abstraction:

- `ai-proxy.mts` (SSE stream + idle-timeout keepalive)
- `asanaClient.ts`, `anthropicAdvisor.ts`, `autoFreezeExecutor.ts`,
  `fiuAckAutoIngest.ts`, `toastStreamPoller.ts`,
  `metalsTrading/reutersRefinitivAdapter.ts`, `advisorStrategy.ts`
  (custom `fetchFn` injection for testing + custom signal
  composition)
- `screening/webhooks/sanctions-alert.mjs` — `.mjs` cross-language
  import overhead not worth it for a single 5s HEAD request.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `vitest run` — 4675/4675 pass across 293 test files
- [x] `grep 'AbortSignal.timeout' netlify/functions/` — no matches
  in migrated scope
- [ ] Deploy-preview smoke test: trigger `asana-migrate-schema`,
  `sanctions-ingest-cron`, `send-alert` against staging and confirm
  `TimeoutError` surfaces with URL + elapsed context in the Netlify
  function logs.

https://claude.ai/code/session_014AJc3FP33Xru5x6HSrjb9r