### PR TITLE
Port routines-style hero to screening-command + fix descenders

### DIFF
--- a/routines.html
+++ b/routines.html
@@ -142,8 +142,9 @@
 
       .hero-title {
         font-family: 'Playfair Display', serif; font-weight: 700;
-        font-size: clamp(40px, 5.5vw, 68px); line-height: 1.02;
+        font-size: clamp(40px, 5.5vw, 68px); line-height: 1.15;
         letter-spacing: -0.02em; margin: 0 0 1.25rem;
+        padding-bottom: 0.12em;
         background: linear-gradient(180deg, #fff 0%, var(--ice) 45%, var(--sky) 100%);
         -webkit-background-clip: text; background-clip: text;
         -webkit-text-fill-color: transparent;

--- a/screening-command.html
+++ b/screening-command.html
@@ -277,9 +277,10 @@
         font-family: 'Playfair Display', serif;
         font-weight: 700;
         font-size: clamp(40px, 5.5vw, 68px);
-        line-height: 1.02;
+        line-height: 1.15;
         letter-spacing: -0.02em;
         margin: 0 0 1.25rem;
+        padding-bottom: 0.12em;
         background: linear-gradient(180deg, #ffffff 0%, var(--ice) 45%, var(--sky) 100%);
         -webkit-background-clip: text;
         background-clip: text;

--- a/screening-command.html
+++ b/screening-command.html
@@ -234,52 +234,137 @@
         text-transform: uppercase;
         font-weight: 600;
       }
-      .intro-panel {
-        margin: 10px 0 22px;
-        padding: 18px 22px;
-        border: 2px solid var(--gold);
-        border-radius: 6px;
-        background:
-          linear-gradient(180deg, rgba(255, 255, 255, 0.01), transparent 60%), var(--bg-elev);
-        box-shadow: var(--shadow-md), var(--shadow-inset);
-        position: relative;
-      }
-      .intro-grid {
+      /* Hero (mirrors routines.html hero, rotated to purple) */
+      .hero {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-        gap: 14px 26px;
+        grid-template-columns: 1.3fr 1fr;
+        gap: 48px;
+        align-items: end;
+        margin: 10px 0 36px;
       }
-      .intro-block h3 {
-        font-family: 'Playfair Display', serif;
-        font-size: 11.5px;
-        font-weight: 600;
-        letter-spacing: 1.5px;
+      .hero-eyebrow {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        font-family: 'DM Mono', monospace;
+        font-size: 11px;
+        letter-spacing: 3px;
         text-transform: uppercase;
-        color: var(--gold);
-        margin: 0 0 4px;
+        color: var(--sky);
+        margin-bottom: 1.25rem;
       }
-      .intro-block p {
-        color: var(--muted);
-        font-size: 12.5px;
-        line-height: 1.55;
+      .hero-eyebrow::before {
+        content: '';
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: var(--azure-bright);
+        box-shadow: 0 0 12px var(--azure-bright);
+        animation: pulse 2.2s ease-in-out infinite;
+      }
+      @keyframes pulse {
+        0%,
+        100% {
+          opacity: 1;
+          transform: scale(1);
+        }
+        50% {
+          opacity: 0.55;
+          transform: scale(1.25);
+        }
+      }
+      .hero-title {
+        font-family: 'Playfair Display', serif;
+        font-weight: 700;
+        font-size: clamp(40px, 5.5vw, 68px);
+        line-height: 1.02;
+        letter-spacing: -0.02em;
+        margin: 0 0 1.25rem;
+        background: linear-gradient(180deg, #ffffff 0%, var(--ice) 45%, var(--sky) 100%);
+        -webkit-background-clip: text;
+        background-clip: text;
+        -webkit-text-fill-color: transparent;
+      }
+      .hero-title em {
+        font-style: italic;
+        font-weight: 600;
+        color: var(--azure-bright);
+        -webkit-text-fill-color: var(--azure-bright);
+      }
+      .hero-lede {
+        color: var(--ice);
+        font-size: 15px;
+        line-height: 1.65;
+        max-width: 560px;
         margin: 0;
+        opacity: 0.85;
       }
-      .intro-block p strong {
-        color: var(--text);
-        font-weight: 500;
+      @media (max-width: 900px) {
+        .hero {
+          grid-template-columns: 1fr;
+          gap: 28px;
+        }
       }
-      .intro-block p.cite {
-        color: var(--accent);
+
+      /* Summary panel — 2×2 stats aside */
+      .summary {
+        background: linear-gradient(160deg, rgba(36, 21, 56, 0.8) 0%, rgba(12, 6, 20, 0.6) 100%);
+        border: 1px solid var(--border);
+        border-radius: 18px;
+        padding: 1.5rem;
+        backdrop-filter: blur(18px);
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 14px;
+      }
+      .summary-cell {
+        padding: 12px 14px;
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        background: rgba(12, 6, 20, 0.5);
+      }
+      .summary-cell .k {
+        font-family: 'DM Mono', monospace;
+        font-size: 9px;
+        letter-spacing: 2px;
+        text-transform: uppercase;
+        color: var(--steel);
+        margin-bottom: 4px;
+      }
+      .summary-cell .v {
+        font-family: 'Playfair Display', serif;
+        font-weight: 700;
+        font-size: 26px;
+        color: var(--mist);
+        line-height: 1;
+      }
+      .summary-cell .v small {
+        font-family: 'DM Mono', monospace;
+        font-size: 11px;
+        color: var(--sky);
+        margin-left: 6px;
+        letter-spacing: 0;
+      }
+
+      /* Regulatory basis slim cite strip (replaces the old intro block) */
+      .reg-basis {
+        margin: 0 0 28px;
+        padding: 12px 18px;
+        border: 1px dashed var(--border);
+        border-radius: 10px;
+        background: rgba(26, 15, 46, 0.35);
+        color: var(--muted);
         font-family: 'DM Mono', monospace;
         font-size: 10.5px;
         letter-spacing: 0.3px;
-        line-height: 1.5;
+        line-height: 1.55;
       }
-      .intro-block.intro-block--wide {
-        grid-column: 1 / -1;
-        padding-top: 10px;
-        margin-top: 2px;
-        border-top: 1px dashed var(--border);
+      .reg-basis strong {
+        color: var(--sky);
+        font-weight: 500;
+        letter-spacing: 2px;
+        text-transform: uppercase;
+        margin-right: 8px;
       }
       .grid {
         display: grid;
@@ -1512,12 +1597,12 @@
       }
       button.btn-save {
         background: var(--gold-grad);
-        color: #1a1407;
-        border: 1px solid rgba(230, 200, 112, 0.5);
+        color: #ffffff;
+        border: 1px solid rgba(232, 121, 249, 0.5);
         box-shadow:
           0 1px 0 rgba(255, 255, 255, 0.2) inset,
           0 -1px 0 rgba(0, 0, 0, 0.25) inset,
-          0 8px 20px rgba(168, 85, 247, 0.22);
+          0 8px 20px rgba(168, 85, 247, 0.35);
       }
       button.btn-save:hover {
         transform: translateY(-1px);
@@ -1674,59 +1759,48 @@
         }
       })();
     </script>
-    <section class="intro-panel">
-      <div class="intro-grid">
-        <div class="intro-block">
-          <h3>Sanctions-list coverage</h3>
-          <p>
-            Parallel screen against six lists: UN Consolidated (1267/1988/1989/2253), OFAC SDN, OFAC
-            Consolidated (non-SDN), EU CFSP, UK OFSI (HMT), and UAE EOCN. UAE EOCN and UN are
-            <strong>mandatory</strong> and cannot be deselected.
-          </p>
-        </div>
-        <div class="intro-block">
-          <h3>Matching engine</h3>
-          <p>
-            Five-algorithm ensemble — Jaro-Winkler, Levenshtein, Soundex, Double Metaphone,
-            token-set — catching phonetic variants, transliterations, word-order permutations, and
-            single-character edits. Deterministic only; no LLM in the match path.
-          </p>
-        </div>
-        <div class="intro-block">
-          <h3>Risk scoring</h3>
-          <p>
-            Every hit feeds an explainable Bayesian risk score with an open-source adverse-media
-            sweep (PEP, litigation, fraud, terrorism-financing signals) on the same pass.
-          </p>
-        </div>
-        <div class="intro-block">
-          <h3>Automation</h3>
-          <p>
-            Confirmed or potential matches auto-enrol into the daily watchlist (06:00 / 14:00 UTC
-            cron). A tagged Asana task lands in the SCREENINGS project, assigned to the on-duty
-            MLRO.
-          </p>
-        </div>
-        <div class="intro-block">
-          <h3>MLRO attestation</h3>
-          <p>
-            MLRO closes every event with a disposition (negative / false positive / partial /
-            confirmed), a named reviewer, and a &ge; 20-character rationale — creating an
-            append-only audit record for MoE, LBMA, and internal audit.
-          </p>
-        </div>
-        <div class="intro-block intro-block--wide">
-          <h3>Regulatory basis</h3>
-          <p>
-            FDL No.10/2025 Art.12-14 (CDD), 20-21 (CO duties), 24 (10-yr retention), 26-27 (STR), 29
-            (no tipping off), 35 (TFS) &middot; Cabinet Res 134/2025 Art.7-10, 14, 19 &middot;
-            Cabinet Res 74/2020 Art.4-7 (24-h freeze) &middot; Cabinet Decision No.(74)/2020
-            &middot; Cabinet Res 71/2024 &middot; MoE Circular 08/AML/2021 &middot; FATF Rec 10 / 12
-            / 22 / 23.
-          </p>
-        </div>
+    <section class="hero">
+      <div>
+        <div class="hero-eyebrow">Six-List Sanctions Screening</div>
+        <h1 class="hero-title">
+          Your subjects, <em>screened</em>.<br />All audit-logged.
+        </h1>
+        <p class="hero-lede">
+          Parallel screen every subject against UN, OFAC, EU, UK OFSI, and UAE EOCN. Five
+          matching algorithms (Jaro-Winkler, Levenshtein, Soundex, Double Metaphone, token-set)
+          plus a Bayesian risk score and adverse-media sweep on the same pass. Every hit lands
+          in the daily watchlist and a tagged Asana task for the on-duty MLRO, closed with a
+          &ge; 20-character rationale for the append-only audit record.
+        </p>
       </div>
+      <aside class="summary" aria-label="Screening coverage summary">
+        <div class="summary-cell">
+          <div class="k">Sanctions Lists</div>
+          <div class="v">6</div>
+        </div>
+        <div class="summary-cell">
+          <div class="k">Mandatory</div>
+          <div class="v">2 <small>UN &middot; EOCN</small></div>
+        </div>
+        <div class="summary-cell">
+          <div class="k">Match Algorithms</div>
+          <div class="v">5</div>
+        </div>
+        <div class="summary-cell">
+          <div class="k">Daily Crons (UTC)</div>
+          <div class="v">2 <small>06:00 &middot; 14:00</small></div>
+        </div>
+      </aside>
     </section>
+
+    <aside class="reg-basis" aria-label="Regulatory basis">
+      <strong>Regulatory basis</strong>
+      FDL No.10/2025 Art.12-14 (CDD), 20-21 (CO duties), 24 (10-yr retention), 26-27 (STR), 29
+      (no tipping off), 35 (TFS) &middot; Cabinet Res 134/2025 Art.7-10, 14, 19 &middot;
+      Cabinet Res 74/2020 Art.4-7 (24-h freeze) &middot; Cabinet Decision No.(74)/2020
+      &middot; Cabinet Res 71/2024 &middot; MoE Circular 08/AML/2021 &middot; FATF Rec 10 /
+      12 / 22 / 23.
+    </aside>
 
     <!-- MLRO identity ──────────────────────────────────────────────── -->
     <div class="card" style="margin-top: 14px; border-color: #ec4899">


### PR DESCRIPTION
## Summary

- Port the routines.html hero pattern to `screening-command.html`: serif italic title (`Your subjects, screened. All audit-logged.`) + 2x2 summary aside (6 lists · 2 mandatory · 5 algorithms · 2 daily crons) + dashed regulatory-basis cite strip — in the purple/lilac/fuchsia palette.
- Fix gold-era remnants on `.btn-save` (white text + fuchsia border, not gold).
- Fix Playfair Display descender clipping on `.hero-title` in both `routines.html` and `screening-command.html` (`line-height: 1.15` + `padding-bottom: 0.12em`).

**Why**: live site at `hawkeye-sterling-v2.netlify.app/screening-command.html` still shows the old 4-column intro-panel layout. This PR replaces it with the hero layout the user requested.

## Regulatory basis

FDL No.10/2025 Art.12-14, 20-21, 24, 26-27, 29, 35 · Cabinet Res 134/2025 Art.7-10, 14, 19 · Cabinet Res 74/2020.

## Test plan

- [ ] Visit `/screening-command.html` and confirm new hero renders (no 4-column panel).
- [ ] Confirm "SAVE SCREENING EVENT" button is white-on-purple, not gold.
- [ ] Confirm `/routines.html` title "logged" descender is no longer clipped.
- [ ] Confirm summary cells show 6 / 2 / 5 / 2.

https://claude.ai/code/session_014AJc3FP33Xru5x6HSrjb9r