### PR TITLE
Add weaponized brain safety clamp & fix sanctions cache poisoning

### DIFF
--- a/netlify/functions/screening-run.mts
+++ b/netlify/functions/screening-run.mts
@@ -95,6 +95,11 @@ import {
   type SearchFn,
   type SearchHit,
 } from '../../src/services/brain';
+import { runWeaponizedAssessment } from '../../src/services/brainBridge';
+import type { WeaponizedBrainResponse } from '../../src/services/weaponizedBrain';
+import type { AdverseMediaHit as WeaponizedAdverseMediaHit } from '../../src/services/adverseMediaRanker';
+import type { MegaBrainRequest } from '../../src/services/megaBrain';
+import type { StrFeatures } from '../../src/services/predictiveStr';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -153,6 +158,12 @@ const HYDRATE_TIMEOUT_MS = 1_200;
 // without starving Phase C. Sits inside the 10s Netlify sync ceiling
 // alongside the other phase budgets.
 const DEEP_BRAIN_DEADLINE_MS = 2_500;
+// Weaponized brain (19 subsystems) runs entirely in-process with no
+// network hops — advisor is disabled in this sync path because the
+// Opus sub-inference would blow the 10s ceiling. Typical wall-clock
+// is <100ms; the cap is a safety net against pathological inputs.
+// FDL Art.20 — CO must still receive a deterministic verdict.
+const WEAPONIZED_BRAIN_DEADLINE_MS = 800;
 // Asana + Watchlist run in parallel. ASANA_TIMEOUT_MS bounds the
 // Asana POST (CO needs a clear "task timed out" diagnostic, never a
 // silent hang). WATCHLIST_TIMEOUT_MS is shorter because watchlist is a
@@ -459,6 +470,7 @@ interface ListSnapshot {
 
 let listCache: ListSnapshot | null = null;
 let uaeSeedAttemptedAt = 0;
+let uaeSeedSucceeded = false;
 
 /**
  * Hydrate the in-process UAE / EOCN sanctions cache from the
@@ -475,10 +487,19 @@ let uaeSeedAttemptedAt = 0;
  * → SanctionsEntry, and call `seedUaeSanctionsList`. Silent on any
  * failure — the caller still throws with the existing diagnostic if no
  * snapshot is available, which is the correct Art.35 signal.
+ *
+ * Retry semantics: once a hydrate succeeds, we respect the 6h TTL
+ * (SANCTIONS_CACHE_TTL_MS) before re-hydrating — the in-memory cache
+ * is good. But when hydrate FAILS (blob store empty, cold-start error),
+ * we only back off for RETRY_BACKOFF_MS before trying again. Otherwise
+ * a single cold-start miss poisons the instance for 6h even after the
+ * MLRO uploads the missing circular (FDL Art.35 gate stays hot).
  */
+const UAE_SEED_RETRY_BACKOFF_MS = 30_000;
 async function hydrateUaeSanctionsFromBlob(): Promise<void> {
   const now = Date.now();
-  if (now - uaeSeedAttemptedAt < SANCTIONS_CACHE_TTL_MS) return;
+  const backoff = uaeSeedSucceeded ? SANCTIONS_CACHE_TTL_MS : UAE_SEED_RETRY_BACKOFF_MS;
+  if (now - uaeSeedAttemptedAt < backoff) return;
   uaeSeedAttemptedAt = now;
   try {
     const store = getStore('sanctions-snapshots');
@@ -509,9 +530,14 @@ async function hydrateUaeSanctionsFromBlob(): Promise<void> {
         };
       })
       .filter((e) => e.name.length > 0);
-    if (entries.length > 0) seedUaeSanctionsList(entries);
+    if (entries.length > 0) {
+      seedUaeSanctionsList(entries);
+      uaeSeedSucceeded = true;
+    }
   } catch {
     // Silent — the Art.35 gate in fetchUAESanctionsList still fires.
+    // uaeSeedSucceeded stays false so the next request retries after
+    // UAE_SEED_RETRY_BACKOFF_MS rather than waiting 6h.
   }
 }
 
@@ -633,8 +659,26 @@ async function loadAllLists(): Promise<ListSnapshot> {
     raceListFetch('UK_OFSI', (signal, timeoutMs) => fetchUKSanctionsList(proxy, { signal, timeoutMs })),
     raceListFetch('UAE_EOCN', () => fetchUAESanctionsList()),
   ]);
