### PR TITLE
Hero nowrap + routines topbar restyle + auth-card shrink

### DIFF
--- a/routines.html
+++ b/routines.html
@@ -142,13 +142,15 @@
 
       .hero-title {
         font-family: 'Playfair Display', serif; font-weight: 700;
-        font-size: clamp(40px, 5.5vw, 68px); line-height: 1.15;
+        font-size: clamp(36px, 4.4vw, 56px); line-height: 1.15;
         letter-spacing: -0.02em; margin: 0 0 1.25rem;
         padding-bottom: 0.12em;
         background: linear-gradient(180deg, #fff 0%, var(--ice) 45%, var(--sky) 100%);
         -webkit-background-clip: text; background-clip: text;
         -webkit-text-fill-color: transparent;
       }
+      .hero-title .nowrap { white-space: nowrap; }
+      @media (max-width: 640px) { .hero-title .nowrap { white-space: normal; } }
       .hero-title em {
         font-style: italic; font-weight: 600; color: var(--azure-bright);
         -webkit-text-fill-color: var(--azure-bright);
@@ -357,7 +359,8 @@
         <div>
           <div class="hero-eyebrow">Scheduled Compliance Workflows</div>
           <h1 class="hero-title">
-            Your routines, <em>running</em>.<br />All audit-logged.
+            <span class="nowrap">Your routines, <em>running</em>.</span><br />
+            <span class="nowrap">All audit-logged.</span>
           </h1>
           <p class="hero-lede">
             Every scheduled workflow that keeps this suite compliant — sanctions

--- a/routines.html
+++ b/routines.html
@@ -92,19 +92,28 @@
         margin-bottom: 3rem;
       }
 
-      .brand { display: flex; align-items: center; gap: 14px; }
-      .brand-mark {
-        width: 38px; height: 38px; border-radius: 10px;
-        background: linear-gradient(135deg, var(--azure) 0%, var(--royal) 100%);
-        box-shadow: 0 0 0 1px rgba(127, 193, 255, 0.4), 0 8px 24px rgba(47, 125, 255, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.18);
-        position: relative;
+      .brand { display: flex; align-items: center; gap: 16px; }
+      .header-logo {
+        width: 56px; height: 56px;
+        flex-shrink: 0; border-radius: 10px; display: block;
+        box-shadow:
+          0 0 0 1px rgba(127, 193, 255, 0.4),
+          0 8px 24px rgba(47, 125, 255, 0.35),
+          inset 0 1px 0 rgba(255, 255, 255, 0.18);
       }
-      .brand-mark::after {
-        content: ''; position: absolute; inset: 6px;
-        border-radius: 6px; border: 1.5px solid rgba(255, 255, 255, 0.55);
+      .brand-title {
+        font-family: 'Playfair Display', serif;
+        font-weight: 700;
+        font-size: clamp(28px, 3.2vw, 42px);
+        letter-spacing: -0.01em;
+        line-height: 1.2;
+        padding-bottom: 0.12em;
+        margin: 0;
+        background: linear-gradient(180deg, #ffffff 0%, var(--ice) 45%, var(--sky) 100%);
+        -webkit-background-clip: text;
+        background-clip: text;
+        -webkit-text-fill-color: transparent;
       }
-      .brand-name { font-family: 'Playfair Display', serif; font-weight: 700; color: var(--mist); font-size: 18px; letter-spacing: 3px; }
-      .brand-sub { font-family: 'DM Mono', monospace; color: var(--steel); font-size: 10px; letter-spacing: 2.5px; text-transform: uppercase; margin-top: 2px; }
 
       .back-link {
         color: var(--ice); text-decoration: none;
@@ -346,11 +355,14 @@
     <main class="shell">
       <header class="topbar">
         <div class="brand">
-          <div class="brand-mark" aria-hidden="true"></div>
-          <div>
-            <div class="brand-name">HAWKEYE STERLING</div>
-            <div class="brand-sub">V2 · Routines Registry</div>
-          </div>
+          <img
+            src="assets/logos/hawkeye-icon.svg"
+            alt="Hawkeye Sterling"
+            class="header-logo"
+            width="56"
+            height="56"
+          />
+          <h1 class="brand-title">Hawkeye Sterling V2 &mdash; Routines Registry</h1>
         </div>
         <a href="index.html" class="back-link">&larr; Main App</a>
       </header>

--- a/screening-command.html
+++ b/screening-command.html
@@ -278,7 +278,7 @@
       .hero-title {
         font-family: 'Playfair Display', serif;
         font-weight: 700;
-        font-size: clamp(40px, 5.5vw, 68px);
+        font-size: clamp(36px, 4.4vw, 56px);
         line-height: 1.15;
         letter-spacing: -0.02em;
         margin: 0 0 1.25rem;
@@ -287,6 +287,14 @@
         -webkit-background-clip: text;
         background-clip: text;
         -webkit-text-fill-color: transparent;
+      }
+      .hero-title .nowrap {
+        white-space: nowrap;
+      }
+      @media (max-width: 640px) {
+        .hero-title .nowrap {
+          white-space: normal;
+        }
       }
       .hero-title em {
         font-style: italic;
@@ -1749,7 +1757,8 @@
       <div>
         <div class="hero-eyebrow">Six-List Sanctions Screening</div>
         <h1 class="hero-title">
-          Your subjects, <em>screened</em>.<br />All audit-logged.
+          <span class="nowrap">Your subjects, <em>screened</em>.</span><br />
+          <span class="nowrap">All audit-logged.</span>
         </h1>
       </div>
       <aside class="summary" aria-label="Screening coverage summary">

--- a/screening-command.html
+++ b/screening-command.html
@@ -575,8 +575,30 @@
         color: #ff6b6b;
       }
       .auth-card {
-        padding: 20px 22px;
+        padding: 12px 16px;
         transition: background 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+      }
+      .auth-card h2 {
+        font-size: 11px !important;
+        margin: 0 0 10px !important;
+      }
+      .auth-card label {
+        font-size: 10px;
+        letter-spacing: 1.5px;
+        text-transform: uppercase;
+        color: var(--muted);
+        display: block;
+        margin-bottom: 4px;
+      }
+      .auth-card input[type='password'] {
+        padding: 8px 10px;
+        font-size: 13px;
+        border-radius: 4px;
+        margin-bottom: 6px;
+      }
+      .auth-card .token-gen-btn {
+        padding: 8px 12px;
+        font-size: 11px;
       }
       .auth-card.authenticated {
         background: linear-gradient(135deg, rgba(52, 211, 153, 0.18) 0%, rgba(52, 211, 153, 0.06) 100%);


### PR DESCRIPTION
## Summary

Three small UI fixes bundled:

1. **Hero title nowrap** — `screened` / `running` were breaking onto a second line. Reduced clamp to `clamp(36px, 4.4vw, 56px)` and wrapped each phrase in a `.nowrap` span so `Your subjects, screened.` and `Your routines, running.` stay together on line 1. Mobile (<=640px) falls back to normal wrap.
2. **Routines topbar restyle** — port the screening-command title treatment (Playfair gradient h1 + 56px `hawkeye-icon.svg`) to `routines.html`. Replaces the old uppercase `HAWKEYE STERLING` + `V2 · Routines Registry` stack.
3. **Auth-card shrink** — `.auth-card` was inheriting the global `input` rule (padding 12px + font-size 16px) making the password field + Sign In/Out buttons oversized. Targeted overrides drop the field to 8px/10px padding at 13px, buttons to 8/12 at 11px, card padding to 12/16.

UI-only polish. No regulatory logic touched.

## Test plan

- [ ] `/screening-command.html` — title reads `Your subjects, screened.` on one line, `All audit-logged.` on the next.
- [ ] `/routines.html` — title reads `Your routines, running.` on one line, topbar shows real Hawkeye icon next to serif `Hawkeye Sterling V2 — Routines Registry`.
- [ ] Authentication card is noticeably smaller; password input and buttons are compact.

https://claude.ai/code/session_014AJc3FP33Xru5x6HSrjb9r