### PR TITLE
ui(screening): fix refresh icon click + purple Data Coverage section

### DIFF
--- a/screening-command.html
+++ b/screening-command.html
@@ -925,6 +925,8 @@
         width: 14px;
         height: 14px;
         display: block;
+        /* The SVG is decorative — bubble clicks to the <button>. */
+        pointer-events: none;
       }
       .list-refresh:hover {
         background: rgba(74, 144, 226, 0.12);
@@ -950,7 +952,7 @@
         display: block;
       }
       .coverage-card {
-        border-left: 3px solid var(--blue);
+        border-left: 3px solid #a855f7;
       }
       .coverage-grid {
         display: grid;
@@ -964,7 +966,7 @@
         font-weight: 600;
         letter-spacing: 1.3px;
         text-transform: uppercase;
-        color: var(--blue);
+        color: #a855f7;
         margin-bottom: 4px;
       }
       .coverage-grid .c-sub {
@@ -1555,8 +1557,8 @@
     </details>
 
     <!-- Data coverage contract ────────────────────────────────────── -->
-    <div class="card coverage-card" style="margin-top: 14px">
-      <h2>Data Coverage</h2>
+    <div class="card coverage-card" style="margin-top: 14px; border-color: #a855f7">
+      <h2 style="color: #a855f7">Data Coverage</h2>
       <div class="coverage-grid">
         <div>
           <div class="c-h">Aliases &amp; alternative spellings</div>

--- a/screening-command.js
+++ b/screening-command.js
@@ -1395,7 +1395,11 @@
   // (e.g. coverage-foot counters) recompute.
   document.addEventListener('click', function (evt) {
     const target = evt.target;
-    if (!(target instanceof HTMLElement)) return;
+    // Element (not HTMLElement) covers the inner SVG / <path> nodes
+    // that receive the click when the user hits the icon itself.
+    // A stricter HTMLElement guard here was returning early and
+    // leaving the button non-functional.
+    if (!(target instanceof Element)) return;
     const btn = target.closest('.list-refresh');
     if (!btn) return;
     const card = btn.closest('.card.list-tier');


### PR DESCRIPTION
## Summary

Two fixes bundled to save Netlify build minutes.

### 1. Refresh icon click was silently dead

The delegated click handler in `screening-command.js` opened with:

```js
if (!(target instanceof HTMLElement)) return;
```

But when the user clicks the SVG refresh-arrow inside the button, `evt.target` is an `SVGElement` (or `SVGPathElement`) — **not** `HTMLElement`. The guard rejected the event and the button appeared non-functional. Fix:

```js
if (!(target instanceof Element)) return;
```

`Element` is the common ancestor of `HTMLElement` + `SVGElement` — covers both without loosening the guard further. Belt-and-braces: added `pointer-events: none` on the inner `<svg>` so the `<button>` is always the event target regardless.

### 2. Data Coverage section painted purple (#a855f7)

- Card border (left accent + full-border-color override)
- `h2` "Data Coverage" title
- All 12 `.c-h` mini-titles (`ALIASES & ALTERNATIVE SPELLINGS`, `UBO & CONTROL-CHAIN COVERAGE`, etc.) — rule scoped to `.coverage-grid .c-h` so no other `.c-h` in the page is affected (none exist anyway — verified by grep).

Color picked to match the existing Tailwind-500-family palette already used for other section accents (`#ec4899` pink, `#22c55e` green, `#4a90e2` blue).

## Test plan

- [ ] Click the refresh icon on each of the three list cards (Mandatory / Enhanced / Risk Categories); confirm all non-locked checkboxes flip to checked and `change` event fires.
- [ ] Confirm locked mandatory entries (EOCN + UN) stay locked (Cabinet Res 74/2020 Art.4).
- [ ] Visual: Data Coverage card now purple border + purple title + purple mini-titles.
- [ ] No CSP regressions (no new inline scripts, no new inline handlers).

https://claude.ai/code/session_014AJc3FP33Xru5x6HSrjb9r