### PR TITLE
ui(auth): dedicated password cell above Sign in / Sign out buttons

### DIFF
--- a/screening-command.html
+++ b/screening-command.html
@@ -1517,18 +1517,20 @@
       </summary>
       <div class="auth-body">
         <label for="loginPassword">Sign in with password</label>
+        <input
+          type="password"
+          id="loginPassword"
+          placeholder="Enter your MLRO password"
+          autocomplete="current-password"
+          spellcheck="false"
+          style="width: 100%; margin-bottom: 8px"
+        />
         <div class="token-row">
-          <input
-            type="password"
-            id="loginPassword"
-            placeholder="Enter your MLRO password"
-            autocomplete="current-password"
-            spellcheck="false"
-          />
           <button
             type="button"
             id="loginBtn"
             class="token-gen-btn"
+            style="flex: 1"
             title="Exchange password for a signed 1-year session token"
           >
             Sign in
@@ -1537,6 +1539,7 @@
             type="button"
             id="logoutBtn"
             class="token-gen-btn"
+            style="flex: 1"
             title="Forget the saved session token and require a new sign-in"
           >
             Sign out


### PR DESCRIPTION
## Summary

The Authentication card was cramming the password input and both buttons into a single `.token-row` flex. On Luisa's screenshot the input collapsed to zero visible width — only **Sign in** and **Sign out** rendered side-by-side with nothing to type into.

Split into two rows:
- Full-width password input on top (`#loginPassword`)
- Two equal-width buttons below (`flex: 1` each)

No JS changes — the `id`s and event listeners are unchanged.

## Test plan

- [ ] Load `/screening-command.html`, expand the Authentication card
- [ ] Confirm the password input cell is visible above the buttons
- [ ] Type password, click Sign in, confirm 200 from `/api/hawkeye-login`

https://claude.ai/code/session_014AJc3FP33Xru5x6HSrjb9r