### PR TITLE
fix: bulletproof OPEN MODULE intercept on landing pages

### DIFF
--- a/compliance-ops.html
+++ b/compliance-ops.html
@@ -561,7 +561,7 @@
       </div>
 
       <div class="grid">
-        <a class="card" href="index.html#training" data-route="training">
+        <a class="card" href="#training" data-route="training">
           <div class="card-icon" aria-hidden="true">🎓</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -588,7 +588,7 @@
           </div>
         </a>
 
-        <a class="card" href="index.html#employees" data-route="employees">
+        <a class="card" href="#employees" data-route="employees">
           <div class="card-icon" aria-hidden="true">👥</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -616,7 +616,7 @@
           </div>
         </a>
 
-        <a class="card" href="index.html#incidents" data-route="incidents">
+        <a class="card" href="#incidents" data-route="incidents">
           <div class="card-icon" aria-hidden="true">🚨</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -644,7 +644,7 @@
           </div>
         </a>
 
-        <a class="card" href="index.html#reports" data-route="reports">
+        <a class="card" href="#reports" data-route="reports">
           <div class="card-icon" aria-hidden="true">📊</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -710,6 +710,6 @@
       <span>© 2026 Hawkeye Sterling</span>
       <span>Confidential &middot; Audit-ready</span>
     </footer>
-    <script src="landing-module-viewer.js?v=1"></script>
+    <script src="landing-module-viewer.js?v=2"></script>
   </body>
 </html>

--- a/landing-module-viewer.js
+++ b/landing-module-viewer.js
@@ -21,14 +21,19 @@
     frame.src = 'about:blank';
   }
 
-  document.querySelectorAll('.card[data-route]').forEach(function (card) {
-    card.addEventListener('click', function (event) {
+  document.addEventListener(
+    'click',
+    function (event) {
+      var card = event.target.closest && event.target.closest('.card[data-route]');
+      if (!card) return;
       event.preventDefault();
+      event.stopPropagation();
       var route = card.getAttribute('data-route');
       var label = card.querySelector('.card-title');
       openModule(route, label ? label.textContent : 'Module');
-    });
-  });
+    },
+    true
+  );
 
   closeBtn.addEventListener('click', closeModule);
   document.addEventListener('keydown', function (event) {

--- a/logistics.html
+++ b/logistics.html
@@ -802,7 +802,7 @@
       </div>
 
       <div class="grid">
-        <a class="card" href="index.html#shipments" data-route="shipments">
+        <a class="card" href="#shipments" data-route="shipments">
           <div class="card-icon" aria-hidden="true">🚚</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -830,7 +830,7 @@
           </div>
         </a>
 
-        <a class="card" href="index.html#tracking" data-route="tracking">
+        <a class="card" href="#tracking" data-route="tracking">
           <div class="card-icon" aria-hidden="true">✈️</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -857,7 +857,7 @@
           </div>
         </a>
 
-        <a class="card" href="index.html#localshipments" data-route="localshipments">
+        <a class="card" href="#localshipments" data-route="localshipments">
           <div class="card-icon" aria-hidden="true">📦</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -956,6 +956,6 @@
         });
       })();
     </script>
-    <script src="landing-module-viewer.js?v=1"></script>
+    <script src="landing-module-viewer.js?v=2"></script>
   </body>
 </html>

--- a/workbench.html
+++ b/workbench.html
@@ -479,7 +479,7 @@
       </div>
 
       <div class="cards">
-        <a class="card" data-tone="orange" href="index.html#asana" data-route="asana">
+        <a class="card" data-tone="orange" href="#asana" data-route="asana">
           <div class="card-icon" aria-hidden="true">📋</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -507,7 +507,7 @@
           </div>
         </a>
 
-        <a class="card" data-tone="yellow" href="index.html#onboarding" data-route="onboarding">
+        <a class="card" data-tone="yellow" href="#onboarding" data-route="onboarding">
           <div class="card-icon" aria-hidden="true">👤</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -535,7 +535,7 @@
           </div>
         </a>
 
-        <a class="card" data-tone="green" href="index.html#approvals" data-route="approvals">
+        <a class="card" data-tone="green" href="#approvals" data-route="approvals">
           <div class="card-icon" aria-hidden="true">✅</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -605,6 +605,6 @@
       <span class="footer-text">© 2026 Hawkeye Sterling</span>
       <span class="footer-text">Confidential · Audit-ready</span>
     </footer>
-    <script src="landing-module-viewer.js?v=1"></script>
+    <script src="landing-module-viewer.js?v=2"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
Some users were still being navigated to `index.html` when clicking OPEN MODULE on `/logistics`, `/compliance-ops`, and `/workbench` after PR #313. Root cause: if `landing-module-viewer.js` is slow to load, cached stale, or racing with an early click, the anchor's default `href="index.html#X"` fires first.

Two defenses:
- Drop the `index.html` prefix from every card href — worst case a click only updates the hash on the landing page instead of navigating away.
- Use capture-phase event delegation at document-level in `landing-module-viewer.js` with `stopPropagation()`, and bump the cache-buster to `v=2` so browsers pick up the new script.

## Regulatory
No regulatory logic changed. Audit-trail retention (FDL No.10/2025 Art.24) and MLRO operational-surface separation still trace to the same inline module routes.

## Test plan
- [ ] Hard refresh `/logistics` → click each card → iframe opens inline, URL stays on `/logistics`.
- [ ] Same for `/compliance-ops` and `/workbench`.
- [ ] With DevTools → Network → block `landing-module-viewer.js` → click card: URL only updates the hash, does not navigate to `index.html`.
- [ ] ESC closes the viewer.
