### PR TITLE
ui(screening-command): make auth + watchlist stat borders yellow

### DIFF
--- a/screening-command.html
+++ b/screening-command.html
@@ -1709,7 +1709,7 @@
             type="button"
             id="loginBtn"
             class="token-gen-btn"
-            style="flex: 1; color: #22c55e; border-color: #22c55e"
+            style="flex: 1; color: #22c55e; border-color: var(--gold)"
             title="Exchange password for a signed 1-year session token"
           >
             Sign in
@@ -1718,7 +1718,7 @@
             type="button"
             id="logoutBtn"
             class="token-gen-btn"
-            style="flex: 1; color: #ef4444; border-color: #ef4444"
+            style="flex: 1; color: #ef4444; border-color: var(--gold)"
             title="Forget the saved session token and require a new sign-in"
           >
             Sign out
@@ -2626,15 +2626,15 @@
         Subjects you screen above auto-enroll here (unless you opt out).
       </p>
       <div class="stat">
-        <div class="stat-item" style="--stat-color: #22c55e; border-color: #22c55e">
+        <div class="stat-item" style="--stat-color: #22c55e; border-color: var(--gold)">
           <div class="stat-value" id="wlCount">—</div>
           <div class="stat-label">Subjects monitored</div>
         </div>
-        <div class="stat-item" style="--stat-color: #ef4444; border-color: #ef4444">
+        <div class="stat-item" style="--stat-color: #ef4444; border-color: var(--gold)">
           <div class="stat-value" id="wlAlerts">—</div>
           <div class="stat-label">Total alerts lifetime</div>
         </div>
-        <div class="stat-item" style="--stat-color: #3b82f6; border-color: #3b82f6">
+        <div class="stat-item" style="--stat-color: #3b82f6; border-color: var(--gold)">
           <div class="stat-value" id="wlLastRun">—</div>
           <div class="stat-label">Last screened</div>
         </div>


### PR DESCRIPTION
## Summary

- SIGN IN (green) + SIGN OUT (red) button borders → `var(--gold)`
- SUBJECTS MONITORED / TOTAL ALERTS LIFETIME / LAST SCREENED stat tile borders → `var(--gold)`
- Text colours preserved (green count, red alerts, blue timestamp,
  green "Sign in", red "Sign out") so semantic affordances still read
  at a glance

Uses the existing `--gold` CSS variable (`#c9a84c`, already used by the
page's `AUTHENTICATION` header and `Refresh watchlist` button) so the
palette stays consistent.

> Note: this branch also contains the in-progress brain upgrade
> (counterfactual / red-team / metacognition). Those modules are not
> wired yet — will merge this UI tweak first, finish the wiring, and
> open a separate PR for the brain work.

## Test plan

- [ ] Deploy preview loads
- [ ] Both cards show yellow borders, text colours unchanged
- [ ] No regression on `Refresh watchlist` button (already gold)
