### PR TITLE
Remove hero lede + reg-basis strip; fix topbar descender clipping

### DIFF
--- a/screening-command.html
+++ b/screening-command.html
@@ -178,7 +178,9 @@
         background-clip: text;
         color: transparent;
         text-shadow: none;
-        line-height: 1.05;
+        line-height: 1.2;
+        padding-bottom: 0.12em;
+        margin: 0;
       }
       h1 .badge {
         display: inline-block;
@@ -292,14 +294,6 @@
         color: var(--azure-bright);
         -webkit-text-fill-color: var(--azure-bright);
       }
-      .hero-lede {
-        color: var(--ice);
-        font-size: 15px;
-        line-height: 1.65;
-        max-width: 560px;
-        margin: 0;
-        opacity: 0.85;
-      }
       @media (max-width: 900px) {
         .hero {
           grid-template-columns: 1fr;
@@ -347,26 +341,6 @@
         letter-spacing: 0;
       }
 
-      /* Regulatory basis slim cite strip (replaces the old intro block) */
-      .reg-basis {
-        margin: 0 0 28px;
-        padding: 12px 18px;
-        border: 1px dashed var(--border);
-        border-radius: 10px;
-        background: rgba(26, 15, 46, 0.35);
-        color: var(--muted);
-        font-family: 'DM Mono', monospace;
-        font-size: 10.5px;
-        letter-spacing: 0.3px;
-        line-height: 1.55;
-      }
-      .reg-basis strong {
-        color: var(--sky);
-        font-weight: 500;
-        letter-spacing: 2px;
-        text-transform: uppercase;
-        margin-right: 8px;
-      }
       .grid {
         display: grid;
         grid-template-columns: 1fr;
@@ -1766,13 +1740,6 @@
         <h1 class="hero-title">
           Your subjects, <em>screened</em>.<br />All audit-logged.
         </h1>
-        <p class="hero-lede">
-          Parallel screen every subject against UN, OFAC, EU, UK OFSI, and UAE EOCN. Five
-          matching algorithms (Jaro-Winkler, Levenshtein, Soundex, Double Metaphone, token-set)
-          plus a Bayesian risk score and adverse-media sweep on the same pass. Every hit lands
-          in the daily watchlist and a tagged Asana task for the on-duty MLRO, closed with a
-          &ge; 20-character rationale for the append-only audit record.
-        </p>
       </div>
       <aside class="summary" aria-label="Screening coverage summary">
         <div class="summary-cell">
@@ -1793,15 +1760,6 @@
         </div>
       </aside>
     </section>
-
-    <aside class="reg-basis" aria-label="Regulatory basis">
-      <strong>Regulatory basis</strong>
-      FDL No.10/2025 Art.12-14 (CDD), 20-21 (CO duties), 24 (10-yr retention), 26-27 (STR), 29
-      (no tipping off), 35 (TFS) &middot; Cabinet Res 134/2025 Art.7-10, 14, 19 &middot;
-      Cabinet Res 74/2020 Art.4-7 (24-h freeze) &middot; Cabinet Decision No.(74)/2020
-      &middot; Cabinet Res 71/2024 &middot; MoE Circular 08/AML/2021 &middot; FATF Rec 10 /
-      12 / 22 / 23.
-    </aside>
 
     <!-- MLRO identity ──────────────────────────────────────────────── -->
     <div class="card" style="margin-top: 14px; border-color: #ec4899">

--- a/screening-command.html
+++ b/screening-command.html
@@ -412,6 +412,14 @@
         appearance: none;
         transition: border-color 0.2s ease, box-shadow 0.2s ease;
       }
+      input[type='checkbox'],
+      input[type='radio'] {
+        width: auto;
+        padding: 0;
+        font-size: 0;
+        border-radius: 3px;
+        background: transparent;
+      }
       textarea {
         resize: vertical;
         min-height: 80px;
@@ -1013,6 +1021,9 @@
         margin-top: 3px;
         width: 14px;
         height: 14px;
+        min-width: 14px;
+        padding: 0;
+        font-size: 0;
         flex-shrink: 0;
         border: 1.5px solid var(--blue);
         border-radius: 3px;


### PR DESCRIPTION
## Summary

- Remove redundant hero lede paragraph + dashed regulatory-basis cite strip from `screening-command.html`.
- Fix clipped Playfair Display descenders on the topbar h1 ("Hawkeye Sterling V2 — Screening Command"): `line-height 1.05 → 1.2` + `padding-bottom: 0.12em`.
- Drop dead `.hero-lede` and `.reg-basis` CSS.

UI-only polish. No regulatory logic touched.

## Test plan

- [ ] Confirm `/screening-command.html` no longer shows the lede paragraph below the hero title.
- [ ] Confirm the dashed "Regulatory basis" strip is gone.
- [ ] Confirm `y` in "Hawkeye", `g` in "Screening", and `2` in `V2` render fully (no clipping).

https://claude.ai/code/session_014AJc3FP33Xru5x6HSrjb9r