### PR TITLE
feat: in-page iframe viewer for /logistics, /compliance-ops, /workbench

### DIFF
--- a/app-boot.js
+++ b/app-boot.js
@@ -129,29 +129,44 @@
     }
   };
 
-  // Handle URL-hash deep links on page load. Used by the Logistics
-  // landing page (logistics.html) to route back into index.html and
-  // auto-open the requested shipments sub-tab.
-  setTimeout(function () {
+  // Handle URL-hash deep links. Used by the landing pages (logistics.html,
+  // compliance-ops.html, workbench.html) that embed index.html in an iframe
+  // and switch sub-tabs by rewriting the iframe hash. Fires on load AND on
+  // hashchange so the embedded tab follows the parent's navigation.
+  var HASH_TAB_MAP = {
+    '#metals-trading': 'metalstrading',
+    '#metalstrading': 'metalstrading',
+    '#shipments': 'shipments',
+    '#tab-shipments': 'shipments',
+    '#tracking': 'tracking',
+    '#tab-tracking': 'tracking',
+    '#localshipments': 'localshipments',
+    '#tab-localshipments': 'localshipments',
+    '#training': 'training',
+    '#tab-training': 'training',
+    '#employees': 'employees',
+    '#tab-employees': 'employees',
+    '#incidents': 'incidents',
+    '#tab-incidents': 'incidents',
+    '#reports': 'reports',
+    '#tab-reports': 'reports',
+    '#asana': 'asana',
+    '#tab-asana': 'asana',
+    '#onboarding': 'onboarding',
+    '#tab-onboarding': 'onboarding',
+    '#approvals': 'approvals',
+    '#tab-approvals': 'approvals',
+  };
+  function applyHashRoute() {
     var hash = window.location.hash;
-    if (hash === '#metals-trading' || hash === '#metalstrading') {
-      window.switchTab('metalstrading');
-    } else if (hash === '#shipments' || hash === '#tab-shipments') {
-      window.switchTab('shipments');
-    } else if (hash === '#tracking' || hash === '#tab-tracking') {
-      window.switchTab('tracking');
-    } else if (hash === '#localshipments' || hash === '#tab-localshipments') {
-      window.switchTab('localshipments');
-    } else if (hash === '#training' || hash === '#tab-training') {
-      window.switchTab('training');
-    } else if (hash === '#employees' || hash === '#tab-employees') {
-      window.switchTab('employees');
-    } else if (hash === '#incidents' || hash === '#tab-incidents') {
-      window.switchTab('incidents');
-    } else if (hash === '#reports' || hash === '#tab-reports') {
-      window.switchTab('reports');
+    if (!hash) return;
+    var target = HASH_TAB_MAP[hash];
+    if (target && typeof window.switchTab === 'function') {
+      window.switchTab(target);
     }
-  }, 500);
+  }
+  setTimeout(applyHashRoute, 500);
+  window.addEventListener('hashchange', applyHashRoute);
 
   // If the hero was dismissed earlier in this session, keep it hidden
   // on reload so the user does not see it flash before the JS hides it.

--- a/compliance-ops.html
+++ b/compliance-ops.html
@@ -672,6 +672,27 @@
         </a>
       </div>
 
+      <section
+        class="module-view"
+        id="moduleView"
+        aria-label="Embedded module view"
+        aria-hidden="true"
+      >
+        <div class="module-view-head">
+          <h2 class="module-view-title" id="moduleViewTitle">Module</h2>
+          <button type="button" class="module-view-close" id="moduleViewClose">
+            &larr; Back to surfaces
+          </button>
+        </div>
+        <iframe
+          class="module-view-frame"
+          id="moduleViewFrame"
+          title="Compliance operations module"
+          loading="lazy"
+          src="about:blank"
+        ></iframe>
+      </section>
+
       <div class="reg-basis">
         <div class="reg-title">Regulatory Basis</div>
         <div class="reg-text">
@@ -689,5 +710,6 @@
       <span>© 2026 Hawkeye Sterling</span>
       <span>Confidential &middot; Audit-ready</span>
     </footer>
+    <script src="landing-module-viewer.js?v=1"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -8780,6 +8780,6 @@
     <script src="str-drafter-client.js?v=20260413"></script>
     <script src="mlro-insights-client.js?v=20260413"></script>
     <script src="global-status-bar.js?v=20260413"></script>
-    <script src="app-boot.js?v=20260414scroll"></script>
+    <script src="app-boot.js?v=20260419hash"></script>
   </body>
 </html>

--- a/landing-module-viewer.js
+++ b/landing-module-viewer.js
@@ -1,0 +1,39 @@
+(function () {
+  var view = document.getElementById('moduleView');
+  var frame = document.getElementById('moduleViewFrame');
+  var titleEl = document.getElementById('moduleViewTitle');
+  var closeBtn = document.getElementById('moduleViewClose');
+  if (!view || !frame || !titleEl || !closeBtn) return;
+
+  function openModule(route, label) {
+    frame.src = 'index.html#' + route;
+    titleEl.textContent = label || 'Module';
+    view.classList.add('is-open');
+    view.setAttribute('aria-hidden', 'false');
+    requestAnimationFrame(function () {
+      view.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+  }
+
+  function closeModule() {
+    view.classList.remove('is-open');
+    view.setAttribute('aria-hidden', 'true');
+    frame.src = 'about:blank';
+  }
+
+  document.querySelectorAll('.card[data-route]').forEach(function (card) {
+    card.addEventListener('click', function (event) {
+      event.preventDefault();
+      var route = card.getAttribute('data-route');
+      var label = card.querySelector('.card-title');
+      openModule(route, label ? label.textContent : 'Module');
+    });
+  });
+
+  closeBtn.addEventListener('click', closeModule);
+  document.addEventListener('keydown', function (event) {
+    if (event.key === 'Escape' && view.classList.contains('is-open')) {
+      closeModule();
+    }
+  });
+})();

--- a/logistics.html
+++ b/logistics.html
@@ -886,6 +886,27 @@
         </a>
       </div>
 
+      <section
+        class="module-view"
+        id="moduleView"
+        aria-label="Embedded module view"
+        aria-hidden="true"
+      >
+        <div class="module-view-head">
+          <h2 class="module-view-title" id="moduleViewTitle">Module</h2>
+          <button type="button" class="module-view-close" id="moduleViewClose">
+            &larr; Back to surfaces
+          </button>
+        </div>
+        <iframe
+          class="module-view-frame"
+          id="moduleViewFrame"
+          title="Shipments module"
+          loading="lazy"
+          src="about:blank"
+        ></iframe>
+      </section>
+
       <div class="reg-strip" role="note">
         <div class="reg-badge" aria-hidden="true">§</div>
         <div class="reg-body">
@@ -935,5 +956,6 @@
         });
       })();
     </script>
