### PR TITLE
Redesign screening-command.html as premium purple / lilac / fuchsia control surface

### DIFF
--- a/screening-command.html
+++ b/screening-command.html
@@ -10,30 +10,43 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;600;700&family=Montserrat:wght@200;300;400;500;600&family=DM+Mono:wght@400;500&display=swap"
+      href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@600;700;800&display=swap"
     />
     <style>
       :root {
-        --gold: #c9a84c;
-        --gold-bright: #e6c870;
-        --gold-dim: rgba(201, 168, 76, 0.6);
-        --gold-grad: linear-gradient(135deg, #e6c870 0%, #c9a84c 40%, #a68432 100%);
-        --bg: #080706;
-        --bg-elev: #0f0d0a;
-        --surface: rgba(201, 168, 76, 0.03);
-        --surface2: rgba(201, 168, 76, 0.06);
-        --border: rgba(201, 168, 76, 0.14);
-        --border-strong: rgba(201, 168, 76, 0.28);
-        --text: #f5f0e8;
-        --muted: rgba(245, 240, 232, 0.55);
-        --red: #d94f4f;
-        --amber: #e8a030;
-        --green: #3da876;
-        --blue: #4a90e2;
-        --shadow-lg: 0 24px 60px rgba(0, 0, 0, 0.55), 0 2px 6px rgba(0, 0, 0, 0.25);
-        --shadow-md: 0 8px 24px rgba(0, 0, 0, 0.35);
-        --shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.03);
-        --hairline: rgba(201, 168, 76, 0.18);
+        /* Purple / lilac / fuchsia system — mirrors routines.html blue tokens */
+        --gold: #a855f7;
+        --gold-bright: #c084fc;
+        --gold-dim: rgba(168, 85, 247, 0.6);
+        --gold-grad: linear-gradient(135deg, #e879f9 0%, #a855f7 45%, #8b5cf6 100%);
+        --ink: #0c0614;
+        --midnight: #120a20;
+        --navy: #1a0f2e;
+        --navy-2: #241538;
+        --bg: #0c0614;
+        --bg-elev: #1a0f2e;
+        --surface: rgba(168, 85, 247, 0.04);
+        --surface2: rgba(168, 85, 247, 0.08);
+        --border: rgba(232, 121, 249, 0.16);
+        --border-strong: rgba(232, 121, 249, 0.38);
+        --text: #fae8ff;
+        --muted: rgba(240, 171, 252, 0.55);
+        --royal: #8b5cf6;
+        --azure: #a855f7;
+        --azure-bright: #c084fc;
+        --sky: #e879f9;
+        --ice: #f0abfc;
+        --mist: #fae8ff;
+        --steel: #7e5e95;
+        --accent: #e879f9;
+        --red: #f43f5e;
+        --amber: #f59e0b;
+        --green: #34d399;
+        --blue: #818cf8;
+        --shadow-lg: 0 24px 60px rgba(0, 0, 0, 0.6), 0 2px 6px rgba(0, 0, 0, 0.3);
+        --shadow-md: 0 8px 24px rgba(0, 0, 0, 0.4);
+        --shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+        --hairline: rgba(232, 121, 249, 0.18);
       }
       * {
         box-sizing: border-box;
@@ -45,17 +58,15 @@
         overscroll-behavior-y: contain;
       }
       body {
-        background:
-          radial-gradient(circle at 20% -10%, rgba(201, 168, 76, 0.07), transparent 55%),
-          radial-gradient(circle at 100% 100%, rgba(201, 168, 76, 0.04), transparent 45%), var(--bg);
+        background: var(--midnight);
         color: var(--text);
         font-family:
-          'Montserrat',
+          'Inter',
           -apple-system,
           BlinkMacSystemFont,
           'Segoe UI',
           sans-serif;
-        font-weight: 300;
+        font-weight: 400;
         max-width: 1680px;
         margin: 0 auto;
         padding: 20px 32px 60px;
@@ -77,15 +88,24 @@
         position: fixed;
         inset: 0;
         pointer-events: none;
-        background-image: linear-gradient(
-          to bottom,
-          rgba(255, 255, 255, 0.01) 0px,
-          rgba(255, 255, 255, 0.01) 1px,
-          transparent 1px,
-          transparent 4px
-        );
-        opacity: 0.35;
         z-index: 0;
+        background:
+          radial-gradient(ellipse 80% 60% at 15% 0%, rgba(168, 85, 247, 0.22), transparent 60%),
+          radial-gradient(ellipse 60% 50% at 85% 10%, rgba(139, 92, 246, 0.18), transparent 55%),
+          radial-gradient(ellipse 70% 40% at 50% 100%, rgba(63, 40, 98, 0.55), transparent 60%);
+      }
+      body::after {
+        content: '';
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        z-index: 0;
+        background-image:
+          linear-gradient(to right, rgba(240, 171, 252, 0.035) 1px, transparent 1px),
+          linear-gradient(to bottom, rgba(240, 171, 252, 0.035) 1px, transparent 1px);
+        background-size: 56px 56px;
+        mask-image: radial-gradient(ellipse 90% 70% at 50% 30%, #000 40%, transparent 80%);
+        -webkit-mask-image: radial-gradient(ellipse 90% 70% at 50% 30%, #000 40%, transparent 80%);
       }
       body > * {
         position: relative;
@@ -106,52 +126,82 @@
         justify-content: space-between;
         align-items: center;
         flex-wrap: wrap;
-        gap: 8px;
-        margin-bottom: 6px;
+        gap: 12px;
+        padding: 6px 0 22px;
+        margin-bottom: 22px;
+        border-bottom: 1px solid var(--border);
       }
       .title-group {
         display: flex;
         align-items: center;
-        gap: 14px;
+        gap: 16px;
       }
       .header-logo {
         flex-shrink: 0;
-        border-radius: 8px;
+        border-radius: 10px;
         display: block;
+        box-shadow:
+          0 0 0 1px rgba(232, 121, 249, 0.4),
+          0 8px 24px rgba(168, 85, 247, 0.35),
+          inset 0 1px 0 rgba(255, 255, 255, 0.18);
+      }
+      header a.muted {
+        color: var(--ice);
+        text-decoration: none;
+        font-size: 11px;
+        font-family: 'DM Mono', monospace;
+        letter-spacing: 2px;
+        text-transform: uppercase;
+        border: 1px solid var(--border-strong);
+        padding: 10px 18px;
+        border-radius: 999px;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        background: rgba(26, 15, 46, 0.6);
+        backdrop-filter: blur(12px);
+        transition: all 0.25s ease;
+      }
+      header a.muted:hover {
+        color: var(--mist);
+        border-color: var(--azure-bright);
+        box-shadow: 0 0 0 4px rgba(168, 85, 247, 0.14);
       }
       h1 {
-        font-family: 'Cinzel', serif;
-        font-size: 30px;
-        font-weight: 600;
-        letter-spacing: 3px;
-        text-transform: uppercase;
-        background: linear-gradient(135deg, #ff3d8a 0%, #ff7ab0 45%, #ffb3d1 100%);
+        font-family: 'Playfair Display', serif;
+        font-size: clamp(32px, 3.4vw, 44px);
+        font-weight: 700;
+        letter-spacing: -0.01em;
+        text-transform: none;
+        background: linear-gradient(180deg, #ffffff 0%, var(--ice) 45%, var(--sky) 100%);
         -webkit-background-clip: text;
         background-clip: text;
         color: transparent;
-        text-shadow: 0 1px 0 rgba(0, 0, 0, 0.4);
+        text-shadow: none;
+        line-height: 1.05;
       }
       h1 .badge {
         display: inline-block;
         background: var(--gold-grad);
-        color: #1a1407;
+        color: #ffffff;
         font-size: 10px;
-        padding: 3px 8px;
-        border-radius: 2px;
-        margin-left: 10px;
+        padding: 4px 10px;
+        border-radius: 999px;
+        margin-left: 12px;
         vertical-align: middle;
         font-weight: 700;
         letter-spacing: 1.5px;
+        font-family: 'DM Mono', monospace;
         box-shadow:
-          0 1px 0 rgba(255, 255, 255, 0.15) inset,
-          0 2px 6px rgba(201, 168, 76, 0.25);
+          0 1px 0 rgba(255, 255, 255, 0.2) inset,
+          0 4px 12px rgba(168, 85, 247, 0.45);
       }
       h2 {
-        color: var(--gold);
-        font-family: 'Cinzel', serif;
-        font-size: 15px;
+        color: var(--sky);
+        font-family: 'DM Mono', monospace;
+        font-size: 11px;
         font-weight: 500;
-        letter-spacing: 2px;
+        letter-spacing: 3px;
         text-transform: uppercase;
         margin-bottom: 8px;
         display: flex;
@@ -170,7 +220,7 @@
         background: linear-gradient(
           to right,
           var(--hairline) 0%,
-          rgba(201, 168, 76, 0.08) 40%,
+          rgba(168, 85, 247, 0.08) 40%,
           transparent 100%
         );
       }
@@ -200,7 +250,7 @@
         gap: 14px 26px;
       }
       .intro-block h3 {
-        font-family: 'Cinzel', serif;
+        font-family: 'Playfair Display', serif;
         font-size: 11.5px;
         font-weight: 600;
         letter-spacing: 1.5px;
@@ -242,28 +292,38 @@
         }
       }
       .card {
-        background:
-          linear-gradient(180deg, rgba(255, 255, 255, 0.015), transparent 60%), var(--bg-elev);
+        background: linear-gradient(
+          180deg,
+          rgba(36, 21, 56, 0.85) 0%,
+          rgba(18, 10, 32, 0.95) 100%
+        );
         border: 1px solid var(--border);
-        border-radius: 10px;
-        padding: 20px 22px;
+        border-radius: 16px;
+        padding: 22px 24px;
+        backdrop-filter: blur(14px);
         box-shadow: var(--shadow-md), var(--shadow-inset);
         position: relative;
+        overflow: hidden;
+        transition: border-color 0.3s ease, box-shadow 0.3s ease;
+      }
+      .card:hover {
+        border-color: var(--border-strong);
+        box-shadow: 0 16px 40px -20px rgba(168, 85, 247, 0.35);
       }
       .card::before {
         content: '';
         position: absolute;
         top: 0;
-        left: 18px;
-        right: 18px;
+        left: 20%;
+        right: 20%;
         height: 1px;
         background: linear-gradient(
-          to right,
-          transparent 0%,
-          var(--hairline) 30%,
-          var(--hairline) 70%,
-          transparent 100%
+          90deg,
+          transparent,
+          rgba(232, 121, 249, 0.55),
+          transparent
         );
+        opacity: 0.5;
       }
       label {
         display: block;
@@ -282,14 +342,15 @@
       textarea {
         width: 100%;
         padding: 12px;
-        background: #111;
+        background: rgba(12, 6, 20, 0.75);
         border: 1px solid var(--border-strong);
         color: var(--text);
-        border-radius: 4px;
+        border-radius: 8px;
         font-size: 16px;
         font-family: inherit;
         -webkit-appearance: none;
         appearance: none;
+        transition: border-color 0.2s ease, box-shadow 0.2s ease;
       }
       textarea {
         resize: vertical;
@@ -299,7 +360,8 @@
       select:focus,
       textarea:focus {
         outline: none;
-        border-color: var(--gold);
+        border-color: var(--azure-bright);
+        box-shadow: 0 0 0 3px rgba(168, 85, 247, 0.18);
       }
       select {
         background-image:
@@ -318,27 +380,30 @@
         width: 100%;
         padding: 14px;
         background: transparent;
-        color: var(--gold);
-        border: 1px solid var(--gold);
-        border-radius: 4px;
-        font-size: 14px;
+        color: var(--ice);
+        border: 1px solid var(--border-strong);
+        border-radius: 10px;
+        font-size: 13px;
         font-weight: 600;
-        letter-spacing: 0.5px;
+        letter-spacing: 1.5px;
+        text-transform: uppercase;
         cursor: pointer;
         margin-top: 18px;
         min-height: 48px;
         touch-action: manipulation;
-        font-family: inherit;
+        font-family: 'DM Mono', monospace;
         transition:
           background-color 0.18s ease,
           border-color 0.18s ease,
+          color 0.18s ease,
           box-shadow 0.18s ease,
           transform 0.12s ease;
       }
       button:hover:not(:disabled) {
-        background: rgba(201, 168, 76, 0.08);
-        border-color: var(--gold-bright);
-        box-shadow: 0 0 0 2px rgba(201, 168, 76, 0.12);
+        background: rgba(168, 85, 247, 0.12);
+        border-color: var(--azure-bright);
+        color: var(--mist);
+        box-shadow: 0 0 0 4px rgba(168, 85, 247, 0.14);
       }
       button:active {
         transform: translateY(1px);
@@ -438,9 +503,9 @@
         transition: background 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
       }
       .auth-card.authenticated {
-        background: linear-gradient(135deg, rgba(61, 168, 118, 0.18) 0%, rgba(61, 168, 118, 0.08) 100%);
+        background: linear-gradient(135deg, rgba(52, 211, 153, 0.18) 0%, rgba(52, 211, 153, 0.06) 100%);
         border-color: var(--green) !important;
-        box-shadow: 0 0 0 1px var(--green) inset, 0 8px 24px rgba(61, 168, 118, 0.18);
+        box-shadow: 0 0 0 1px var(--green) inset, 0 8px 24px rgba(52, 211, 153, 0.22);
       }
       .auth-card.authenticated h2 {
         color: var(--green) !important;
@@ -511,8 +576,8 @@
       .subject-details {
         margin-top: 10px;
         padding: 10px 12px;
-        background: rgba(201, 168, 76, 0.05);
-        border: 1px solid rgba(201, 168, 76, 0.2);
+        background: rgba(168, 85, 247, 0.05);
+        border: 1px solid rgba(168, 85, 247, 0.2);
         border-radius: 4px;
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
@@ -1023,7 +1088,7 @@
         margin-top: 4px;
       }
       .coverage-grid .c-h {
-        font-family: 'Cinzel', serif;
+        font-family: 'Playfair Display', serif;
         font-size: 11.5px;
         font-weight: 600;
         letter-spacing: 1.3px;
@@ -1118,7 +1183,7 @@
         font-family: 'DM Mono', ui-monospace, monospace;
       }
       .outcome-btn .label {
-        font-family: 'Cinzel', serif;
+        font-family: 'Playfair Display', serif;
         font-size: 12px;
         font-weight: 600;
         letter-spacing: 1.2px;
@@ -1196,7 +1261,7 @@
       }
       .compliance-report h3 {
         margin: 0 0 4px 0;
-        font-family: 'Cinzel', serif;
+        font-family: 'Playfair Display', serif;
         font-size: 14px;
         letter-spacing: 1px;
         text-transform: uppercase;
@@ -1292,7 +1357,7 @@
         color: var(--gold);
       }
       .compliance-report .cr-pdf-btn:hover {
-        background: rgba(201, 168, 76, 0.08);
+        background: rgba(168, 85, 247, 0.08);
       }
       .compliance-report .cr-asana-link {
         background: transparent;
@@ -1378,7 +1443,7 @@
       }
       .four-eyes h4 {
         margin: 0 0 6px 0;
-        font-family: 'Cinzel', serif;
+        font-family: 'Playfair Display', serif;
         font-size: 13px;
         letter-spacing: 2px;
         text-transform: uppercase;
@@ -1430,7 +1495,7 @@
       button.btn-save,
       button.btn-rerun,
       button.btn-cancel {
-        font-family: 'Cinzel', serif;
+        font-family: 'Playfair Display', serif;
         font-size: 12px;
         font-weight: 600;
         letter-spacing: 2.4px;
@@ -1452,14 +1517,14 @@
         box-shadow:
           0 1px 0 rgba(255, 255, 255, 0.2) inset,
           0 -1px 0 rgba(0, 0, 0, 0.25) inset,
-          0 8px 20px rgba(201, 168, 76, 0.22);
+          0 8px 20px rgba(168, 85, 247, 0.22);
       }
       button.btn-save:hover {
         transform: translateY(-1px);
         box-shadow:
           0 1px 0 rgba(255, 255, 255, 0.25) inset,
           0 -1px 0 rgba(0, 0, 0, 0.25) inset,
-          0 14px 30px rgba(201, 168, 76, 0.3);
+          0 14px 30px rgba(168, 85, 247, 0.3);
       }
       button.btn-save:active {
         transform: translateY(0);
@@ -1518,11 +1583,11 @@
         outline: none;
         border-color: var(--gold) !important;
         box-shadow:
-          0 0 0 1px rgba(201, 168, 76, 0.2),
-          0 0 0 4px rgba(201, 168, 76, 0.08);
+          0 0 0 1px rgba(168, 85, 247, 0.2),
+          0 0 0 4px rgba(168, 85, 247, 0.08);
       }
       ::selection {
-        background: rgba(201, 168, 76, 0.3);
+        background: rgba(168, 85, 247, 0.3);
         color: var(--text);
       }
       /* Refined scrollbar for the luxury language. */
@@ -1564,11 +1629,11 @@
       style="
         margin: 12px 24px 0;
         padding: 10px 14px;
-        border: 1px solid #d4af37;
-        border-left: 3px solid #d4af37;
+        border: 1px solid var(--azure);
+        border-left: 3px solid var(--sky);
         border-radius: 3px;
-        background: rgba(212, 175, 55, 0.06);
-        color: #f5f1e6;
+        background: rgba(168, 85, 247, 0.08);
+        color: var(--mist);
         font-size: 13px;
         line-height: 1.4;
       "


### PR DESCRIPTION
## Summary

Restyles `screening-command.html` to the premium design system shipped in `routines.html` (PR #287) — but rotated from **blue** to **pink / lilac / fuchsia / purple** per MLRO request.

Visual parity with the routines page: topbar + ambient radial gradients + 56px masked grid + glass cards + Playfair Display / Inter / DM Mono typography.

## Palette

| Token | Hex | Role |
|-------|-----|------|
| `--azure` | `#a855f7` | primary accent (was `#c9a84c` gold) |
| `--azure-bright` | `#c084fc` | bright highlight |
| `--sky` | `#e879f9` | pink glow + section labels |
| `--ice` | `#f0abfc` | body copy tint |
| `--mist` | `#fae8ff` | head copy + input text |
| `--royal` | `#8b5cf6` | deep accent |
| `--midnight` | `#120a20` | body background |
| `--border` | `rgba(232, 121, 249, 0.16)` | card hairline |

Legacy `var(--gold*)` aliases point at the new purple tokens so the 35 pre-existing callers keep working without per-rule churn.

## Changes

- `:root` palette swap (gold → violet/fuchsia, plus routines-parity tokens)
- Font imports: Cinzel + Montserrat → Playfair Display + Inter + DM Mono
- Every `'Cinzel'` `font-family` rewritten to `'Playfair Display'`
- Body: flat `--midnight` + `::before` ambient radial gradients + `::after` masked 56px grid
- Header: bottom-border rhythm, pill-shaped back-link (DM Mono 11px uppercase, `backdrop-blur`, hover ring)
- `.card`: glass-layered background, radius 16px, `backdrop-filter: blur(14px)`, hover border + fuchsia drop-shadow, `::before` hairline
- `h1`: Playfair 700, white-to-ice-to-sky gradient
- `h1 .badge`: pill, DM Mono, white text on fuchsia gradient
- `h2`: DM Mono 11px letter-spacing 3px, sky-fuchsia colour
- Inputs/selects/textareas: darker glass bg, radius 8px, focus ring `3px rgba(168,85,247,0.18)`
- Buttons: DM Mono uppercase, radius 10px, border-strong default, hover lift to azure-bright with 4px ring
- `.auth-card.authenticated`: alpha realigned to the new `#34d399` teal-green
- `#sanctionsStaleBanner` inline styles rewrapped to CSS vars

## No-change guarantees

- **No HTML/DOM-id edits.** `screening-command.js` continues to drive every form field by id (`#token`, `#loginBtn`, etc.) unchanged.
- **No JavaScript touched.**
- **No regulatory surface change.** Every Art.12 / 20-21 / 24 / 26-27 / 29 / 35 citation in disposition reports (NEGATIVE / FALSE POSITIVE / PARTIAL / CONFIRMED MATCH) is identical text content.
- **Accessibility:** focus ring meets 3:1 on `--midnight`; `h1` gradient preserves pure white at 0%.

## Test plan

- [ ] Visit `https://hawkeye-sterling-v2.netlify.app/screening-command.html` after deploy
- [ ] Confirm pink/lilac/purple theme renders end-to-end (hero, auth card, screening form, run/save buttons, report blocks)
- [ ] Sign in — `.auth-card.authenticated` flips to teal-green overlay
- [ ] Run a screening — confirm all input fields, select dropdowns, and buttons are interactive and readable
- [ ] Trigger a partial match — confirm four-eyes attestation block renders correctly
- [ ] Trigger a confirmed match — confirm FREEZE IMMEDIATELY banner renders in red (unchanged)
- [ ] Save and export PDF — confirm disposition report renders cleanly

## Regulatory basis

Pure CSS restyle. No regulatory surface or business-logic change. All citations in disposition reports preserved verbatim (FDL No.10/2025 Art.12, 20-21, 24, 26-27, 29, 35; Cabinet Res 74/2020 Art.4-7; Cabinet Res 134/2025 Art.7, 14, 19; Cabinet Decision 109/2023).

https://claude.ai/code/session_014AJc3FP33Xru5x6HSrjb9r