### PR TITLE
ui(screening): Refresh buttons, smaller checkboxes, outlined gold CTAs

### DIFF
--- a/screening-command.html
+++ b/screening-command.html
@@ -328,9 +328,9 @@
       button {
         width: 100%;
         padding: 14px;
-        background: var(--gold);
-        color: var(--bg);
-        border: none;
+        background: transparent;
+        color: var(--gold);
+        border: 1px solid var(--gold);
         border-radius: 4px;
         font-size: 14px;
         font-weight: 600;
@@ -340,12 +340,20 @@
         min-height: 48px;
         touch-action: manipulation;
         font-family: inherit;
+        transition: background-color 0.18s ease, border-color 0.18s ease,
+          box-shadow 0.18s ease, transform 0.12s ease;
+      }
+      button:hover:not(:disabled) {
+        background: rgba(201, 168, 76, 0.08);
+        border-color: var(--gold-bright);
+        box-shadow: 0 0 0 2px rgba(201, 168, 76, 0.12);
       }
       button:active {
         transform: translateY(1px);
       }
       button:disabled {
-        background: #555;
+        background: transparent;
+        border-color: #555;
         cursor: not-allowed;
         color: var(--muted);
       }
@@ -822,12 +830,12 @@
       .list-check input[type='checkbox'] {
         appearance: none;
         -webkit-appearance: none;
-        margin-top: 1px;
-        width: 20px;
-        height: 20px;
+        margin-top: 2px;
+        width: 16px;
+        height: 16px;
         flex-shrink: 0;
         border: 1.5px solid var(--blue);
-        border-radius: 5px;
+        border-radius: 4px;
         background: transparent;
         cursor: pointer;
         position: relative;
@@ -846,12 +854,12 @@
       .list-check input[type='checkbox']:checked::after {
         content: '';
         position: absolute;
-        left: 5px;
+        left: 4px;
         top: 1px;
-        width: 6px;
-        height: 11px;
+        width: 4px;
+        height: 8px;
         border: solid #fff;
-        border-width: 0 2.5px 2.5px 0;
+        border-width: 0 2px 2px 0;
         transform: rotate(45deg);
       }
       .list-check input[type='checkbox']:focus-visible {
@@ -891,6 +899,36 @@
         line-height: 1.5;
         padding-top: 8px;
         border-top: 1px dashed var(--border);
+      }
+      .list-refresh-row {
+        display: flex;
+        justify-content: flex-end;
+        margin-top: 10px;
+      }
+      .list-refresh {
+        appearance: none;
+        background: transparent;
+        color: var(--blue);
+        border: 1px solid rgba(74, 144, 226, 0.5);
+        border-radius: 4px;
+        padding: 4px 10px;
+        font-family: 'Cinzel', serif;
+        font-size: 10px;
+        letter-spacing: 1.5px;
+        text-transform: uppercase;
+        cursor: pointer;
+        transition: background-color 0.18s ease, border-color 0.18s ease,
+          box-shadow 0.18s ease, transform 0.12s ease;
+      }
+      .list-refresh:hover {
+        background: rgba(74, 144, 226, 0.1);
+        border-color: var(--blue);
+        box-shadow: 0 0 0 2px rgba(74, 144, 226, 0.12);
+        transform: translateY(-1px);
+      }
+      .list-refresh:focus-visible {
+        outline: 2px solid var(--blue);
+        outline-offset: 2px;
       }
       /* Disposition section (hidden until a screening result is rendered) */
       .disposition {
@@ -1660,6 +1698,11 @@
           constitutes a regulatory offence under FDL No.10/2025 Art.35 and is subject to
           administrative penalty under Cabinet Res 71/2024 (AED 10K–100M range).
         </p>
+        <div class="list-refresh-row">
+          <button type="button" class="list-refresh" data-refresh-scope="mandatory">
+            Refresh
+          </button>
+        </div>
       </div>
       <div class="card list-tier enhanced">
         <h2 style="color: var(--blue)">Enhanced Controls</h2>
@@ -1700,6 +1743,11 @@
           supervisory authority for appropriate course of action. Opting out is permitted; every
           opt-out is logged with the screening event (FDL Art.24 — 10-year retention).
         </p>
+        <div class="list-refresh-row">
+          <button type="button" class="list-refresh" data-refresh-scope="enhanced">
+            Refresh
+          </button>
+        </div>
       </div>
     </div>
 
@@ -1802,6 +1850,11 @@
             >
           </span>
         </label>
+      </div>
+      <div class="list-refresh-row">
+        <button type="button" class="list-refresh" data-refresh-scope="risk">
+          Refresh
+        </button>
       </div>
     </div>
 

--- a/screening-command.html
+++ b/screening-command.html
@@ -1660,7 +1660,7 @@
 
     <!-- List selector ────────────────────────────────────────────── -->
     <div class="grid grid-2" style="margin-top: 14px">
-      <div class="card list-tier mandatory">
+      <div class="card list-tier mandatory" style="border-color: var(--blue)">
         <h2 style="color: var(--blue)">Mandatory UAE Lists</h2>
         <label class="list-check locked">
           <input
@@ -1704,7 +1704,7 @@
           </button>
         </div>
       </div>
-      <div class="card list-tier enhanced">
+      <div class="card list-tier enhanced" style="border-color: var(--blue)">
         <h2 style="color: var(--blue)">Enhanced Controls</h2>
         <label class="list-check">
           <input type="checkbox" data-list="OFAC" data-tier="enhanced" checked />
@@ -1752,7 +1752,7 @@
     </div>
 
     <!-- Risk categories ────────────────────────────────────────────── -->
-    <div class="card list-tier enhanced" style="margin-top: 14px">
+    <div class="card list-tier enhanced" style="margin-top: 14px; border-color: var(--blue)">
       <h2 style="color: var(--blue)">Risk Categories</h2>
       <p class="help-text" style="margin-top: -4px">
         Content categories screened against every selected list + adverse-media corpus. Default: all

--- a/screening-command.js
+++ b/screening-command.js
@@ -1385,6 +1385,30 @@
 
   refreshBtn.addEventListener('click', refreshWatchlist);
 
+  // ─── List / Risk-category "Refresh" buttons ───────────────────────
+  // Each list card carries a small Refresh button that restores every
+  // non-locked checkbox in its scope back to the default "checked"
+  // state (default: all ON). Locked entries (mandatory EOCN + UN) are
+  // skipped — those are regulatory hard-wires per Cabinet Decision
+  // 74/2020 and must never be toggled by the UI. The control dispatches
+  // a `change` event so any listeners observing the live screening set
+  // (e.g. coverage-foot counters) recompute.
+  document.addEventListener('click', function (evt) {
+    const target = evt.target;
+    if (!(target instanceof HTMLElement)) return;
+    const btn = target.closest('.list-refresh');
+    if (!btn) return;
+    const card = btn.closest('.card.list-tier');
+    if (!card) return;
+    card.querySelectorAll('input[type="checkbox"]').forEach(function (cb) {
+      if (cb.disabled) return;
+      if (!cb.checked) {
+        cb.checked = true;
+        cb.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+    });
+  });
+
   // ─── Delete button delegation on the watchlist ─────────────────────
   // A mistaken enrolment (wrong name, duplicate, test entry) needs to be
   // removable. The watchlist API already exposes action:"remove" — we


### PR DESCRIPTION
## Summary

1. **Refresh button on each list card.** Mandatory UAE Lists, Enhanced Controls, and Risk Categories each carry a small "Refresh" pill bottom-right. Clicking restores every non-locked checkbox in that card to the default checked state. Locked mandatory entries (EOCN / UN per Cabinet Decision 74/2020) are skipped — regulatory hard-wires must never be toggled by the UI.

2. **Smaller checkboxes.** 20×20 → 16×16 with proportional checkmark geometry (4×8, border-radius 4px). Hover scale and focus ring preserved.

3. **Outlined gold CTAs.** Primary buttons switched from solid gold fill to transparent + gold border + gold text, matching the existing "Idle" pill sample. Affected: `screenBtn` (Run Screening), `tmBtn` (Run Transaction Monitor), `refreshBtn` (Refresh watchlist), token management buttons inside the Authentication card.

## Implementation notes
- Refresh handler is a **CSP-safe delegated click listener** on `document`. Uses `closest('.card.list-tier')` to scope the reset to the card containing the button, so adding a 4th list card in future needs no JS change. Dispatches bubbling `change` events so downstream counters recompute.
- No CSP hash changes; no new inline scripts.
- `.btn-secondary` already used outlined gold; base `button` rule now agrees so the two are visually consistent.

## Regulatory impact
- None. EOCN/UN remain locked-checked-disabled. Refresh only re-asserts the documented default (all controls ON) and every opt-out/opt-in remains logged per FDL Art.24.

## Test plan
- [ ] Uncheck several items in each of the three cards → click Refresh → all non-locked boxes return to checked.
- [ ] EOCN + UN remain locked/disabled (Cabinet Decision 74/2020).
- [ ] Checkboxes now 16×16; checkmark centered; hover scale 1.04 intact.
- [ ] `Run Screening`, `Run Transaction Monitor`, `Refresh watchlist` render as outlined gold and still function.
- [ ] No CSP violations in browser console.

https://claude.ai/code/session_014AJc3FP33Xru5x6HSrjb9r