### PR TITLE
fix: skip splash preloader when index.html runs in landing-page iframe

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,14 @@
     <link rel="apple-touch-icon" href="assets/logos/hawkeye-icon.svg" />
     <title>Hawkeye Sterling V2 — Compliance Suite</title>
     <script>
+      // When index.html is embedded in an iframe (landing pages
+      // /workbench, /compliance-ops, /logistics use landing-module-viewer
+      // to load the main app inline), skip the full-screen preloader
+      // so the landing page does not appear to "navigate to the main
+      // page" — FDL No.10/2025 Art.20 operational continuity.
+      if (window.self !== window.top) {
+        document.documentElement.classList.add('embedded');
+      }
       // KILL all service workers and caches — must run FIRST
       if ('serviceWorker' in navigator) {
         navigator.serviceWorker.getRegistrations().then(function (regs) {
@@ -1770,6 +1778,7 @@
         gap: 30px;
         animation: hsPreloaderOut 0.8s ease 2.8s forwards;
       }
+      html.embedded .hs-preloader { display: none !important; }
       .hs-preloader-icon {
         width: 80px;
         height: 80px;


### PR DESCRIPTION
## Summary

When `/workbench`, `/compliance-ops`, or `/logistics` open a card, `landing-module-viewer.js` loads `index.html` into an inline iframe so the URL bar stays on the landing page. The iframe was showing index.html's 2.8s full-viewport `HAWKEYE STERLING V2` preloader, which made the landing page appear to navigate to the main app.

- Mark the iframed document with `html.embedded` (set at the top of `<head>` when `window.self !== window.top`).
- Suppress `.hs-preloader` only in that state — the top-level main-app load is unchanged.

## Regulatory basis

- FDL No.10/2025 Art.20 (MLRO operational continuity — the analyst reaches the requested surface without a misleading splash).

## Test plan

- [ ] Load `/workbench`, click any of the three cards — iframe opens with main-app content, no splash.
- [ ] Load `/compliance-ops` and `/logistics`, click a card — same behaviour.
- [ ] Load `/` (top-level) — preloader still runs for 2.8s as before.

https://claude.ai/code/session_01E8pBhVcBUnd4pax1S2A8XM