### PR TITLE
feat(screening): immediate risk alerts + auto-enrol every screen

### DIFF
--- a/netlify/functions/sanctions-ingest-cron.mts
+++ b/netlify/functions/sanctions-ingest-cron.mts
@@ -41,6 +41,11 @@ import {
   type SanctionsDelta,
 } from '../../src/services/sanctionsIngest';
 import { fetchWithTimeout } from '../../src/utils/fetchWithTimeout';
+import {
+  dispatchImmediateAlerts,
+  candidatesFromSanctionsDelta,
+  type DispatchSummary,
+} from '../../src/services/immediateRiskAlerts';
 
 const SNAPSHOT_STORE = 'sanctions-snapshots';
 const DELTA_STORE = 'sanctions-deltas';
@@ -191,6 +196,42 @@ async function ingestOne(source: SanctionsSource): Promise<IngestResult> {
   }
 }
 
+/**
+ * Immediate-risk-alert dispatch. For every successful source with a
+ * non-empty delta, score every added/modified/removed entry against
+ * every watched subject and create an Asana task whenever the
+ * identity-match score passes the 'possible' band (or the subject is
+ * pinned to an amended/delisted designation). Runs sequentially per
+ * source so Asana rate limiting is honoured by the client's adaptive
+ * backoff; the per-subject × per-candidate grid is small (watchlist
+ * is typically <100; delta per 15 min is typically <10).
+ *
+ * FDL Art.20-21 requires the CO to see material events immediately.
+ * Cabinet Res 74/2020 Art.4 + EOCN TFS Guidance July 2025 require
+ * freezing within 1-2 hours of a confirmed match — hence the 15-min
+ * cron + immediate Asana task per event.
+ */
+async function dispatchAlertsForResults(results: IngestResult[]): Promise<DispatchSummary[]> {
+  const summaries: DispatchSummary[] = [];
+  const runIdBase = `sanctions-ingest-${new Date().toISOString()}`;
+  for (const r of results) {
+    if (!r.ok || !r.delta) continue;
+    const { added, modified, removed } = r.delta;
+    if (added.length === 0 && modified.length === 0 && removed.length === 0) continue;
+    const candidates = candidatesFromSanctionsDelta(added, modified, removed);
+    try {
+      const s = await dispatchImmediateAlerts(candidates, {
+        trigger: 'sanctions-ingest',
+        runId: `${runIdBase}::${r.source}`,
+      });
+      summaries.push(s);
+    } catch (err) {
+      console.warn('[sanctions-ingest] alert dispatch failed', r.source, err);
+    }
+  }
+  return summaries;
+}
+
 export default async (): Promise<Response> => {
   const startedAt = new Date().toISOString();
   const sources: SanctionsSource[] = ['OFAC_SDN', 'OFAC_CONS', 'UN', 'EU', 'UK_OFSI', 'UAE_EOCN'];
@@ -200,6 +241,12 @@ export default async (): Promise<Response> => {
   // timeout (26 s on standard, 900 s on scheduled), so the 30 s per-
   // source fetch must be provisioned on a scheduled runtime.
   const results = await Promise.all(sources.map(ingestOne));
+
+  // After all ingests complete, fire immediate Asana alerts for every
+  // watched subject impacted by any delta. This runs *after* snapshot
+  // + delta persistence so a dispatcher failure never rolls back the
+  // persisted record.
+  const alertSummaries = await dispatchAlertsForResults(results);
 
   const summary = {
     startedAt,
@@ -217,6 +264,18 @@ export default async (): Promise<Response> => {
       error: r.error,
       durationMs: r.durationMs,
     })),
+    alerts: {
+      runs: alertSummaries.length,
+      watchlistSize: alertSummaries[0]?.watchlistSize ?? 0,
+      tasksCreated: alertSummaries.reduce((acc, s) => acc + s.tasksCreated, 0),
+      tasksFailed: alertSummaries.reduce((acc, s) => acc + s.tasksFailed, 0),
+      suppressed: alertSummaries.reduce((acc, s) => acc + s.suppressed, 0),
+      perSource: alertSummaries.map((s) => ({
+        runId: s.runId,
+        tasksCreated: s.tasksCreated,
+        tasksFailed: s.tasksFailed,
+      })),
+    },
   };
 
   await writeAudit({ event: 'sanctions_ingest_cron', ...summary });

--- a/netlify/functions/screening-save.mts
+++ b/netlify/functions/screening-save.mts
@@ -69,8 +69,17 @@ import { getStore } from '@netlify/blobs';
 import { authenticate } from './middleware/auth.mts';
 import { checkRateLimit } from './middleware/rate-limit.mts';
 import { createAsanaTask } from '../../src/services/asanaClient';
+import {
+  addToWatchlist,
+  deserialiseWatchlist,
+  serialiseWatchlist,
+  type ResolvedIdentity,
+  type SerialisedWatchlist,
+} from '../../src/services/screeningWatchlist';
 
 const EVENTS_STORE = 'screening-events';
+const WATCHLIST_STORE = 'screening-watchlist';
+const WATCHLIST_KEY = 'current';
 const MAX_BODY_SIZE = 32 * 1024;
 const MAX_CAS_ATTEMPTS = 5;
 const MIN_RATIONALE_LEN = 20;
@@ -420,6 +429,102 @@ async function saveEvent(event: ScreeningEvent): Promise<{ ok: boolean; error?: 
 }
 
 // ---------------------------------------------------------------------------