-  listCache = { fetchedAt: Date.now(), lists: lists as ListSnapshot['lists'] };
-  return listCache;
+  const snapshot: ListSnapshot = { fetchedAt: Date.now(), lists: lists as ListSnapshot['lists'] };
+
+  // Cache ONLY when every mandatory list (UN, UAE_EOCN) came back without
+  // an error. Otherwise a cold-start miss poisons the warm instance for
+  // 6h (SANCTIONS_CACHE_TTL_MS) and every subsequent screening surfaces
+  // the same "fetch cancelled / cache empty" message even after upstream
+  // recovers or the MLRO uploads the missing circular. Cabinet Res
+  // 74/2020 Art.4 + FDL No.10/2025 Art.35 require fresh UAE coverage;
+  // serving a stale error for 6h is the exact failure mode we just
+  // saw in production.
+  const MANDATORY_FOR_CACHE = new Set<string>(['UN', 'UAE_EOCN']);
+  const mandatoryClean = snapshot.lists
+    .filter((l) => MANDATORY_FOR_CACHE.has(l.name))
+    .every((l) => !l.error);
+  if (mandatoryClean) {
+    listCache = snapshot;
+  } else {
+    listCache = null;
+  }
+  return snapshot;
 }
 
 // ---------------------------------------------------------------------------
@@ -1307,6 +1351,90 @@ export default async (req: Request, context: Context): Promise<Response> => {
     }
   }
 
+  // ─── Phase B.5. Weaponized brain — 19-subsystem safety-clamp pass ────
+  // Runs the full Weaponized Brain whenever a high-risk signal surfaces:
+  //   - any non-"none" multi-modal classification from any list, OR
+  //   - screening integrity degraded/incomplete (mandatory-list failure
+  //     or adverse-media provider missing → absence of evidence is NOT
+  //     evidence of absence under FDL Art.20-21), OR
+  //   - deep brain confidence below 0.7 (uncertain posterior).
+  //
+  // The brain runs fully in-process (no advisor network call in this
+  // synchronous path — advisor would blow the 10s Netlify ceiling). Its
+  // 19 subsystems apply deterministic safety clamps over the MegaBrain
+  // verdict: sanctions → freeze, adverse-media-critical → escalate,
+  // undisclosed UBO / shell-company / structuring → flag.
+  //
+  // Regulatory basis: FDL No.10/2025 Art.20-21 (CO duty of care, can
+  // never report clean when data is incomplete), Cabinet Res 134/2025
+  // Art.19 (internal review before decision), Cabinet Res 74/2020
+  // Art.4-7 (mandatory freeze on sanctions).
+  let weaponized: WeaponizedBrainResponse | null = null;
+  const deepBrainConfidence = deepBrain?.confidence ?? 1;
+  const weaponizedNeeded =
+    overallTopClassification !== 'none' ||
+    screeningIntegrity !== 'complete' ||
+    deepBrainConfidence < 0.7;
+  if (weaponizedNeeded) {
+    const entityFeatures: StrFeatures = {
+      priorAlerts90d: 0,
+      txValue30dAED: 0,
+      nearThresholdCount30d: 0,
+      crossBorderRatio30d: 0,
+      isPep: false,
+      highRiskJurisdiction: false,
+      hasAdverseMedia: adverseMediaHits > 0,
+      daysSinceOnboarding: 0,
+      sanctionsMatchScore: Math.max(0, Math.min(1, overallTopScore)),
+      cashRatio30d: 0,
+    };
+    const isSanctionsConfirmed =
+      overallTopClassification === 'confirmed' || overallTopScore >= 0.9;
+    const megaReq: MegaBrainRequest = {
+      topic: `screening ${input.subjectName} (${ranAt.slice(0, 10)})`,
+      entity: {
+        id: subjectId,
+        name: input.subjectName,
+        features: entityFeatures,
+        isSanctionsConfirmed,
+      },
+    };
+    // Map adverse media hits into the weaponized brain's ranker input
+    // shape. The ranker is subsystem 14 and produces impact categories
+    // the clamp layer uses to force escalate on "critical".
+    const adverseMediaForBrain: readonly WeaponizedAdverseMediaHit[] = input.runAdverseMedia
+      ? amRes.value.hits.slice(0, 30).map((h, idx) => ({
+          id: h.url ?? `am-${idx}`,
+          entityNameQueried: input.subjectName,
+          headline: h.title,
+          snippet: h.snippet,
+          sourceDomain: h.source ?? 'unknown',
+          publishedAtIso: h.publishedAt,
+        }))
+      : [];
+    try {
+      const weaponizedRes = await withTimeout(
+        runWeaponizedAssessment(
+          {
+            mega: megaReq,
+            adverseMedia: adverseMediaForBrain,
+            // No advisor in the serverless sync path — the Opus
+            // sub-inference would exceed the 10s Netlify ceiling. UI
+            // callers can re-run with the advisor enabled on demand.
+            sealProofBundle: false,
+          },
+          { advisor: null }
+        ),
+        WEAPONIZED_BRAIN_DEADLINE_MS,
+        null,
+        'weaponized-brain'
+      );
+      weaponized = weaponizedRes.value;
+    } catch {
+      weaponized = null;
+    }
+  }
+
   // ─── Phase C. Watchlist + Asana in parallel ─────────────────────────
   // FDL Art.24 10-yr retention: every screening lands in Asana even on
   // a clean run. Cabinet Res 134/2025 Art.19: periodic internal review
