### PR TITLE
Restrict gender dropdown to Male/Female on screening form

### DIFF
--- a/screening-command.html
+++ b/screening-command.html
@@ -2198,8 +2198,6 @@
               <option value="">Select gender</option>
               <option value="male">Male</option>
               <option value="female">Female</option>
-              <option value="other">Other / non-binary</option>
-              <option value="unspecified">Prefer not to say</option>
             </select>
           </div>
           <div>


### PR DESCRIPTION
## Summary

Removes `Other / non-binary` and `Prefer not to say` options from the gender dropdown on `/screening-command.html`. Only `Male` and `Female` remain (plus the empty "Select gender" placeholder).

## Test plan

- [ ] Manual: load `/screening-command.html`, confirm only Male/Female appear
- [ ] Manual: submit a screening and confirm the gender field is persisted correctly

https://claude.ai/code/session_014AJc3FP33Xru5x6HSrjb9r