### PR TITLE
Shrink MLRO auth card — inline sign-in icons with password field

### DIFF
--- a/screening-command.html
+++ b/screening-command.html
@@ -2222,39 +2222,40 @@
         </div>
         <div>
           <label for="loginPassword">Password</label>
-          <input
-            type="password"
-            id="loginPassword"
-            placeholder="MLRO password"
-            autocomplete="current-password"
-            spellcheck="false"
-            aria-label="MLRO password"
-          />
+          <div style="display: flex; gap: 6px; align-items: center">
+            <input
+              type="password"
+              id="loginPassword"
+              placeholder="MLRO password"
+              autocomplete="current-password"
+              spellcheck="false"
+              aria-label="MLRO password"
+              style="flex: 1; min-width: 0; margin-bottom: 0"
+            />
+            <button
+              type="button"
+              id="loginBtn"
+              class="token-gen-btn auth-icon-btn"
+              style="color: #22c55e; border-color: #ec4899"
+              title="Sign in — exchange password for a signed 1-year session token"
+              aria-label="Sign in"
+            >
+              &rarr;
+            </button>
+            <button
+              type="button"
+              id="logoutBtn"
+              class="token-gen-btn auth-icon-btn"
+              style="color: #ef4444; border-color: #ec4899"
+              title="Sign out — forget the saved session token"
+              aria-label="Sign out"
+            >
+              &times;
+            </button>
+          </div>
         </div>
       </div>
-      <div class="token-row" style="margin-top: 10px; justify-content: flex-end; gap: 6px">
-        <button
-          type="button"
-          id="loginBtn"
-          class="token-gen-btn auth-icon-btn"
-          style="color: #22c55e; border-color: #ec4899"
-          title="Sign in — exchange password for a signed 1-year session token"
-          aria-label="Sign in"
-        >
-          &rarr;
-        </button>
-        <button
-          type="button"
-          id="logoutBtn"
-          class="token-gen-btn auth-icon-btn"
-          style="color: #ef4444; border-color: #ec4899"
-          title="Sign out — forget the saved session token"
-          aria-label="Sign out"
-        >
-          &times;
-        </button>
-      </div>
-      <p class="help-text" style="margin: 10px 0 0; font-size: 11px">
+      <p class="help-text" style="margin: 8px 0 0; font-size: 11px">
         <b>Screened by:</b> <span id="mlroActiveBadge" class="tag">—</span>
         &middot; Saved locally (FDL Art.24 &mdash; 10yr audit trail)
       </p>


### PR DESCRIPTION
## Summary

The MLRO Identity & Authentication card carried a large empty strip between the three input fields and a right-aligned button row below them. This PR moves the Sign-In (→) and Sign-Out (×) icon buttons into the Password column itself, sharing a flex row with the password input so the buttons sit immediately to the right of the field. Drops the now-empty `.token-row` block and tightens the `help-text` margin.

## Scope

Pure visual tightening on `screening-command.html`. No auth logic changed — `#loginBtn` / `#logoutBtn` IDs are preserved, so the `screening-command.js` click handlers still fire correctly. Pure UI change, no regulatory citation required under CLAUDE.md §8.

## Test plan

- [ ] Card height is noticeably shorter — no vertical gap between the input row and the help text
- [ ] Sign-in (→) still exchanges the password for a 1-year session token
- [ ] Sign-out (×) still clears the stored token
- [ ] Password input still stretches to fill the column while the two 34×34 icon buttons sit flush to its right
- [ ] Mobile layout wraps gracefully (the `row-3` collapses to a single column and the icons stay adjacent to the password field)

https://claude.ai/code/session_014AJc3FP33Xru5x6HSrjb9r