@@ -1471,6 +1599,37 @@ export default async (req: Request, context: Context): Promise<Response> => {
           rationale: deepBrain.reasoning.top.rationale,
           coverage: deepBrain.investigation.coverage,
           lessons: deepBrain.lessons,
+        }
+      : null,
+    weaponized: weaponized
+      ? {
+          megaVerdict: weaponized.mega.verdict,
+          finalVerdict: weaponized.finalVerdict,
+          confidence: weaponized.confidence,
+          requiresHumanReview: weaponized.requiresHumanReview,
+          clampReasons: weaponized.clampReasons,
+          subsystemFailures: weaponized.subsystemFailures,
+          auditNarrative: weaponized.auditNarrative,
+          advisor: weaponized.advisorResult
+            ? {
+                text: weaponized.advisorResult.text,
+                advisorCallCount: weaponized.advisorResult.advisorCallCount,
+                modelUsed: weaponized.advisorResult.modelUsed,
+              }
+            : null,
+          extensions: {
+            adverseMediaTopCategory:
+              weaponized.extensions.adverseMedia?.topCategory ?? null,
+            adverseMediaCriticalCount:
+              weaponized.extensions.adverseMedia?.counts.critical ?? 0,
+            explainableScore: weaponized.extensions.explanation
+              ? {
+                  score: weaponized.extensions.explanation.score,
+                  rating: weaponized.extensions.explanation.rating,
+                  cddLevel: weaponized.extensions.explanation.cddLevel,
+                }
+              : null,
+          },
         }
       : null,
   });

--- a/screening-command.js
+++ b/screening-command.js
@@ -1380,6 +1380,35 @@
         }
         html.push('</ul>');
       }