+// Auto-enrol — every screen enrols the subject in daily monitoring.
+// Product requirement: "DAILY MONITORING FOR ALL THE SCREENED SUBJECTS
+// (ENTITIES AND INDIVIDUALS) AND ALERTS ... IF SOMETHING HAPPEN RELATED
+// TO THE RISKS AND SANCTIONS APPEAR." — there is no opt-out.
+// FDL Art.20-21 + Cabinet Res 134/2025 Art.19 (ongoing monitoring).
+// ---------------------------------------------------------------------------
+
+function subjectRiskTier(event: ScreeningEvent): 'high' | 'medium' | 'low' {
+  if (event.outcome === 'confirmed_match' || event.outcome === 'partial_match') return 'high';
+  return event.riskTier ?? 'medium';
+}
+
+function buildResolvedIdentity(event: ScreeningEvent): ResolvedIdentity | undefined {
+  const identity: ResolvedIdentity = {};
+  if (event.dob) identity.dob = event.dob;
+  if (event.country) identity.nationality = event.country.toUpperCase().slice(0, 4);
+  if (event.idNumber) {
+    identity.idNumber = event.idNumber;
+    identity.idType = 'other';
+  }
+  identity.resolvedBy = event.reviewedBy;
+  identity.resolvedAtIso = event.savedAt;
+  identity.resolutionNote = `Enrolled from screening event ${event.eventId} (${event.outcome})`;
+  const hasAnyIdField = identity.dob || identity.nationality || identity.idNumber;
+  return hasAnyIdField ? identity : undefined;
+}
+
+async function autoEnrolInWatchlist(
+  event: ScreeningEvent
+): Promise<{ ok: boolean; enrolled: boolean; alreadyEnrolled?: boolean; error?: string }> {
+  const subjectId = event.subjectId || event.eventId;
+  try {
+    const store = getStore(WATCHLIST_STORE);
+    for (let attempt = 0; attempt < MAX_CAS_ATTEMPTS; attempt++) {
+      const bucket =
+        (await (
+          store as unknown as {
+            getWithMetadata?: (
+              key: string,
+              opts: unknown
+            ) => Promise<{ data: unknown; etag?: string } | null>;
+          }
+        ).getWithMetadata?.(WATCHLIST_KEY, { type: 'json' })) ?? null;
+      const rawData = bucket?.data ?? null;
+      const etag = bucket?.etag ?? null;
+      const wl = deserialiseWatchlist(rawData);
+      if (wl.entries.has(subjectId)) {
+        return { ok: true, enrolled: false, alreadyEnrolled: true };
+      }
+      addToWatchlist(wl, {
+        id: subjectId,
+        subjectName: event.subjectName,
+        riskTier: subjectRiskTier(event),
+        metadata: {
+          sourceEventId: event.eventId,
+          enrolledVia: 'screening-save',
+          enrolledAt: event.savedAt,
+          ...(event.jurisdiction ? { jurisdiction: event.jurisdiction } : {}),
+        },
+        resolvedIdentity: buildResolvedIdentity(event),
+      });
+
+      const opts = etag ? { onlyIfMatch: etag } : { onlyIfNew: true };
+      try {
+        const res: unknown = await (
+          store as unknown as {
+            setJSON: (key: string, value: unknown, opts?: unknown) => Promise<unknown>;
+          }
+        ).setJSON(WATCHLIST_KEY, serialiseWatchlist(wl) as SerialisedWatchlist, opts);
+        const landed =
+          res === null || res === undefined
+            ? true
+            : typeof res === 'object' && 'modified' in (res as Record<string, unknown>)
+              ? (res as { modified: boolean }).modified === true
+              : res !== false;
+        if (landed) return { ok: true, enrolled: true };
+      } catch (err) {
+        return {
+          ok: false,
+          enrolled: false,
+          error: err instanceof Error ? err.message : 'setJSON failed',
+        };
+      }
+      // CAS conflict — re-read and retry.
+    }
+    return { ok: false, enrolled: false, error: 'watchlist CAS contention' };
+  } catch (err) {
+    return {
+      ok: false,
+      enrolled: false,
+      error: err instanceof Error ? err.message : 'blob store unavailable',
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Asana — every saved event creates a task (audit attestation)
 // ---------------------------------------------------------------------------
 
@@ -594,11 +699,26 @@ export default async (req: Request, context: Context): Promise<Response> => {
     projectName: 'Hawkeye Screenings',
   };
 
+  // Auto-enrol in daily monitoring. Product requirement is no opt-out —
+  // every screened subject (individual or legal entity, any outcome,
+  // including negative_no_match) is added to the watchlist so the
+  // sanctions-ingest cron can alert immediately on any future risk
+  // event. Enrolment failure is logged but never blocks the screening
+  // save itself — the event record + Asana attestation is the primary
+  // compliance artefact.
+  const enrolRes = await autoEnrolInWatchlist(event);
+
   return jsonResponse({
     ok: true,
     eventId: event.eventId,
     savedAt: event.savedAt,
     asana,
+    monitoring: {
+      enrolled: enrolRes.enrolled,
+      alreadyEnrolled: enrolRes.alreadyEnrolled === true,
+      ok: enrolRes.ok,
+      error: enrolRes.error,
+    },
   });
 };
 

--- a/screening-command.html
+++ b/screening-command.html
@@ -2254,18 +2254,14 @@
           </div>
         </div>
 
-        <div class="row-2">
-          <div>
-            <label for="enrollInWatchlist">Enroll in daily monitoring</label>
-            <select id="enrollInWatchlist">
-              <option value="true" selected>Yes (06:00 / 14:00 UTC)</option>
-              <option value="false">No</option>
-            </select>
-          </div>
-          <div>
-            <label for="notes">Notes</label>
-            <input type="text" id="notes" placeholder="Context for the MLRO" autocomplete="off" />
-          </div>
+        <div>
+          <label for="notes">Notes</label>
+          <input type="text" id="notes" placeholder="Context for the MLRO" autocomplete="off" />
+          <p class="help-text" style="margin-top: 4px">
+            Every screened subject is automatically enrolled in daily monitoring (06:00 / 14:00 UTC)
+            and in immediate sanctions / adverse-media / PEP / UBO alerts. No opt-out (FDL
+            Art.20-21, Cabinet Res 134/2025 Art.19).
+          </p>
         </div>
 
         <p class="help-text" style="margin-top: 6px">
@@ -2607,23 +2603,14 @@
             </select>
           </div>
         </div>
-        <div class="row-2">
-          <div>
-            <label for="tmCommodity">Commodity Type</label>
-            <input
-              type="text"
-              id="tmCommodity"
-              placeholder="e.g. Gold bars, used vehicles, diamonds"
-              autocomplete="off"
-            />
-          </div>
-          <div>
-            <label for="tmEnrollMonitoring">Enroll in daily monitoring</label>
-            <select id="tmEnrollMonitoring">
-              <option value="true" selected>Yes (06:00 / 14:00 UTC)</option>
-              <option value="false">No</option>
-            </select>
-          </div>
+        <div>
+          <label for="tmCommodity">Commodity Type</label>
+          <input
+            type="text"
+            id="tmCommodity"
+            placeholder="e.g. Gold bars, used vehicles, diamonds"
+            autocomplete="off"
+          />
         </div>
         <div>
           <label for="tmNotes">Notes</label>

--- a/screening-command.js
+++ b/screening-command.js
@@ -531,7 +531,6 @@
   const eventTypeSelect = $('eventType');
   const riskTierSelect = $('riskTier');
   const jurisdictionInput = $('jurisdiction');
-  const enrollSelect = $('enrollInWatchlist');
   const notesInput = $('notes');
   const screenBtn = $('screenBtn');
   const screenMsg = $('screenMsg');
@@ -1711,7 +1710,7 @@
       jurisdiction: jurisdictionInput.value.trim() || undefined,
       notes: notesInput.value.trim() || undefined,
       selectedLists: selectedLists,
-      enrollInWatchlist: enrollSelect.value === 'true',
+      enrollInWatchlist: true,
       runAdverseMedia: isAdverseMediaEnabled(),
       adverseMediaPredicates: isAdverseMediaEnabled() ? allPredicateKeys() : undefined,
       createAsanaTask: true,
@@ -1766,7 +1765,6 @@
   const tmPaymentMethodSelect = $('tmPaymentMethod');
   const tmPayerMatchesSelect = $('tmPayerMatches');
   const tmCommodityInput = $('tmCommodity');
-  const tmEnrollMonitoringSelect = $('tmEnrollMonitoring');
   const tmNotesInput = $('tmNotes');
   const tmBtn = $('tmBtn');
   const tmMsg = $('tmMsg');
@@ -1889,7 +1887,7 @@
       customerName: customerName,
       transactions: [tx],
       createAsanaOnCritical: true,
-      enrollInDailyMonitoring: tmEnrollMonitoringSelect.value === 'true',
+      enrollInDailyMonitoring: true,
     });
     if (!result.ok) {
       showMessage(tmMsg, result.error, 'error');

--- a/src/services/immediateRiskAlerts.ts
+++ b/src/services/immediateRiskAlerts.ts
@@ -1,0 +1,383 @@
+/**
+ * Immediate Risk Alerts — dispatcher that fires an Asana task within
+ * seconds of a relevant event for any watched subject.
+ *
+ * Triggers supported today:
+ *   - sanctions-ingest delta (NEW / AMENDMENT / DELISTING across
+ *     UN/OFAC SDN/OFAC Cons/EU/UK OFSI/UAE EOCN) — called from
+ *     netlify/functions/sanctions-ingest-cron.mts after computeDelta.
+ *   - adverse-media hot-ingest hit — called from the hot-ingest path
+ *     when a new article mentions a watched subject.
+ *   - PEP status change — called when a PEP feed flips a watched
+ *     subject from non-PEP to PEP or vice versa.
+ *   - UBO status change — called when a UBO register change moves a
+ *     watched subject's >25% ownership.
+ *
+ * For each trigger, the dispatcher:
+ *   1. Loads the current watchlist from Netlify Blobs.
+ *   2. Scores every (subject, candidate) pair via scoreHitAgainstProfile.
+ *   3. Suppresses name-only coincidences (classification 'suppress').
+ *   4. Builds a unified Asana task via buildRiskAlertTask.
+ *   5. Posts the task to the SCREENINGS project via createAsanaTask.
+ *
+ * The dispatcher is deliberately I/O-dependency-injected: tests pass in
+ * fake loaders and fake Asana posters so the whole flow can be driven
+ * deterministically without touching Netlify Blobs or the Asana API.
+ *
+ * Regulatory basis:
+ *   FDL No.10/2025 Art.20-21    CO monitoring duty (must see immediately)
+ *   FDL No.10/2025 Art.24       10yr audit retention of the alert
+ *   FDL No.10/2025 Art.29       never notify the subject (footer in task)
+ *   FDL No.10/2025 Art.35       TFS — freeze THE subject, not the name
+ *   Cabinet Res 74/2020 Art.4   "without delay" — hence "immediate"
+ *   Cabinet Res 134/2025 Art.19 periodic internal review of monitoring
+ *   FATF Rec 10                 positive identification required
+ */
+
+import { getStore } from '@netlify/blobs';
+import { createAsanaTask } from './asanaClient';
+import { deserialiseWatchlist, listAllEntries, type WatchlistEntry } from './screeningWatchlist';
+import { scoreHitAgainstProfile, type IdentityMatchResult } from './identityMatchScore';
+import {
+  buildRiskAlertTask,
+  type RiskAlertChangeType,
+  type RiskAlertContext,
+  type RiskAlertMatch,
+  type RiskAlertScore,
+  type RiskAlertTrigger,
+} from './riskAlertTemplate';
+import type { NormalisedSanction } from './sanctionsIngest';
+
+// ---------------------------------------------------------------------------
+// Injected dependencies — swappable for tests
+// ---------------------------------------------------------------------------
+
+export interface ImmediateRiskAlertsDeps {
+  /** Load the full watchlist — defaults to Netlify Blobs 'screening-watchlist'/'current'. */
+  loadWatchlist: () => Promise<WatchlistEntry[]>;
+  /** Post a task to Asana — defaults to createAsanaTask(). */
+  postTask: (input: {
+    name: string;
+    notes: string;
+    projects: string[];
+    tags: string[];
+  }) => Promise<{ ok: boolean; gid?: string; error?: string }>;
+  /** Env reader — defaults to process.env (allows test override). */
+  env: (key: string) => string | undefined;
+  /** Clock — defaults to new Date(). */
+  now: () => Date;
+}
+
+const WATCHLIST_STORE = 'screening-watchlist';
+const WATCHLIST_KEY = 'current';
+const DEFAULT_SCREENINGS_PROJECT_GID = '1213759768596515';
+
+async function defaultLoadWatchlist(): Promise<WatchlistEntry[]> {
+  try {
+    const store = getStore(WATCHLIST_STORE);
+    const raw = (await store.get(WATCHLIST_KEY, { type: 'json' })) as unknown;
+    const wl = deserialiseWatchlist(raw);
+    return listAllEntries(wl);
+  } catch {
+    return [];
+  }
+}
+
+export function createDefaultDeps(): ImmediateRiskAlertsDeps {
+  return {
+    loadWatchlist: defaultLoadWatchlist,
+    postTask: (input) =>
+      createAsanaTask({
+        name: input.name,
+        notes: input.notes,
+        projects: input.projects,
+        tags: input.tags,
+      }),
+    env: (key) => process.env[key],
+    now: () => new Date(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public input shapes
+// ---------------------------------------------------------------------------
+
+/**
+ * A single candidate to evaluate against the watchlist. Source-agnostic —
+ * the caller maps the native delta/hit shape into this before invoking
+ * the dispatcher.
+ */
+export interface CandidateEntry {
+  list: string;
+  reference: string;
+  primaryName: string;
+  aliases?: string[];
+  dateOfBirth?: string;
+  nationality?: string;
+  idNumber?: string;
+  listedOn?: string;
+  reason?: string;
+  changeType: RiskAlertChangeType;
+  /** For AMENDMENT: free-text summary of what changed. */
+  amendmentSummary?: string;
+}
+
+export interface DispatchContext {
+  trigger: RiskAlertTrigger;
+  runId: string;
+  commitSha?: string;
+}
+
+export interface DispatchTaskRecord {
+  subjectId: string;
+  subjectName: string;
+  list: string;
+  reference: string;
+  severity: 'ALERT' | 'POSSIBLE' | 'CHANGE';
+  classification: IdentityMatchResult['classification'];
+  composite: number;
+  ok: boolean;
+  gid?: string;
+  error?: string;
+}
+
+export interface DispatchSummary {
+  trigger: RiskAlertTrigger;
+  runId: string;
+  watchlistSize: number;
+  candidatesEvaluated: number;
+  suppressed: number;
+  tasksAttempted: number;
+  tasksCreated: number;
+  tasksFailed: number;
+  tasks: DispatchTaskRecord[];
+}
+
+// ---------------------------------------------------------------------------
+// Core dispatcher
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a RiskAlertScore from the raw identityMatchScore output. The
+ * template needs the same payload plus the "clamped" flag so the
+ * reviewer can see that an alert band was downgraded.
+ */
+function buildScore(raw: IdentityMatchResult, hasResolved: boolean): RiskAlertScore {
+  const clamped = !hasResolved && raw.composite >= 0.8 && raw.classification === 'possible';
+  return {
+    composite: raw.composite,
+    breakdown: raw.breakdown,
+    classification: raw.classification,
+    clamped,
+  };
+}
+
+function candidateToMatch(c: CandidateEntry): RiskAlertMatch {
+  return {
+    list: c.list,
+    reference: c.reference,
+    entryName: c.primaryName,
+    entryAliases: c.aliases,
+    entryDob: c.dateOfBirth,
+    entryNationality: c.nationality,
+    entryId: c.idNumber,
+    listedOn: c.listedOn,
+    reason: c.reason,
+    changeType: c.changeType,
+    amendmentSummary: c.amendmentSummary,
+  };
+}
+
+/**
+ * Evaluate one candidate against one subject. Returns `null` when the
+ * hit should be suppressed (name-only coincidence on a non-CHANGE
+ * event). AMENDMENT/DELISTING events only fire if the subject has a
+ * pinned listEntryRef that matches the candidate — otherwise they are
+ * list-wide noise, not subject-specific.
+ */
+function shouldDispatch(
+  subject: WatchlistEntry,
+  candidate: CandidateEntry,
+  score: IdentityMatchResult
+): boolean {
+  if (candidate.changeType === 'AMENDMENT' || candidate.changeType === 'DELISTING') {
+    const pin = subject.resolvedIdentity?.listEntryRef;
+    if (!pin) return false;
+    return (
+      pin.list.trim().toUpperCase() === candidate.list.trim().toUpperCase() &&
+      pin.reference.trim() === candidate.reference.trim()
+    );
+  }
+  // NEW: fire on alert or possible only. Suppress is name-only noise.
+  return score.classification !== 'suppress';
+}
+
+export async function dispatchImmediateAlerts(
+  candidates: readonly CandidateEntry[],
+  ctx: DispatchContext,
+  deps: ImmediateRiskAlertsDeps = createDefaultDeps()
+): Promise<DispatchSummary> {
+  const summary: DispatchSummary = {
+    trigger: ctx.trigger,
+    runId: ctx.runId,
+    watchlistSize: 0,
+    candidatesEvaluated: candidates.length,
+    suppressed: 0,
+    tasksAttempted: 0,
+    tasksCreated: 0,
+    tasksFailed: 0,
+    tasks: [],
+  };
+
+  if (candidates.length === 0) return summary;
+
+  const subjects = await deps.loadWatchlist();
+  summary.watchlistSize = subjects.length;
+  if (subjects.length === 0) return summary;
+
+  const projectGid = deps.env('ASANA_SCREENINGS_PROJECT_GID') || DEFAULT_SCREENINGS_PROJECT_GID;
+  const generatedAtIso = deps.now().toISOString();
+
+  for (const subject of subjects) {
+    for (const candidate of candidates) {
+      const score = scoreHitAgainstProfile(
+        {
+          listEntryName: candidate.primaryName,
+          listEntryAliases: candidate.aliases,
+          listEntryDob: candidate.dateOfBirth,
+          listEntryNationality: candidate.nationality,
+          listEntryIdNumber: candidate.idNumber,
+          listEntryRef: { list: candidate.list, reference: candidate.reference },
+        },
+        subject.subjectName,
+        subject.resolvedIdentity
+      );
+
+      if (!shouldDispatch(subject, candidate, score)) {
+        summary.suppressed += 1;
+        continue;
+      }
+
+      const alertCtx: RiskAlertContext = {
+        trigger: ctx.trigger,
+        runId: ctx.runId,
+        generatedAtIso,
+        commitSha: ctx.commitSha,
+      };
+      const riskScore = buildScore(score, score.hasResolvedIdentity);
+      const task = buildRiskAlertTask({
+        subject,
+        match: candidateToMatch(candidate),
+        score: riskScore,
+        ctx: alertCtx,
+      });
+
+      summary.tasksAttempted += 1;
+      const res = await deps.postTask({
+        name: task.title,
+        notes: task.notes,
+        projects: [projectGid],
+        tags: task.tags,
+      });
+
+      const record: DispatchTaskRecord = {
+        subjectId: subject.id,
+        subjectName: subject.subjectName,
+        list: candidate.list,
+        reference: candidate.reference,
+        severity: task.severity,
+        classification: score.classification,
+        composite: score.composite,
+        ok: res.ok,
+        gid: res.gid,
+        error: res.error,
+      };
+      summary.tasks.push(record);
+      if (res.ok) summary.tasksCreated += 1;
+      else summary.tasksFailed += 1;
+    }
+  }
+
+  return summary;
+}
+
+// ---------------------------------------------------------------------------
+// Convenience adapter — NormalisedSanction → CandidateEntry
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a sanctions-ingest delta to the dispatcher's candidate shape.
+ * NEW entries map 1:1. AMENDMENT entries carry a summary of which
+ * fields changed so the reviewer knows whether the designation is
+ * materially different (e.g. a new passport number vs a cosmetic alias
+ * tweak).
+ */
+export function candidatesFromSanctionsDelta(
+  added: readonly NormalisedSanction[],
+  modified: ReadonlyArray<{ before: NormalisedSanction; after: NormalisedSanction }>,
+  removed: readonly NormalisedSanction[]
+): CandidateEntry[] {
+  const out: CandidateEntry[] = [];
+  for (const s of added) {
+    out.push(normalisedToCandidate(s, 'NEW'));
+  }
+  for (const pair of modified) {
+    const c = normalisedToCandidate(pair.after, 'AMENDMENT');
+    c.amendmentSummary = summariseAmendment(pair.before, pair.after);
+    out.push(c);
+  }
+  for (const s of removed) {
+    out.push(normalisedToCandidate(s, 'DELISTING'));
+  }
+  return out;
+}
+
+function normalisedToCandidate(
+  s: NormalisedSanction,
+  changeType: RiskAlertChangeType
+): CandidateEntry {
+  return {
+    list: s.source,
+    reference: s.sourceId,
+    primaryName: s.primaryName,
+    aliases: s.aliases,
+    dateOfBirth: s.dateOfBirth,
+    nationality: s.nationality,
+    reason: s.remarks,
+    changeType,
+  };
+}
+
+function summariseAmendment(before: NormalisedSanction, after: NormalisedSanction): string {
+  const parts: string[] = [];
+  if (before.primaryName !== after.primaryName) {
+    parts.push(`name "${before.primaryName}" → "${after.primaryName}"`);
+  }
+  if (before.dateOfBirth !== after.dateOfBirth) {
+    parts.push(`DoB ${before.dateOfBirth ?? '(none)'} → ${after.dateOfBirth ?? '(none)'}`);
+  }
+  if (before.nationality !== after.nationality) {
+    parts.push(`nationality ${before.nationality ?? '(none)'} → ${after.nationality ?? '(none)'}`);
+  }
+  if (before.programmes.join(',') !== after.programmes.join(',')) {
+    parts.push(`programmes [${before.programmes.join(', ')}] → [${after.programmes.join(', ')}]`);
+  }
+  const beforeAliases = [...before.aliases].sort().join('|');
+  const afterAliases = [...after.aliases].sort().join('|');
+  if (beforeAliases !== afterAliases) {
+    parts.push(`aliases ${before.aliases.length} → ${after.aliases.length} entries`);
+  }
+  return parts.length > 0 ? parts.join('; ') : 'Record hash changed (no field-level diff computed)';
+}
+
+// ---------------------------------------------------------------------------
+// Internals exported for tests
+// ---------------------------------------------------------------------------
+
+export const __test__ = {
+  buildScore,
+  candidateToMatch,
+  shouldDispatch,
+  normalisedToCandidate,
+  summariseAmendment,
+};

--- a/src/services/riskAlertTemplate.ts
+++ b/src/services/riskAlertTemplate.ts
@@ -1,0 +1,329 @@
+/**
+ * Risk Alert Template — unified Asana task builder for immediate
+ * risk notifications.
+ *
+ * Single template covers every immediate-alert path:
+ *   - sanctions-ingest delta (NEW / AMENDMENT / DELISTING)
+ *   - adverse-media hot-ingest hit
+ *   - PEP status change
+ *   - UBO status change on the subject's legal entity
+ *
+ * Adapts automatically to:
+ *   - resolved vs unresolved identity (FATF Rec 10 clamp)
+ *   - severity band (ALERT / POSSIBLE / CHANGE)
+ *   - trigger source (cron name + runId rendered in SOURCE block)
+ *
+ * Pure function — no I/O, no Asana calls. The dispatcher layer
+ * (src/services/immediateRiskAlerts.ts) feeds the output of this
+ * module to createAsanaTask().
+ *
+ * Regulatory basis (rendered into every task body):
+ *   FATF Rec 10                positive ID
+ *   FDL No.10/2025 Art.12      CDD
+ *   FDL No.10/2025 Art.20-21   CO duty
+ *   FDL No.10/2025 Art.24      10yr retention
+ *   FDL No.10/2025 Art.26-27   STR filing
+ *   FDL No.10/2025 Art.29      no tipping off (RENDERED AT BOTTOM OF EVERY TASK)
+ *   FDL No.10/2025 Art.35      TFS — freezes apply to THE subject
+ *   Cabinet Res 74/2020 Art.4  freeze without delay (EOCN TFS Guidance
+ *                              July 2025: 1-2 h max)
+ *   Cabinet Res 74/2020 Art.6  CNMR within 5 business days
+ */
+
+import type { WatchlistEntry } from './screeningWatchlist';
+import type { IdentityMatchBreakdown, IdentityClassification } from './identityMatchScore';
+
+// ---------------------------------------------------------------------------
+// Public surface
+// ---------------------------------------------------------------------------
+
+export type RiskAlertTrigger =
+  | 'sanctions-ingest'
+  | 'adverse-media-hot'
+  | 'pep-status'
+  | 'ubo-change';
+
+export type RiskAlertChangeType = 'NEW' | 'AMENDMENT' | 'DELISTING';
+
+export interface RiskAlertMatch {
+  /** Which list / feed produced the hit. */
+  list: string;
+  /** Source-stable reference on that list (e.g. QDi.123, SDN-12345). */
+  reference: string;
+  /** Primary name as it appears on the list entry. */
+  entryName: string;
+  /** Up to 3 aliases on the list entry — further truncated by the renderer. */
+  entryAliases?: string[];
+  /** Date of birth on the list entry (any format — rendered verbatim). */
+  entryDob?: string;
+  /** Nationality / country of designation (ISO-2 preferred). */
+  entryNationality?: string;
+  /** ID number on the list entry, if published. */
+  entryId?: string;
+  /** Date listed / effective date — rendered verbatim. */
+  listedOn?: string;
+  /** Designation reason / listing reason — truncated to 300 chars. */
+  reason?: string;
+  /** NEW / AMENDMENT / DELISTING — drives the ACTION block. */
+  changeType: RiskAlertChangeType;
+  /** For AMENDMENT: what changed (free-text summary). */
+  amendmentSummary?: string;
+}
+
+export interface RiskAlertScore {
+  composite: number;
+  breakdown: IdentityMatchBreakdown;
+  classification: IdentityClassification;
+  /** True when the 'alert' band was clamped to 'possible' by the unresolved-identity rule. */
+  clamped: boolean;
+}
+
+export interface RiskAlertContext {
+  trigger: RiskAlertTrigger;
+  /** Cron name / run identifier, rendered into SOURCE. */
+  runId: string;
+  /** ISO timestamp of the event that generated the alert. */
+  generatedAtIso: string;
+  /** Optional git sha of the deployed bot for audit. */
+  commitSha?: string;
+}
+
+export interface RiskAlertInput {
+  subject: WatchlistEntry;
+  match: RiskAlertMatch;
+  score: RiskAlertScore;
+  ctx: RiskAlertContext;
+}
+
+export interface RiskAlertTask {
+  title: string;
+  notes: string;
+  tags: string[];
+  /** ALERT / POSSIBLE / CHANGE — drives assignee + due-date logic in the dispatcher. */
+  severity: 'ALERT' | 'POSSIBLE' | 'CHANGE';
+  /** Whether this task needs CO escalation (alerts do, possibles don't). */
+  requiresCoEscalation: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Severity resolver
+// ---------------------------------------------------------------------------
+
+export function resolveSeverity(
+  score: RiskAlertScore,
+  match: RiskAlertMatch,
+  hasResolvedIdentity: boolean
+): 'ALERT' | 'POSSIBLE' | 'CHANGE' {
+  if (match.changeType === 'AMENDMENT' || match.changeType === 'DELISTING') {
+    return 'CHANGE';
+  }
+  if (score.classification === 'alert' && hasResolvedIdentity) {
+    return 'ALERT';
+  }
+  return 'POSSIBLE';
+}
+
+// ---------------------------------------------------------------------------
+// Formatters
+// ---------------------------------------------------------------------------
+
+function truncate(s: string, n: number): string {
+  if (s.length <= n) return s;
+  return s.slice(0, n - 1) + '…';
+}
+
+function fmt2(n: number): string {
+  if (!Number.isFinite(n)) return '0.00';
+  return n.toFixed(2);
+}
+
+function listSlug(list: string): string {
+  return list
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function renderSubjectBlock(entry: WatchlistEntry): string {
+  const lines: string[] = [];
+  lines.push('SUBJECT');
+  lines.push(`  Customer:     ${entry.subjectName}  (id: ${entry.id})`);
+  lines.push(`  Risk tier:    ${entry.riskTier}`);
+  const rid = entry.resolvedIdentity;
+  if (rid) {
+    const who = rid.resolvedBy ? ` by ${rid.resolvedBy}` : '';
+    const when = rid.resolvedAtIso ? ` ${rid.resolvedAtIso.slice(0, 10)}` : '';
+    lines.push(`  Identity:     PINNED${when}${who}`);
+    if (rid.dob) lines.push(`  DoB:          ${rid.dob}`);
+    if (rid.nationality) lines.push(`  Nationality:  ${rid.nationality}`);
+    if (rid.idNumber) {
+      const type = rid.idType ?? 'id';
+      const issuer = rid.idIssuingCountry ? ` (${rid.idIssuingCountry})` : '';
+      lines.push(`  ID:           ${type} ${rid.idNumber}${issuer}`);
+    }
+    if (rid.aliases && rid.aliases.length > 0) {
+      lines.push(`  Aliases:      ${rid.aliases.join(', ')}`);
+    }
+    if (rid.listEntryRef) {
+      lines.push(`  Pin ref:      ${rid.listEntryRef.list}/${rid.listEntryRef.reference}`);
+    }
+    if (rid.resolutionNote) {
+      lines.push(`  Note:         ${truncate(rid.resolutionNote, 200)}`);
+    }
+  } else {
+    lines.push('  Identity:     UNRESOLVED');
+    lines.push('    FATF Rec 10: NOT yet positively identified. Any "alert" band is');
+    lines.push('    auto-downgraded to "possible" until the MLRO pins or dismisses the');
+    lines.push('    identity in Screening Command.');
+  }
+  return lines.join('\n');
+}
+
+function renderMatchBlock(match: RiskAlertMatch): string {
+  const lines: string[] = [];
+  lines.push('MATCH');
+  lines.push(`  List:         ${match.list}`);
+  lines.push(`  Entry ref:    ${match.reference}`);
+  lines.push(`  Entry name:   ${match.entryName}`);
+  if (match.entryAliases && match.entryAliases.length > 0) {
+    lines.push(
+      `  Entry aliases: ${match.entryAliases
+        .slice(0, 3)
+        .map((a) => `"${a}"`)
+        .join(', ')}`
+    );
+  }
+  if (match.entryDob) lines.push(`  Entry DoB:    ${match.entryDob}`);
+  if (match.entryNationality) lines.push(`  Entry nat:    ${match.entryNationality}`);
+  if (match.entryId) lines.push(`  Entry ID:     ${match.entryId}`);
+  if (match.listedOn) lines.push(`  Listed:       ${match.listedOn}`);
+  if (match.reason) lines.push(`  Reason:       ${truncate(match.reason, 300)}`);
+  lines.push(`  Change type:  ${match.changeType}`);
+  if (match.amendmentSummary) {
+    lines.push(`  What changed: ${truncate(match.amendmentSummary, 300)}`);
+  }
+  return lines.join('\n');
+}
+
+function renderScoreBlock(score: RiskAlertScore): string {
+  const b = score.breakdown;
+  const lines: string[] = [];
+  lines.push('SCORE BREAKDOWN');
+  lines.push(
+    `  name ${fmt2(b.name)}   dob ${fmt2(b.dob)}   nationality ${fmt2(b.nationality)}   id ${fmt2(b.id)}   alias ${fmt2(b.alias)}`
+  );
+  lines.push('  Weights:      name 0.30, dob 0.30, nat 0.20, id 0.20, alias bonus 0.10');
+  lines.push(`  Composite:    ${fmt2(score.composite)}  → ${score.classification}`);
+  lines.push(`  Clamp:        ${score.clamped ? "'alert' → 'possible' (unresolved)" : 'none'}`);
+  return lines.join('\n');
+}
+
+const REGULATORY_BLOCK = [
+  'REGULATORY BASIS',
+  '  FATF Rec 10              positive identification required',
+  '  FDL No.10/2025 Art.12    CDD',
+  '  FDL No.10/2025 Art.20    CO monitoring',
+  '  FDL No.10/2025 Art.35    targeted financial sanctions apply to THE subject',
+  '  FDL No.10/2025 Art.29    no tipping off',
+  '  Cabinet Res 74/2020 Art.4 + EOCN TFS Guidance July 2025',
+  '                           freeze immediately (1-2 h max) on confirmed match',
+  '  Cabinet Res 74/2020 Art.6  CNMR within 5 business days',
+].join('\n');
+
+function renderActionBlock(severity: 'ALERT' | 'POSSIBLE' | 'CHANGE', subjectId: string): string {
+  const lines: string[] = ['ACTION REQUIRED'];
+  if (severity === 'ALERT') {
+    lines.push(`  [ ] 1. FREEZE all assets/accounts under ${subjectId} NOW (1-2 h max).`);
+    lines.push('  [ ] 2. Notify EOCN (goAML) within 5 business days — CNMR.');
+    lines.push('  [ ] 3. Draft STR/SAR, validate via /goaml, upload to FIU portal.');
+    lines.push('  [ ] 4. Log freeze timestamp + 4-eyes approver in audit trail.');
+    lines.push('  [ ] 5. DO NOT notify subject (FDL Art.29).');
+  } else if (severity === 'POSSIBLE') {
+    lines.push('  [ ] 1. Open Screening Command → matched candidates row.');
+    lines.push('  [ ] 2. Click "Pin as subject" (if this person IS the customer)');
+    lines.push('         OR "Not the subject" (if coincidence).');
+    lines.push('  [ ] 3. If pinned: composite rescores on next monitor run. A pinned');
+    lines.push('         composite >= 0.80 escalates to ALERT + freeze path automatically.');
+    lines.push('  [ ] 4. DO NOT notify subject (FDL Art.29).');
+  } else {
+    lines.push('  [ ] 1. Read the amendment / delisting above.');
+    lines.push('  [ ] 2. Decide if existing freeze remains sufficient or needs extension.');
+    lines.push('  [ ] 3. Update STR file if material; re-file to FIU if required.');
+    lines.push('  [ ] 4. DO NOT notify subject (FDL Art.29).');
+  }
+  return lines.join('\n');
+}
+
+function renderSourceBlock(ctx: RiskAlertContext): string {
+  const lines: string[] = [];
+  lines.push('SOURCE');
+  lines.push(`  Trigger:   ${ctx.trigger}`);
+  lines.push(`  Run:       ${ctx.runId}`);
+  lines.push(`  At:        ${ctx.generatedAtIso}`);
+  if (ctx.commitSha) lines.push(`  Commit:    ${ctx.commitSha}`);
+  return lines.join('\n');
+}
+
+const TIPOFF_FOOTER = [
+  '──────────────────────────────────────────────────────────────────',
+  'Do NOT notify the subject — FDL No.10/2025 Art.29 (no tipping off).',
+  '──────────────────────────────────────────────────────────────────',
+].join('\n');
+
+// ---------------------------------------------------------------------------
+// Main builder
+// ---------------------------------------------------------------------------
+
+export function buildRiskAlertTask(input: RiskAlertInput): RiskAlertTask {
+  const { subject, match, score, ctx } = input;
+  const hasResolved = Boolean(subject.resolvedIdentity);
+  const severity = resolveSeverity(score, match, hasResolved);
+
+  const pinMarker =
+    hasResolved && subject.resolvedIdentity?.listEntryRef
+      ? ` (PIN:${subject.resolvedIdentity.listEntryRef.list}/${subject.resolvedIdentity.listEntryRef.reference})`
+      : '';
+  const title = truncate(
+    `[SCREEN:${severity}] ${match.list} — ${subject.subjectName}${pinMarker}`,
+    300
+  );
+
+  const tags: string[] = ['screening', severity.toLowerCase(), listSlug(match.list)];
+  tags.push(hasResolved ? 'pinned-match' : 'unresolved-identity');
+  tags.push(`trigger-${ctx.trigger}`);
+
+  const header = [
+    '┌───────────────────────────────────────────────────────────────┐',
+    `│ POTENTIAL MATCH                                               │`,
+    `│ Severity: ${severity.padEnd(51)} │`,
+    `│ Composite score: ${fmt2(score.composite)}  →  ${score.classification.padEnd(38)} │`,
+    `│ Generated: ${ctx.generatedAtIso.padEnd(50)} │`,
+    '└───────────────────────────────────────────────────────────────┘',
+  ].join('\n');
+
+  const notes = [
+    header,
+    '',
+    renderSubjectBlock(subject),
+    '',
+    renderMatchBlock(match),
+    '',
+    renderScoreBlock(score),
+    '',
+    REGULATORY_BLOCK,
+    '',
+    renderActionBlock(severity, subject.id),
+    '',
+    renderSourceBlock(ctx),
+    '',
+    TIPOFF_FOOTER,
+  ].join('\n');
+
+  return {
+    title,
+    notes: truncate(notes, 60_000),
+    tags,
+    severity,
+    requiresCoEscalation: severity === 'ALERT',
+  };
+}

--- a/tests/immediateRiskAlerts.test.ts
+++ b/tests/immediateRiskAlerts.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Tests for dispatchImmediateAlerts — the dispatcher that fans out
+ * sanctions/adverse-media/PEP/UBO events to Asana for every watched
+ * subject impacted.
+ *
+ * Coverage:
+ *   - Empty candidate list → no tasks, summary reports zero work.
+ *   - Empty watchlist → no tasks even if candidates present.
+ *   - Name-only coincidence (classification=suppress) is suppressed.
+ *   - Pinned match to a new designation fires an ALERT task.
+ *   - Unresolved match on a matching name fires a POSSIBLE task.
+ *   - AMENDMENT event without a pin is NOT dispatched to that subject.
+ *   - AMENDMENT event with a matching pin IS dispatched as CHANGE.
+ *   - DELISTING event with a matching pin fires CHANGE.
+ *   - Asana failure is recorded in summary but does not stop other
+ *     tasks from being attempted.
+ *   - candidatesFromSanctionsDelta maps NEW/AMENDMENT/DELISTING correctly.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  dispatchImmediateAlerts,
+  candidatesFromSanctionsDelta,
+  type CandidateEntry,
+  type DispatchContext,
+  type ImmediateRiskAlertsDeps,
+} from '../src/services/immediateRiskAlerts';
+import type { WatchlistEntry } from '../src/services/screeningWatchlist';
+import type { NormalisedSanction } from '../src/services/sanctionsIngest';
+
+const CTX: DispatchContext = {
+  trigger: 'sanctions-ingest',
+  runId: 'test-run',
+  commitSha: 'deadbee',
+};
+
+const FIXED_NOW = new Date('2026-04-18T10:00:00.000Z');
+
+function makeDeps(overrides: Partial<ImmediateRiskAlertsDeps>): ImmediateRiskAlertsDeps {
+  return {
+    loadWatchlist: vi.fn(async () => []),
+    postTask: vi.fn(async () => ({ ok: true, gid: 'task-1' })),
+    env: () => 'PROJ-GID',
+    now: () => FIXED_NOW,
+    ...overrides,
+  };
+}
+
+const PINNED_UN_SUBJECT: WatchlistEntry = {
+  id: 'CUS-42',
+  subjectName: 'Mohamed Ahmed',
+  riskTier: 'high',
+  addedAtIso: '2026-04-01T00:00:00.000Z',
+  seenHitFingerprints: [],
+  alertCount: 0,
+  resolvedIdentity: {
+    dob: '12/03/1982',
+    nationality: 'AE',
+    idType: 'emirates_id',
+    idNumber: '784-1982-1234567-1',
+    listEntryRef: { list: 'UN', reference: 'QDi.123' },
+    resolvedBy: 'MLRO',
+    resolvedAtIso: '2026-04-10T08:00:00.000Z',
+  },
+};
+
+const UNRESOLVED_SUBJECT: WatchlistEntry = {
+  id: 'CUS-99',
+  subjectName: 'Ahmad Al Marri',
+  riskTier: 'medium',
+  addedAtIso: '2026-04-15T00:00:00.000Z',
+  seenHitFingerprints: [],
+  alertCount: 0,
+};
+
+/**
+ * Subject partially resolved (DoB only) — enough for a name+dob match
+ * to cross the 0.50 "possible" threshold without crossing the 0.80
+ * alert threshold. Models the common case where the MLRO captured a
+ * DoB during onboarding but never pinned a specific designation.
+ */
+const DOB_ONLY_SUBJECT: WatchlistEntry = {
+  id: 'CUS-77',
+  subjectName: 'Ahmad Al Marri',
+  riskTier: 'medium',
+  addedAtIso: '2026-04-15T00:00:00.000Z',
+  seenHitFingerprints: [],
+  alertCount: 0,
+  resolvedIdentity: {
+    dob: '01/01/1990',
+    resolvedBy: 'MLRO',
+    resolvedAtIso: '2026-04-15T00:00:00.000Z',
+  },
+};
+
+describe('dispatchImmediateAlerts', () => {
+  it('does nothing when there are no candidates', async () => {
+    const deps = makeDeps({});
+    const res = await dispatchImmediateAlerts([], CTX, deps);
+    expect(res.tasksAttempted).toBe(0);
+    expect(res.watchlistSize).toBe(0);
+    expect(deps.loadWatchlist).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the watchlist is empty', async () => {
+    const deps = makeDeps({ loadWatchlist: vi.fn(async () => []) });
+    const res = await dispatchImmediateAlerts(
+      [
+        {
+          list: 'UN',
+          reference: 'X',
+          primaryName: 'Someone',
+          changeType: 'NEW',
+        },
+      ],
+      CTX,
+      deps
+    );
+    expect(res.tasksAttempted).toBe(0);
+    expect(deps.postTask).not.toHaveBeenCalled();
+  });
+
+  it('suppresses name-only coincidence', async () => {
+    const deps = makeDeps({
+      loadWatchlist: vi.fn(async () => [PINNED_UN_SUBJECT]),
+    });
+    // Same-reference different name — name is far off, pin only triggers
+    // on ref match which won't promote a totally different name.
+    const candidate: CandidateEntry = {
+      list: 'UN',
+      reference: 'QDi.999', // different from pinned QDi.123
+      primaryName: 'Zelda Fitzgerald', // totally different name
+      changeType: 'NEW',
+    };
+    const res = await dispatchImmediateAlerts([candidate], CTX, deps);
+    expect(res.suppressed).toBe(1);
+    expect(res.tasksAttempted).toBe(0);
+  });
+
+  it('fires ALERT for a pinned match with full identifiers', async () => {
+    const postTask = vi.fn(async () => ({ ok: true, gid: 'G1' }));
+    const deps = makeDeps({
+      loadWatchlist: vi.fn(async () => [PINNED_UN_SUBJECT]),
+      postTask,
+    });
+    const candidate: CandidateEntry = {
+      list: 'UN',
+      reference: 'QDi.123', // matches the pinned ref → treated as ID=1
+      primaryName: 'Mohamed Ahmed',
+      dateOfBirth: '12/03/1982',
+      nationality: 'AE',
+      changeType: 'NEW',
+      reason: 'ISIL associate',
+    };
+    const res = await dispatchImmediateAlerts([candidate], CTX, deps);
+    expect(res.tasksCreated).toBe(1);
+    expect(res.tasks[0].severity).toBe('ALERT');
+    expect(postTask).toHaveBeenCalledOnce();
+    const call = postTask.mock.calls[0]![0];
+    expect(call.projects).toEqual(['PROJ-GID']);
+    expect(call.name).toContain('[SCREEN:ALERT]');
+    expect(call.name).toContain('(PIN:UN/QDi.123)');
+    expect(call.tags).toContain('pinned-match');
+  });
+
+  it('fires POSSIBLE for a partial-identity match (name + DoB, no pin)', async () => {
+    const postTask = vi.fn(async () => ({ ok: true, gid: 'G2' }));
+    const deps = makeDeps({
+      loadWatchlist: vi.fn(async () => [DOB_ONLY_SUBJECT]),
+      postTask,
+    });
+    const candidate: CandidateEntry = {
+      list: 'OFAC_SDN',
+      reference: 'SDN-9999',
+      primaryName: 'Ahmad Al Marri',
+      dateOfBirth: '01/01/1990',
+      changeType: 'NEW',
+    };
+    const res = await dispatchImmediateAlerts([candidate], CTX, deps);
+    expect(res.tasksCreated).toBe(1);
+    expect(res.tasks[0].severity).toBe('POSSIBLE');
+    expect(postTask).toHaveBeenCalledOnce();
+    const call = postTask.mock.calls[0]![0];
+    // DOB_ONLY_SUBJECT has a resolvedIdentity so it's tagged as pinned-match.
+    expect(call.tags).toContain('pinned-match');
+  });
+
+  it('does NOT dispatch AMENDMENT to subjects without a matching pin', async () => {
+    const postTask = vi.fn(async () => ({ ok: true, gid: 'G3' }));
+    const deps = makeDeps({
+      loadWatchlist: vi.fn(async () => [UNRESOLVED_SUBJECT, PINNED_UN_SUBJECT]),
+      postTask,
+    });
+    const candidate: CandidateEntry = {
+      list: 'UN',
+      reference: 'QDi.777', // NOT the pinned ref (QDi.123)
+      primaryName: 'Someone Else',
+      changeType: 'AMENDMENT',
+      amendmentSummary: 'passport number added',
+    };
+    const res = await dispatchImmediateAlerts([candidate], CTX, deps);
+    expect(res.tasksCreated).toBe(0);
+    expect(postTask).not.toHaveBeenCalled();
+  });
+
+  it('dispatches AMENDMENT to the pinned subject when the ref matches', async () => {
+    const postTask = vi.fn(async () => ({ ok: true, gid: 'G4' }));
+    const deps = makeDeps({
+      loadWatchlist: vi.fn(async () => [PINNED_UN_SUBJECT]),
+      postTask,
+    });
+    const candidate: CandidateEntry = {
+      list: 'UN',
+      reference: 'QDi.123',
+      primaryName: 'Mohamed Ahmed',
+      changeType: 'AMENDMENT',
+      amendmentSummary: 'DoB 12/03/1982 → 12/03/1981',
+    };
+    const res = await dispatchImmediateAlerts([candidate], CTX, deps);
+    expect(res.tasksCreated).toBe(1);
+    expect(res.tasks[0].severity).toBe('CHANGE');
+    const call = postTask.mock.calls[0]![0];
+    expect(call.name).toContain('[SCREEN:CHANGE]');
+  });
+
+  it('dispatches DELISTING to the pinned subject as CHANGE', async () => {
+    const postTask = vi.fn(async () => ({ ok: true, gid: 'G5' }));
+    const deps = makeDeps({
+      loadWatchlist: vi.fn(async () => [PINNED_UN_SUBJECT]),
+      postTask,
+    });
+    const candidate: CandidateEntry = {
+      list: 'UN',
+      reference: 'QDi.123',
+      primaryName: 'Mohamed Ahmed',
+      changeType: 'DELISTING',
+    };
+    const res = await dispatchImmediateAlerts([candidate], CTX, deps);
+    expect(res.tasksCreated).toBe(1);
+    expect(res.tasks[0].severity).toBe('CHANGE');
+  });
+
+  it('records task failure without stopping the remaining tasks', async () => {
+    let callCount = 0;
+    const postTask = vi.fn(async () => {
+      callCount += 1;
+      if (callCount === 1) return { ok: false, error: 'Asana 503' };
+      return { ok: true, gid: `G-${callCount}` };
+    });
+    // Two subjects that both score 'alert' on the same candidate — both
+    // pinned on designation QDi.123 with matching DoB + nationality, so
+    // a candidate carrying the same ref lands an ALERT for each.
+    const TWIN_A: WatchlistEntry = { ...PINNED_UN_SUBJECT, id: 'CUS-A' };
+    const TWIN_B: WatchlistEntry = { ...PINNED_UN_SUBJECT, id: 'CUS-B' };
+    const deps = makeDeps({
+      loadWatchlist: vi.fn(async () => [TWIN_A, TWIN_B]),
+      postTask,
+    });
+    const candidate: CandidateEntry = {
+      list: 'UN',
+      reference: 'QDi.123',
+      primaryName: 'Mohamed Ahmed',
+      dateOfBirth: '12/03/1982',
+      nationality: 'AE',
+      changeType: 'NEW',
+    };
+    const res = await dispatchImmediateAlerts([candidate], CTX, deps);
+    expect(res.tasksAttempted).toBe(2);
+    expect(res.tasksCreated).toBe(1);
+    expect(res.tasksFailed).toBe(1);
+    expect(res.tasks[0].ok).toBe(false);
+    expect(res.tasks[0].error).toBe('Asana 503');
+    expect(res.tasks[1].ok).toBe(true);
+  });
+
+  it('uses the default screenings project GID when env is unset', async () => {
+    const postTask = vi.fn(async () => ({ ok: true, gid: 'G6' }));
+    const deps = makeDeps({
+      loadWatchlist: vi.fn(async () => [DOB_ONLY_SUBJECT]),
+      postTask,
+      env: () => undefined,
+    });
+    const candidate: CandidateEntry = {
+      list: 'OFAC_SDN',
+      reference: 'SDN-1',
+      primaryName: 'Ahmad Al Marri',
+      dateOfBirth: '01/01/1990',
+      changeType: 'NEW',
+    };
+    await dispatchImmediateAlerts([candidate], CTX, deps);
+    expect(postTask.mock.calls[0]![0].projects).toEqual(['1213759768596515']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// candidatesFromSanctionsDelta
+// ---------------------------------------------------------------------------
+
+function makeSanction(overrides: Partial<NormalisedSanction> = {}): NormalisedSanction {
+  return {
+    source: 'UN',
+    sourceId: 'QDi.1',
+    primaryName: 'Some Person',
+    aliases: [],
+    type: 'individual',
+    programmes: ['AQ'],
+    hash: 'deadbeef',
+    ...overrides,
+  };
+}
+
+describe('candidatesFromSanctionsDelta', () => {
+  it('maps added → NEW', () => {
+    const out = candidatesFromSanctionsDelta([makeSanction({ sourceId: 'QDi.1' })], [], []);
+    expect(out).toHaveLength(1);
+    expect(out[0].changeType).toBe('NEW');
+    expect(out[0].reference).toBe('QDi.1');
+  });
+
+  it('maps modified → AMENDMENT with a diff summary', () => {
+    const before = makeSanction({ sourceId: 'QDi.2', dateOfBirth: '1970' });
+    const after = makeSanction({ sourceId: 'QDi.2', dateOfBirth: '1971' });
+    const out = candidatesFromSanctionsDelta([], [{ before, after }], []);
+    expect(out).toHaveLength(1);
+    expect(out[0].changeType).toBe('AMENDMENT');
+    expect(out[0].amendmentSummary).toContain('DoB 1970 → 1971');
+  });
+
+  it('maps removed → DELISTING', () => {
+    const out = candidatesFromSanctionsDelta([], [], [makeSanction({ sourceId: 'QDi.3' })]);
+    expect(out).toHaveLength(1);
+    expect(out[0].changeType).toBe('DELISTING');
+  });
+
+  it('maps mixed delta preserving order add → mod → del', () => {
+    const out = candidatesFromSanctionsDelta(
+      [makeSanction({ sourceId: 'A' })],
+      [
+        {
+          before: makeSanction({ sourceId: 'B' }),
+          after: makeSanction({ sourceId: 'B', primaryName: 'X' }),
+        },
+      ],
+      [makeSanction({ sourceId: 'C' })]
+    );
+    expect(out.map((c) => c.changeType)).toEqual(['NEW', 'AMENDMENT', 'DELISTING']);
+  });
+});

--- a/tests/riskAlertTemplate.test.ts
+++ b/tests/riskAlertTemplate.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Tests for buildRiskAlertTask — the unified Asana task template used
+ * by every immediate-risk-alert trigger (sanctions-ingest delta,
+ * adverse-media hot-ingest hit, PEP change, UBO change).
+ *
+ * Coverage:
+ *   - Unresolved identity renders the FATF Rec 10 warning block.
+ *   - Pinned identity renders the SUBJECT facets and the pin ref.
+ *   - Severity resolves to ALERT only when pinned AND classification=alert.
+ *   - AMENDMENT / DELISTING always resolve to CHANGE regardless of score.
+ *   - The no-tipping-off footer is present in every output.
+ *   - The task title includes the severity, list, subject, and pin ref
+ *     when the subject is pinned.
+ *   - Tags include severity + list slug + pinned/unresolved marker +
+ *     trigger tag so Asana filters can slice by any dimension.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildRiskAlertTask,
+  resolveSeverity,
+  type RiskAlertInput,
+} from '../src/services/riskAlertTemplate';
+import type { WatchlistEntry } from '../src/services/screeningWatchlist';
+
+const BASE_SUBJECT: WatchlistEntry = {
+  id: 'CUS-42',
+  subjectName: 'Mohamed Ahmed',
+  riskTier: 'high',
+  addedAtIso: '2026-04-01T00:00:00.000Z',
+  seenHitFingerprints: [],
+  alertCount: 0,
+};
+
+const PINNED_SUBJECT: WatchlistEntry = {
+  ...BASE_SUBJECT,
+  resolvedIdentity: {
+    dob: '12/03/1982',
+    nationality: 'AE',
+    idType: 'emirates_id',
+    idNumber: '784-1982-1234567-1',
+    aliases: ['Mohammed A. Al-Marri'],
+    listEntryRef: { list: 'UN', reference: 'QDi.123' },
+    resolvedAtIso: '2026-04-10T08:00:00.000Z',
+    resolvedBy: 'MLRO',
+    resolutionNote: 'Pinned by MLRO during onboarding screening',
+  },
+};
+
+const CTX = {
+  trigger: 'sanctions-ingest' as const,
+  runId: 'sanctions-ingest-2026-04-18T10:00:00.000Z::UN',
+  generatedAtIso: '2026-04-18T10:00:00.000Z',
+  commitSha: 'abc1234',
+};
+
+function baseInput(): RiskAlertInput {
+  return {
+    subject: BASE_SUBJECT,
+    match: {
+      list: 'UN',
+      reference: 'QDi.999',
+      entryName: 'Mohamed Ahmed',
+      entryAliases: ['M. Ahmed'],
+      entryDob: '12/03/1982',
+      entryNationality: 'AE',
+      changeType: 'NEW',
+      listedOn: '2026-04-18',
+      reason: 'Designated for association with ISIL/Al-Qaida (QDi.999).',
+    },
+    score: {
+      composite: 0.62,
+      breakdown: { name: 0.95, dob: 0.5, nationality: 1, id: 0, alias: 0 },
+      classification: 'possible',
+      clamped: false,
+    },
+    ctx: CTX,
+  };
+}
+
+describe('resolveSeverity', () => {
+  it('returns CHANGE for AMENDMENT regardless of score', () => {
+    expect(
+      resolveSeverity(
+        {
+          composite: 0.95,
+          breakdown: { name: 1, dob: 1, nationality: 1, id: 1, alias: 0 },
+          classification: 'alert',
+          clamped: false,
+        },
+        { list: 'UN', reference: 'X', entryName: 'X', changeType: 'AMENDMENT' },
+        true
+      )
+    ).toBe('CHANGE');
+  });
+
+  it('returns CHANGE for DELISTING regardless of score', () => {
+    expect(
+      resolveSeverity(
+        {
+          composite: 0,
+          breakdown: { name: 0, dob: 0, nationality: 0, id: 0, alias: 0 },
+          classification: 'suppress',
+          clamped: false,
+        },
+        { list: 'UN', reference: 'X', entryName: 'X', changeType: 'DELISTING' },
+        true
+      )
+    ).toBe('CHANGE');
+  });
+
+  it('returns ALERT only when classification=alert AND subject is pinned', () => {
+    expect(
+      resolveSeverity(
+        {
+          composite: 0.9,
+          breakdown: { name: 1, dob: 1, nationality: 1, id: 0.5, alias: 0 },
+          classification: 'alert',
+          clamped: false,
+        },
+        { list: 'UN', reference: 'X', entryName: 'X', changeType: 'NEW' },
+        true
+      )
+    ).toBe('ALERT');
+  });
+
+  it('downgrades alert to POSSIBLE when subject is unresolved', () => {
+    expect(
+      resolveSeverity(
+        {
+          composite: 0.9,
+          breakdown: { name: 1, dob: 1, nationality: 1, id: 0.5, alias: 0 },
+          classification: 'alert',
+          clamped: true,
+        },
+        { list: 'UN', reference: 'X', entryName: 'X', changeType: 'NEW' },
+        false
+      )
+    ).toBe('POSSIBLE');
+  });
+});
+
+describe('buildRiskAlertTask — unresolved POSSIBLE', () => {
+  it('renders the FATF Rec 10 warning for unresolved subjects', () => {
+    const task = buildRiskAlertTask(baseInput());
+    expect(task.severity).toBe('POSSIBLE');
+    expect(task.requiresCoEscalation).toBe(false);
+    expect(task.notes).toContain('UNRESOLVED');
+    expect(task.notes).toContain('FATF Rec 10');
+    expect(task.notes).toContain('auto-downgraded to "possible"');
+  });
+
+  it('renders the POSSIBLE action block with pin-or-dismiss steps', () => {
+    const task = buildRiskAlertTask(baseInput());
+    expect(task.notes).toContain('Open Screening Command');
+    expect(task.notes).toContain('Pin as subject');
+    expect(task.notes).toContain('Not the subject');
+  });
+
+  it('tags include unresolved-identity marker', () => {
+    const task = buildRiskAlertTask(baseInput());
+    expect(task.tags).toContain('unresolved-identity');
+    expect(task.tags).toContain('possible');
+    expect(task.tags).toContain('screening');
+    expect(task.tags).toContain('trigger-sanctions-ingest');
+  });
+
+  it('does not tip off the subject (footer always rendered)', () => {
+    const task = buildRiskAlertTask(baseInput());
+    expect(task.notes).toContain('Art.29');
+    expect(task.notes).toContain('Do NOT notify the subject');
+  });
+
+  it('title has no pin marker when subject is unresolved', () => {
+    const task = buildRiskAlertTask(baseInput());
+    expect(task.title).toContain('[SCREEN:POSSIBLE]');
+    expect(task.title).toContain('UN');
+    expect(task.title).toContain('Mohamed Ahmed');
+    expect(task.title).not.toContain('PIN:');
+  });
+});
+
+describe('buildRiskAlertTask — pinned ALERT', () => {
+  it('renders the full SUBJECT facet block when pinned', () => {
+    const input = baseInput();
+    input.subject = PINNED_SUBJECT;
+    input.match.reference = 'QDi.123'; // same as pinned designation
+    input.score = {
+      composite: 0.95,
+      breakdown: { name: 1, dob: 1, nationality: 1, id: 1, alias: 0 },
+      classification: 'alert',
+      clamped: false,
+    };
+    const task = buildRiskAlertTask(input);
+    expect(task.severity).toBe('ALERT');
+    expect(task.requiresCoEscalation).toBe(true);
+    expect(task.notes).toContain('PINNED');
+    expect(task.notes).toContain('12/03/1982');
+    expect(task.notes).toContain('AE');
+    expect(task.notes).toContain('emirates_id');
+    expect(task.notes).toContain('Mohammed A. Al-Marri');
+    expect(task.notes).toContain('UN/QDi.123');
+  });
+
+  it('renders the ALERT action block with freeze + CNMR + STR steps', () => {
+    const input = baseInput();
+    input.subject = PINNED_SUBJECT;
+    input.score = {
+      composite: 0.95,
+      breakdown: { name: 1, dob: 1, nationality: 1, id: 1, alias: 0 },
+      classification: 'alert',
+      clamped: false,
+    };
+    const task = buildRiskAlertTask(input);
+    expect(task.notes).toContain('FREEZE all assets/accounts under CUS-42 NOW');
+    expect(task.notes).toContain('EOCN');
+    expect(task.notes).toContain('CNMR');
+    expect(task.notes).toContain('Draft STR/SAR');
+  });
+
+  it('title includes pin marker when pinned', () => {
+    const input = baseInput();
+    input.subject = PINNED_SUBJECT;
+    input.score = {
+      composite: 0.95,
+      breakdown: { name: 1, dob: 1, nationality: 1, id: 1, alias: 0 },
+      classification: 'alert',
+      clamped: false,
+    };
+    const task = buildRiskAlertTask(input);
+    expect(task.title).toContain('[SCREEN:ALERT]');
+    expect(task.title).toContain('(PIN:UN/QDi.123)');
+  });
+
+  it('tags include pinned-match + alert + list slug', () => {
+    const input = baseInput();
+    input.subject = PINNED_SUBJECT;
+    input.score = {
+      composite: 0.95,
+      breakdown: { name: 1, dob: 1, nationality: 1, id: 1, alias: 0 },
+      classification: 'alert',
+      clamped: false,
+    };
+    const task = buildRiskAlertTask(input);
+    expect(task.tags).toContain('pinned-match');
+    expect(task.tags).toContain('alert');
+    expect(task.tags).toContain('un');
+  });
+});
+
+describe('buildRiskAlertTask — CHANGE (amendment)', () => {
+  it('renders CHANGE severity and amendment summary', () => {
+    const input = baseInput();
+    input.subject = PINNED_SUBJECT;
+    input.match.changeType = 'AMENDMENT';
+    input.match.amendmentSummary = 'DoB 12/03/1982 → 12/03/1981';
+    input.match.reference = 'QDi.123';
+    const task = buildRiskAlertTask(input);
+    expect(task.severity).toBe('CHANGE');
+    expect(task.notes).toContain('AMENDMENT');
+    expect(task.notes).toContain('What changed: DoB 12/03/1982 → 12/03/1981');
+    expect(task.notes).toContain('Read the amendment / delisting above');
+  });
+});
+
+describe('buildRiskAlertTask — formatting', () => {
+  it('truncates notes to 60000 chars (Asana task body cap)', () => {
+    const input = baseInput();
+    input.match.reason = 'x'.repeat(10_000); // will be truncated to 300 by template
+    const task = buildRiskAlertTask(input);
+    expect(task.notes.length).toBeLessThanOrEqual(60_000);
+  });
+
+  it('renders score breakdown with weights line for auditor transparency', () => {
+    const task = buildRiskAlertTask(baseInput());
+    expect(task.notes).toContain('SCORE BREAKDOWN');
+    expect(task.notes).toContain('name 0.30, dob 0.30, nat 0.20, id 0.20, alias bonus 0.10');
+    expect(task.notes).toContain('Composite:');
+  });
+
+  it('renders regulatory basis block with every cited article', () => {
+    const task = buildRiskAlertTask(baseInput());
+    expect(task.notes).toContain('REGULATORY BASIS');
+    expect(task.notes).toContain('FATF Rec 10');
+    expect(task.notes).toContain('FDL No.10/2025 Art.12');
+    expect(task.notes).toContain('FDL No.10/2025 Art.35');
+    expect(task.notes).toContain('Cabinet Res 74/2020 Art.4');
+    expect(task.notes).toContain('Cabinet Res 74/2020 Art.6');
+  });
+
+  it('renders SOURCE block with trigger + runId + commit', () => {
+    const task = buildRiskAlertTask(baseInput());
+    expect(task.notes).toContain('Trigger:   sanctions-ingest');
+    expect(task.notes).toContain('abc1234');
+  });
+});


### PR DESCRIPTION
## Summary

PR #A of the continuous-monitoring plan. Ships the pieces that don't need
new data sources:

- **Unified Asana risk-alert template** (`src/services/riskAlertTemplate.ts`)
  with three severity bands (ALERT / POSSIBLE / CHANGE), unresolved-identity
  FATF Rec 10 clamp, and full regulatory-basis + no-tipping-off footer.
- **Dispatcher** (`src/services/immediateRiskAlerts.ts`) — pure DI module
  that scores every sanctions-delta candidate against the watchlist and
  posts one Asana task per match. AMENDMENT/DELISTING only fire for
  pinned designations.
- **Sanctions-ingest cron** now calls the dispatcher after `computeDelta`
  on every `*/15` run → near-real-time alerting.
- **Auto-enrol every screen** in `screening-save.mts` (individuals AND
  entities) using the Netlify Blobs CAS envelope pattern. No opt-out.
- **UI** removes the "Enroll in daily monitoring" select from both the
  screening form and the TM form; replaced with a Notes field + help text
  citing FDL Art.20-21, Cabinet Res 134/2025 Art.19.

## Regulatory basis

- **FDL No.10/2025** Art.12 (CDD), Art.20-21 (CO ongoing monitoring duty),
  Art.24 (10-yr retention), Art.26-27 (STR), Art.29 (no tipping off),
  Art.35 (TFS)
- **Cabinet Res 134/2025** Art.7-10 (CDD tiers), Art.19 (internal review)
- **Cabinet Res 74/2020** Art.4-7 (24h freeze, EOCN, CNMR within 5 days)
- **FATF Rec 10** — source of the unresolved-identity clamp
- **EOCN TFS Guidance July 2025** — 1-2h freeze window that justifies the
  immediate (non-daily) dispatch path

## Product directive

> "NO opt-out" + "IF SOMETHING HAPPEN RELATED TO THE RISKS...IT MUST BE
> IMMEDIATELY" + "BOTH ARE NICE. MERGE IN 1 AND MAKE A KILLER ONE"

## Test plan

- [x] `vitest`: 4768 / 4768 pass (32 new — 18 template + 14 dispatcher)
- [x] `tsc --noEmit`: clean
- [x] `eslint` on changed src/ + netlify/functions files: clean
- [x] `prettier`: applied
- [ ] Post-deploy: trigger a test sanctions-ingest run against a pinned
      subject and confirm the Asana task renders with the pin marker +
      ALERT severity
- [ ] Post-deploy: screen a new subject and confirm `monitoring.enrolled`
      is `true` in the response and the subject appears in the next
      daily-monitor cron pass

https://claude.ai/code/session_014AJc3FP33Xru5x6HSrjb9r