### PR TITLE
ui(auth): drop manual-token fallback + collapsible wrapper

### DIFF
--- a/screening-command.html
+++ b/screening-command.html
@@ -431,54 +431,10 @@
         color: #ff6b6b;
       }
       .auth-card {
-        padding: 14px 18px;
-      }
-      .auth-card[open] {
         padding: 20px 22px;
       }
-      .auth-summary {
-        display: flex;
-        align-items: center;
-        gap: 10px;
-        cursor: pointer;
-        list-style: none;
-        user-select: none;
-      }
-      .auth-summary::-webkit-details-marker {
-        display: none;
-      }
-      .auth-summary-title {
-        font-family: 'DM Mono', monospace;
-        font-size: 13px;
-        letter-spacing: 2px;
-        text-transform: uppercase;
-        color: var(--gold);
-      }
-      .auth-summary-hint {
-        margin-left: auto;
-        font-size: 11px;
-        color: var(--muted);
-      }
-      .auth-card[open] .auth-summary-hint {
-        opacity: 0.6;
-      }
       .auth-body {
-        margin-top: 14px;
-      }
-      .token-fallback {
-        border-top: 1px dashed var(--border);
-        padding-top: 10px;
-      }
-      .token-fallback-summary {
-        cursor: pointer;
-        color: var(--muted);
-        font-size: 11px;
-        text-transform: uppercase;
-        letter-spacing: 1px;
-        user-select: none;
-      }
-      .token-fallback-summary::-webkit-details-marker {
-        display: none;
+        margin-top: 0;
       }
       .stat {
         display: flex;
@@ -1509,12 +1465,10 @@
     </div>
 
     <!-- Authentication ────────────────────────────────────────────── -->
-    <details class="card auth-card" style="margin-top: 14px">
-      <summary class="auth-summary">
-        <span class="auth-summary-title">Authentication</span>
-        <span class="tag">Required</span>
-        <span class="auth-summary-hint">click to manage token</span>
-      </summary>
+    <div class="card auth-card" style="margin-top: 14px">
+      <h2 style="font-family: 'DM Mono', monospace; font-size: 13px; letter-spacing: 2px; text-transform: uppercase; color: var(--gold); margin: 0 0 14px; display: flex; align-items: center; gap: 10px">
+        Authentication <span class="tag">Required</span>
+      </h2>
       <div class="auth-body">
         <label for="loginPassword">Sign in with password</label>
         <input
@@ -1553,51 +1507,13 @@
         </span>
         <div id="loginMsg" class="token-msg"></div>
 
-        <details class="token-fallback" style="margin-top: 14px">
-          <summary class="token-fallback-summary">Manual token (backend-to-backend)</summary>
-          <label for="token" style="margin-top: 10px">Hawkeye brain token</label>
-          <div class="token-row">
-            <input
-              type="password"
-              id="token"
-              placeholder="Paste your HAWKEYE_BRAIN_TOKEN"
-              autocomplete="off"
-              spellcheck="false"
-            />
-            <button
-              type="button"
-              id="tokenGenBtn"
-              class="token-gen-btn"
-              title="Generate a fresh 32-byte CSPRNG token (local only)"
-            >
-              Generate
-            </button>
-            <button
-              type="button"
-              id="tokenRevealBtn"
-              class="token-gen-btn token-reveal-btn"
-              title="Show / hide the token"
-            >
-              Show
-            </button>
-            <button
-              type="button"
-              id="tokenCopyBtn"
-              class="token-gen-btn"
-              title="Copy token to clipboard"
-            >
-              Copy
-            </button>
-          </div>
-          <span class="token-hint"
-            >For crons / orchestrator only. Paste a 64-char hex value matching
-            <code>HAWKEYE_BRAIN_TOKEN</code> on Netlify. The interactive MLRO path above is
-            preferred.</span
-          >
-          <div id="tokenMsg" class="token-msg"></div>
-        </details>
+        <!-- Hidden token store. The screening-command.js auth helpers
+             read/write `#token` to keep the bearer in localStorage and
+             attach it to every API call. After sign-in the JWT lands
+             here; the field is never shown to the MLRO. -->
+        <input type="hidden" id="token" autocomplete="off" />
       </div>
-    </details>
+    </div>
 
     <!-- Data coverage contract ────────────────────────────────────── -->
     <div class="card coverage-card" style="margin-top: 14px; border-color: #a855f7">

--- a/screening-command.html
+++ b/screening-command.html
@@ -1517,18 +1517,20 @@
       </summary>
       <div class="auth-body">
         <label for="loginPassword">Sign in with password</label>
+        <input
+          type="password"
+          id="loginPassword"
+          placeholder="Enter your MLRO password"
+          autocomplete="current-password"
+          spellcheck="false"
+          style="width: 100%; margin-bottom: 8px"
+        />
         <div class="token-row">
-          <input
-            type="password"
-            id="loginPassword"
-            placeholder="Enter your MLRO password"
-            autocomplete="current-password"
-            spellcheck="false"
-          />
           <button
             type="button"
             id="loginBtn"
             class="token-gen-btn"
+            style="flex: 1"
             title="Exchange password for a signed 1-year session token"
           >
             Sign in
@@ -1537,6 +1539,7 @@
             type="button"
             id="logoutBtn"
             class="token-gen-btn"
+            style="flex: 1"
             title="Forget the saved session token and require a new sign-in"
           >
             Sign out

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -151,10 +151,7 @@ export interface VerifyJwtInput {
 export function verifyJwt(input: VerifyJwtInput): JwtPayload {
   const { token, secret } = input;
   if (!secret || secret.length < 32) {
-    throw new JwtError(
-      'malformed',
-      'verifyJwt: secret must be at least 32 bytes.'
-    );
+    throw new JwtError('malformed', 'verifyJwt: secret must be at least 32 bytes.');
   }
   const parts = token.split('.');
   if (parts.length !== 3) {


### PR DESCRIPTION
## Summary

Per Luisa: deputy MLRO (Vishmi Nayanika) will share the same password, so the backend-to-backend hex-token UI on the screening page is dead weight.

Removed:
- The entire **"Manual token (backend-to-backend)"** `<details>` block (Hawkeye brain token input + Generate / Show / Copy buttons)
- The outer `<details>` + "click to manage token" hint — the card is now always-open
- Now-dead `.auth-summary`, `.auth-summary-hint`, `.token-fallback` CSS

Kept `#token` as a **hidden input** so `screening-command.js`'s localStorage helpers (lines 34, 89, 204, 232, 357, 398, 428) keep reading/writing the same DOM target without any JS edit. The hex-token path on the **server** (HAWKEYE_BRAIN_TOKEN env var, used by crons / orchestrator) remains intact — only the on-page UI for it is gone.

## Test plan

- [ ] Load `/screening-command.html`, confirm the Authentication card is always-open
- [ ] No "click to manage token" hint, no Manual Token section
- [ ] Sign in with the MLRO password works; session persists across reloads

https://claude.ai/code/session_014AJc3FP33Xru5x6HSrjb9r