+      // EOCN-specific actionable hint. When the integrity reason is
+      // "UAE_EOCN cache is empty" the gate is operational, not
+      // transient — no amount of re-running will seed the cache.
+      // Point the MLRO at the upload endpoint so they can post the
+      // latest EOCN circular and close the Art.35 gap. We emit a
+      // plain URL the MLRO can copy instead of a clickable form —
+      // this page has a strict CSP and the upload requires a bearer
+      // token that must not be entered in the browser console.
+      var uaeCacheEmpty = integrityReasons.some(function (r) {
+        return (
+          typeof r === 'string' &&
+          /UAE_EOCN/i.test(r) &&
+          /cache is empty|cache empty/i.test(r)
+        );
+      });
+      if (uaeCacheEmpty) {
+        html.push(
+          '<div style="margin-top:10px; padding:10px 12px; border-left:3px solid var(--red); ' +
+            'background: rgba(201,52,52,0.04); font-size:12px; line-height:1.5;">' +
+            '<strong>ACTION REQUIRED · UPLOAD EOCN CIRCULAR.</strong><br>' +
+            'No EOCN circular has been ingested into <code>sanctions-snapshots</code>. ' +
+            'The ingest cron does not poll EOCN (PDF-distributed); the MLRO must POST ' +
+            'the normalised circular to the manual upload endpoint. ' +
+            'Endpoint: <code>POST /api/sanctions/eocn-upload</code> ' +
+            '(bearer <code>SANCTIONS_UPLOAD_TOKEN</code>). ' +
+            'See <code>netlify/functions/sanctions-eocn-upload.mts</code> for the payload shape.' +
+            '</div>'
+        );
+      }
       html.push('</div>');
     } else if (integrity === 'degraded') {
       html.push(

--- a/src/services/sanctionsApi.ts
+++ b/src/services/sanctionsApi.ts
@@ -61,17 +61,92 @@ export async function fetchUNSanctionsList(
   if (!response.ok) throw new Error(`UN API returned ${response.status}`);
 
   const xmlText = await response.text();
-  return parseUNXml(xmlText);
+  return parseUNXml(xmlText, opts?.signal);
 }
 
 /**
- * Parse UN Consolidated Sanctions XML into structured entries.
+ * Yield control back to the Node event loop. Used between chunks of a
+ * long synchronous XML parse so that setTimeout-based abort and hard
+ * timers inside screening-run.mts can actually fire. Without these
+ * yields a 5 MB UN or EU payload can block the event loop for 10+
+ * seconds, silently pushing the whole function past Netlify's 10 s
+ * sync ceiling — which surfaces to the browser as
+ * "Stream idle timeout - partial response received" even though the
+ * upstream fetch completed cleanly. The yield itself costs ~0 ms but
+ * it is what lets the clock actually tick.
  */
-function parseUNXml(xml: string): SanctionsEntry[] {
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => {
+    const si = (globalThis as { setImmediate?: (cb: () => void) => unknown }).setImmediate;
+    if (typeof si === 'function') {
+      si(() => resolve());
+    } else {
+      setTimeout(resolve, 0);
+    }
+  });
+}
+
+/** Throw an AbortError if the signal is aborted. */
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    const err = new Error('aborted');
+    err.name = 'AbortError';
+    throw err;
+  }
+}
+
+/**
+ * Iterate all non-overlapping occurrences of `<tag>...</tag>` in `xml`
+ * using indexOf instead of a global regex. Avoids the pathological
+ * backtracking cost of `/<tag>[\s\S]*?<\/tag>/g` on a 5 MB string,
+ * which is the primary driver of the EU-parser event-loop stall.
+ */
+function* iterateBlocks(xml: string, tag: string): IterableIterator<string> {
+  const openLower = `<${tag.toLowerCase()}`;
+  const closeLower = `</${tag.toLowerCase()}>`;
+  const xmlLower = xml.toLowerCase();
+  let cursor = 0;
+  while (cursor < xmlLower.length) {
+    const openIdx = xmlLower.indexOf(openLower, cursor);
+    if (openIdx === -1) return;
+    // Ensure we match `<tag ` or `<tag>` — not `<tagOther>`.
+    const afterTag = xmlLower.charCodeAt(openIdx + openLower.length);
+    // ' ' (0x20), '>' (0x3e), '/' (0x2f), '\t' (0x09), '\n' (0x0a), '\r' (0x0d)
+    if (
+      afterTag !== 0x20 &&
+      afterTag !== 0x3e &&
+      afterTag !== 0x2f &&
+      afterTag !== 0x09 &&
+      afterTag !== 0x0a &&
+      afterTag !== 0x0d
+    ) {
+      cursor = openIdx + openLower.length;
+      continue;
+    }
+    const closeIdx = xmlLower.indexOf(closeLower, openIdx + openLower.length);
+    if (closeIdx === -1) return;
+    const blockEnd = closeIdx + closeLower.length;
+    yield xml.slice(openIdx, blockEnd);
+    cursor = blockEnd;
+  }
+}
+
+/** How many blocks to parse between event-loop yields. */
+const PARSE_YIELD_EVERY = 100;
+
+/**
+ * Parse UN Consolidated Sanctions XML into structured entries.
+ * Async + signal-aware so abort timers in the caller can fire while
+ * we're chewing through the payload.
+ */
+async function parseUNXml(xml: string, signal?: AbortSignal): Promise<SanctionsEntry[]> {
   const entries: SanctionsEntry[] = [];
+  let parsed = 0;
   // Parse INDIVIDUAL entries
-  const individualBlocks = xml.match(/<INDIVIDUAL>[\s\S]*?<\/INDIVIDUAL>/g) || [];
-  for (const block of individualBlocks) {
+  for (const block of iterateBlocks(xml, 'INDIVIDUAL')) {
+    throwIfAborted(signal);
+    if (parsed > 0 && parsed % PARSE_YIELD_EVERY === 0) await yieldToEventLoop();
+    parsed++;
     const id = extractTag(block, 'DATAID') || extractTag(block, 'REFERENCE_NUMBER') || '';
     const firstName = extractTag(block, 'FIRST_NAME') || '';
     const secondName = extractTag(block, 'SECOND_NAME') || '';
@@ -96,8 +171,10 @@ function parseUNXml(xml: string): SanctionsEntry[] {
   }
 
   // Parse ENTITY entries
-  const entityBlocks = xml.match(/<ENTITY>[\s\S]*?<\/ENTITY>/g) || [];
-  for (const block of entityBlocks) {
+  for (const block of iterateBlocks(xml, 'ENTITY')) {
+    throwIfAborted(signal);
+    if (parsed > 0 && parsed % PARSE_YIELD_EVERY === 0) await yieldToEventLoop();
+    parsed++;
     const id = extractTag(block, 'DATAID') || extractTag(block, 'REFERENCE_NUMBER') || '';
     const name = extractTag(block, 'FIRST_NAME') || '';
     const aliases = extractAllTags(block, 'ALIAS_NAME');
@@ -266,7 +343,7 @@ export async function fetchEUSanctionsList(
   if (!response.ok) throw new Error(`EU API returned ${response.status}`);
 
   const xmlText = await response.text();
-  return parseEUXml(xmlText);
+  return parseEUXml(xmlText, opts?.signal);
 }
 
 /**
@@ -280,12 +357,21 @@ function extractAttribute(tagString: string, attrName: string): string | null {
 
 /**
  * Parse EU Consolidated Sanctions XML into structured entries.
+ * Async + signal-aware so abort timers in the caller can fire while
+ * we're chewing through the ~5 MB payload. Uses indexOf-based block
+ * iteration instead of `/<sanctionEntity[\s\S]*?<\/sanctionEntity>/gi`
+ * against the whole string, which was the primary event-loop stall
+ * the "aborted at 10364ms" diagnostic in screening-run.mts was
+ * catching.
  */
-function parseEUXml(xml: string): SanctionsEntry[] {
+async function parseEUXml(xml: string, signal?: AbortSignal): Promise<SanctionsEntry[]> {
   const entries: SanctionsEntry[] = [];
-  const entityBlocks = xml.match(/<sanctionEntity[\s\S]*?<\/sanctionEntity>/gi) || [];
+  let parsed = 0;
 
-  for (const block of entityBlocks) {
+  for (const block of iterateBlocks(xml, 'sanctionEntity')) {
+    throwIfAborted(signal);
+    if (parsed > 0 && parsed % PARSE_YIELD_EVERY === 0) await yieldToEventLoop();
+    parsed++;
     const logicalId =
       extractAttribute(block, 'logicalId') || extractAttribute(block, 'designationId') || '';
 


### PR DESCRIPTION
## Summary

This PR introduces a new "weaponized brain" safety-clamp layer to the screening pipeline and fixes critical cache poisoning issues in the sanctions list hydration logic. It also optimizes XML parsing to prevent event-loop stalls during large payload processing.

## Key Changes

### Weaponized Brain Safety Clamp (Phase B.5)
- Added `runWeaponizedAssessment` integration with 19 subsystems that apply deterministic safety clamps over the MegaBrain verdict
- Runs fully in-process (no network calls) with a 800ms timeout budget
- Triggers when: non-"none" classification detected, screening integrity degraded, or deep brain confidence < 0.7
- Maps adverse media hits into the weaponized brain's ranker input and includes clamp reasons, subsystem failures, and audit narratives in the response
- Regulatory basis: FDL No.10/2025 Art.20-21, Cabinet Res 134/2025 Art.19, Cabinet Res 74/2020 Art.4-7

### Sanctions Cache Poisoning Fix
- Fixed `listCache` to only cache when **all mandatory lists** (UN, UAE_EOCN) succeed without errors
- Previously, a single cold-start miss would poison the warm instance for 6 hours, serving stale errors even after upstream recovery
- Added `uaeSeedSucceeded` flag to distinguish between successful hydrations (6h TTL) and failed hydrations (30s retry backoff)
- Prevents a single transient failure from blocking the Art.35 gate for the entire cache TTL window

### XML Parsing Event-Loop Optimization
- Replaced regex-based block extraction (`/<tag>[\s\S]*?<\/tag>/g`) with `indexOf`-based `iterateBlocks()` generator
- Avoids pathological backtracking on 5 MB UN/EU payloads that was blocking the event loop for 10+ seconds
- Added `yieldToEventLoop()` calls every 100 parsed blocks to allow abort timers and hard timeouts to fire
- Made `parseUNXml()` and `parseEUXml()` async and signal-aware so callers can abort long-running parses
- Fixes "Stream idle timeout - partial response received" errors that were silently exceeding Netlify's 10s sync ceiling

### UI Improvements
- Added actionable hint in screening-command.js when UAE_EOCN cache is empty
- Directs MLRO to the manual upload endpoint (`POST /api/sanctions/eocn-upload`) with clear instructions
- Helps distinguish between transient failures (retry) and operational gaps (manual intervention needed)

## Implementation Details

- Weaponized brain response includes: mega verdict, final verdict, confidence, clamp reasons, subsystem failures, audit narrative, advisor result (if available), and extension data (adverse media categories, explainable score)
- Cache validation checks that mandatory lists have no errors before caching the snapshot
- Event-loop yields use `setImmediate` when available, falling back to `setTimeout(0)`
- AbortSignal propagation allows upstream timeouts to interrupt long XML parses mid-stream

https://claude.ai/code/session_01E8pBhVcBUnd4pax1S2A8XM