+    <script src="landing-module-viewer.js?v=1"></script>
   </body>
 </html>

--- a/workbench.html
+++ b/workbench.html
@@ -348,6 +348,62 @@
       .reg-text { font-size: 12px; line-height: 1.7; color: var(--ice); opacity: 0.78; }
       .reg-text strong { color: var(--mist); font-weight: 600; }
 
+      /* In-page module viewer — opens the index.html tab inline via iframe
+         so the user stays on workbench.html. */
+      .module-view {
+        display: none;
+        margin-top: 1.5rem;
+        border-radius: 16px;
+        border: 1px solid var(--border);
+        background: rgba(10, 22, 40, 0.6);
+        backdrop-filter: blur(18px);
+        -webkit-backdrop-filter: blur(18px);
+        overflow: hidden;
+      }
+      .module-view.is-open { display: block; }
+      .module-view-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        padding: 14px 18px;
+        border-bottom: 1px solid var(--border);
+        background: rgba(23, 50, 87, 0.5);
+      }
+      .module-view-title {
+        font-family: 'Playfair Display', serif;
+        font-weight: 700;
+        font-size: 20px;
+        color: var(--mist);
+        margin: 0;
+      }
+      .module-view-close {
+        font-family: 'DM Mono', monospace;
+        font-size: 11px;
+        letter-spacing: 2px;
+        text-transform: uppercase;
+        color: var(--ice);
+        background: transparent;
+        border: 1px solid var(--border-strong);
+        border-radius: 999px;
+        padding: 7px 14px;
+        cursor: pointer;
+        transition: all 0.2s ease;
+      }
+      .module-view-close:hover {
+        color: var(--mist);
+        border-color: var(--orange-bright);
+        box-shadow: 0 0 0 4px rgba(251, 146, 60, 0.14);
+      }
+      .module-view-frame {
+        width: 100%;
+        height: 78vh;
+        min-height: 640px;
+        border: 0;
+        background: var(--midnight);
+        display: block;
+      }
+
       .footer {
         position: relative; z-index: 1;
         padding: 2rem; border-top: 1px solid var(--border);
@@ -423,7 +479,7 @@
       </div>
 
       <div class="cards">
-        <a class="card" data-tone="orange" href="index.html#asana">
+        <a class="card" data-tone="orange" href="index.html#asana" data-route="asana">
           <div class="card-icon" aria-hidden="true">📋</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -451,7 +507,7 @@
           </div>
         </a>
 
-        <a class="card" data-tone="yellow" href="index.html#onboarding">
+        <a class="card" data-tone="yellow" href="index.html#onboarding" data-route="onboarding">
           <div class="card-icon" aria-hidden="true">👤</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -479,7 +535,7 @@
           </div>
         </a>
 
-        <a class="card" data-tone="green" href="index.html#approvals">
+        <a class="card" data-tone="green" href="index.html#approvals" data-route="approvals">
           <div class="card-icon" aria-hidden="true">✅</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -508,6 +564,27 @@
         </a>
       </div>
 
+      <section
+        class="module-view"
+        id="moduleView"
+        aria-label="Embedded module view"
+        aria-hidden="true"
+      >
+        <div class="module-view-head">
+          <h2 class="module-view-title" id="moduleViewTitle">Module</h2>
+          <button type="button" class="module-view-close" id="moduleViewClose">
+            &larr; Back to surfaces
+          </button>
+        </div>
+        <iframe
+          class="module-view-frame"
+          id="moduleViewFrame"
+          title="Workbench module"
+          loading="lazy"
+          src="about:blank"
+        ></iframe>
+      </section>
+
       <div class="reg-strip" role="note">
         <div class="reg-badge" aria-hidden="true">§</div>
         <div>
@@ -528,5 +605,6 @@
       <span class="footer-text">© 2026 Hawkeye Sterling</span>
       <span class="footer-text">Confidential · Audit-ready</span>
     </footer>
+    <script src="landing-module-viewer.js?v=1"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

OPEN MODULE on each of the three landing pages (`/logistics`, `/compliance-ops`, `/workbench`) now keeps the user on the landing URL and opens the target `index.html` tab inside an in-page iframe instead of navigating away.

Covers 10 module routes end-to-end:

- `/logistics` → shipments, tracking, localshipments
- `/compliance-ops` → training, employees, incidents, reports
- `/workbench` → asana, onboarding, approvals

## Implementation

- New `landing-module-viewer.js` — shared external script that intercepts `.card[data-route]` clicks, points the iframe at `index.html#<route>`, scrolls the viewer into view, and wires an ESC/close-button exit. Loaded as external so the inline `<script>` hash allowlist in `netlify.toml` CSP stays valid; no inline JS added.
- `.module-view` section + iframe markup added to `logistics.html`, `compliance-ops.html`, `workbench.html`. CSS was already present in the first two; added to `workbench.html` in this PR.
- `data-route` attributes added to the three workbench cards.
- `app-boot.js` hash-reader extended: handles `asana`, `onboarding`, `approvals` in addition to the existing shipment/ops routes, and now listens to `hashchange` so the embedded tab tracks parent navigation when the user opens a second card without reloading the iframe.
- `index.html` cache-buster bumped on `app-boot.js`.

## Regulatory basis

Preserves the 10-year audit-trail surface under **FDL No.10/2025 Art.24**: every module view still loads the production `index.html` tab that writes to the live audit trail. No change to the underlying compliance logic.

## Test plan

- [ ] `/logistics` — all three cards keep URL on `/logistics` and load the right tab inside the iframe.
- [ ] `/compliance-ops.html` — all four cards likewise.
- [ ] `/workbench` — all three cards likewise.
- [ ] Opening a second card in the same session swaps the iframe contents without leaving the landing URL.
- [ ] ESC and the back chip both close the viewer and clear the iframe `src`.
- [ ] CSP does not report violations in the browser console.
- [ ] `X-Frame-Options = SAMEORIGIN` + `frame-ancestors 'self'` continue to allow same-origin iframing.

https://claude.ai/code/session_01NS4gn3GsVrWGVzadLKB6y3