### PR TITLE
fix: strip main-app chrome when index.html runs in landing-page iframe

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,14 @@
     <link rel="apple-touch-icon" href="assets/logos/hawkeye-icon.svg" />
     <title>Hawkeye Sterling V2 — Compliance Suite</title>
     <script>
+      // When index.html is embedded in an iframe (landing pages
+      // /workbench, /compliance-ops, /logistics use landing-module-viewer
+      // to load the main app inline), skip the full-screen preloader
+      // so the landing page does not appear to "navigate to the main
+      // page" — FDL No.10/2025 Art.20 operational continuity.
+      if (window.self !== window.top) {
+        document.documentElement.classList.add('embedded');
+      }
       // KILL all service workers and caches — must run FIRST
       if ('serviceWorker' in navigator) {
         navigator.serviceWorker.getRegistrations().then(function (regs) {
@@ -1770,6 +1778,7 @@
         gap: 30px;
         animation: hsPreloaderOut 0.8s ease 2.8s forwards;
       }
+      html.embedded .hs-preloader { display: none !important; }
       .hs-preloader-icon {
         width: 80px;
         height: 80px;

--- a/index.html
+++ b/index.html
@@ -1779,6 +1779,19 @@
         animation: hsPreloaderOut 0.8s ease 2.8s forwards;
       }
       html.embedded .hs-preloader { display: none !important; }
+      /* When index.html is loaded into a landing-page iframe
+         (/workbench, /compliance-ops, /logistics, /routines),
+         strip the main-app chrome so only the requested module
+         renders. The landing page already provides its own header
+         and "Back to surfaces" affordance. */
+      html.embedded .header,
+      html.embedded .hawkeye-intro,
+      html.embedded .hero-intro,
+      html.embedded .tabs,
+      html.embedded #tabsNav { display: none !important; }
+      html.embedded #mainApp,
+      html.embedded .app { padding-top: 0 !important; margin-top: 0 !important; }
+      html.embedded body { padding-top: 0 !important; }
       .hs-preloader-icon {
         width: 80px;
         height: 80px;


### PR DESCRIPTION
## Summary

When `/workbench`, `/compliance-ops`, `/logistics`, or `/routines` open a card, `landing-module-viewer.js` loads `index.html` into an inline iframe. The iframe was still rendering the main-app header, tenant selector, intro section, and full tab bar — so the landing page looked like it had navigated to the main app and exposed every other tab to the analyst.

- Extend the `html.embedded` guard (from #316) so `.header`, `.hawkeye-intro`, `.hero-intro`, `.tabs`, and `#tabsNav` are hidden when embedded.
- The module content alone now renders inside the iframe; the landing page keeps its own header and "Back to surfaces" affordance.
- Top-level main-app load is unchanged.

## Regulatory basis

- FDL No.10/2025 Art.20 (MLRO operational continuity — a dedicated surface per module, no misleading navigation).

## Test plan

- [ ] `/workbench` → click Onboarding: shows only the onboarding form, no HAWKEYE header, no tab bar.
- [ ] `/compliance-ops` → click Training: shows only the employee training form.
- [ ] `/logistics` → click Shipments: shows only the shipments tab content.
- [ ] `/routines` → behaviour unchanged if it uses iframe; otherwise unaffected.
- [ ] `/` (top-level main app) still shows full header, tenant bar, and tabs.

https://claude.ai/code/session_01E8pBhVcBUnd4pax1S2A8XM