### PR TITLE
Asana life-story report + route to The Screenings section

### DIFF
--- a/netlify/functions/screening-run.mts
+++ b/netlify/functions/screening-run.mts
@@ -89,6 +89,12 @@ import {
   type RiskTier,
 } from '../../src/services/screeningWatchlist';
 import { createAsanaTask } from '../../src/services/asanaClient';
+import { moveTaskToNamedSection } from '../../src/services/asanaSectionByName';
+import {
+  buildLifeStoryMarkdown,
+  type LifeStoryInput,
+  type LifeStoryPerListRow,
+} from '../../src/services/lifeStoryReportBuilder';
 import {
   runDeepBrain,
   type OrchestrationResult,
@@ -1177,8 +1183,29 @@ async function postAsanaTask(params: {
   eventType?: ScreeningEventType;
   integrity?: 'complete' | 'degraded' | 'incomplete';
   integrityReasons?: string[];
-}): Promise<{ ok: boolean; gid?: string; error?: string }> {
-  const projectId = process.env.ASANA_SCREENINGS_PROJECT_GID || '1213759768596515';
+  /** Full life-story deep-dive (first-screen events only). When provided,
+   *  becomes the task body in place of the plain line list and the task
+   *  is moved into the "The Screenings" section on success. */
+  lifeStory?: LifeStoryInput;
+  /** Name of the Asana board section to move the task into after create.
+   *  Resolved case-insensitively at runtime so MLROs can rename the
+   *  section slightly without a code change. */
+  targetSectionName?: string;
+  /** Optional override for ASANA_SCREENINGS_PROJECT_GID. Lets
+   *  continuous-monitor reuse this function with a different project
+   *  if/when we split boards. */
+  projectGidOverride?: string;
+}): Promise<{
+  ok: boolean;
+  gid?: string;
+  error?: string;
+  sectionName?: string;
+  sectionError?: string;
+}> {
+  const projectId =
+    params.projectGidOverride ||
+    process.env.ASANA_SCREENINGS_PROJECT_GID ||
+    '1214124911186857';
   if (!process.env.ASANA_TOKEN && !process.env.ASANA_ACCESS_TOKEN && !process.env.ASANA_API_TOKEN) {
     return { ok: false, error: 'ASANA_TOKEN not configured' };
   }
@@ -1283,13 +1310,45 @@ async function postAsanaTask(params: {
   }
   if (params.eventType) tags.push(`event-${params.eventType}`);
 
+  // Life-story body for first-screen events (new_customer_onboarding /
+  // periodic_review). Replaces the plain line list with the rich
+  // markdown the MLRO actually reads on the Asana board. Falls back
+  // to the plain body when lifeStory is undefined so the contract for
+  // continuous-monitor + ad-hoc screens is unchanged.
+  const body = params.lifeStory ? buildLifeStoryMarkdown(params.lifeStory) : lines.join('\n');
+
   const result = await createAsanaTask({
     name,
-    notes: lines.join('\n'),
+    notes: body,
     projects: [projectId],
     tags,
   });
-  return result;
+
+  // Section write-back — fire-and-log. If it fails, the task still
+  // exists in the project's default column, so the MLRO never loses
+  // evidence. The error is surfaced on the verdict page via
+  // `asana.sectionError` so the integrations status can flag a
+  // misconfigured board.
+  let sectionName: string | undefined;
+  let sectionError: string | undefined;
+  if (result.ok && result.gid && params.targetSectionName) {
+    try {
+      const moved = await moveTaskToNamedSection(
+        projectId,
+        result.gid,
+        params.targetSectionName
+      );
+      if (moved.ok) {
+        sectionName = moved.sectionName;
+      } else {
+        sectionError = moved.error;
+      }
+    } catch (err) {
+      sectionError = err instanceof Error ? err.message : 'section move failed';
+    }
+  }
+
+  return { ...result, sectionName, sectionError };
 }
 
 // ---------------------------------------------------------------------------
@@ -1883,13 +1942,104 @@ export default async (req: Request, context: Context): Promise<Response> => {
   // a clean run. Cabinet Res 134/2025 Art.19: periodic internal review
   // sees every event. Running the two writes in parallel shaves ~1.5s
   // off the tail of the pipeline.
-  const asanaProjectGid = process.env.ASANA_SCREENINGS_PROJECT_GID || '1213759768596515';
+  // Default project GID points at the MLRO board the user designated
+  // ("The Screenings" + "Transaction Monitor" sections live here).
+  // Override via ASANA_SCREENINGS_PROJECT_GID in Netlify env if we ever
+  // split boards per tenant.
+  const asanaProjectGid = process.env.ASANA_SCREENINGS_PROJECT_GID || '1214124911186857';
   const asanaAnomalies = [
     ...anomalousListErrors.map((l) => `${l.list}: ${l.error}`),
     ...(screeningIntegrity !== 'complete'
       ? integrityReasons.map((r) => `integrity-${screeningIntegrity}: ${r}`)
       : []),
   ];
+
+  // First-screen events get the full life-story deep-dive (Sample 1
+  // markdown) and land in "The Screenings" section. Ad-hoc and
+  // transaction-triggered screens keep the compact line-list body
+  // and go to the default section. Configurable via env so the MLRO
+  // can rename the section without a code change (FDL Art.24 audit
+  // trail preserved via Asana's native activity log).
+  const isFirstScreen =
+    input.eventType === 'new_customer_onboarding' ||
+    input.eventType === 'periodic_review';
+  const screeningsSectionName =
+    process.env.ASANA_SECTION_SCREENINGS_NAME || 'The Screenings';
+
+  const lifeStoryInput: LifeStoryInput | undefined = isFirstScreen
+    ? (() => {
+        const nameVariants = searchTerms?.length ? Array.from(searchTerms) : undefined;
+        const lifeStoryPerList: LifeStoryPerListRow[] = perList.map((l) => {
+          const err = l.error ?? '';
+          let status: LifeStoryPerListRow['status'] = 'ok';
+          let note: string | undefined;
+          if (err) {
+            if (/served .* rows from cached ingest-cron snapshot/i.test(err)) {
+              status = 'snapshot';
+              note = err;
+            } else if (/UN fallback/i.test(err) || /hydrated from UN snapshot/i.test(err)) {
+              status = 'fallback';
+              note = err;
+            } else {
+              status = 'error';
+              note = err;
+            }
+          }
+          return {
+            list: l.list,
+            status,
+            topScore: l.topScore,
+            hitCount: l.hitCount,
+            note,
+          };
+        });
+        const amHits = input.runAdverseMedia
+          ? amRes.value.hits.slice(0, 20).map((h) => ({
+              date: h.publishedAt,
+              source: h.source,
+              title: h.title,
+              url: h.url,
+              relevance: (h as { relevance?: number }).relevance,
+            }))
+          : [];
+        const verdictGuess: LifeStoryInput['verdict'] =
+          overallTopClassification === 'confirmed'
+            ? 'freeze'
+            : overallTopClassification === 'potential' ||
+                (typeof explanation.score === 'number' && explanation.score >= 16)
+              ? 'escalate'
+              : typeof explanation.score === 'number' && explanation.score >= 6
+                ? 'monitor'
+                : 'clean';
+        const reviewMonths =
+          verdictGuess === 'escalate' ? 3 : verdictGuess === 'monitor' ? 6 : 12;
+        return {
+          screeningId: subjectId,
+          ranAt,
+          subjectName: input.subjectName,
+          aliases: input.aliases,
+          nameVariants,
+          dob: input.dob,
+          nationality: input.country,
+          entityType: input.entityType,
+          jurisdiction: input.jurisdiction,
+          eventType: input.eventType,
+          integrity: screeningIntegrity,
+          integrityReasons,
+          verdict: verdictGuess,
+          compositeRisk: explanation.score,
+          riskRating: explanation.rating,
+          cddLevel: explanation.cddLevel,
+          reviewCadenceMonths: reviewMonths,
+          perList: lifeStoryPerList,
+          sanctionsTopClassification: overallTopClassification,
+          adverseMediaSinceDate: amSinceDate,
+          adverseMediaProviders: adverseMediaProvidersUsed,
+          adverseMediaHits: amHits,
+          mlroActions: undefined,
+        };
+      })()
+    : undefined;
 
   const [watchlistRes, asanaRes] = await Promise.all([
     input.enrollInWatchlist
@@ -1938,6 +2088,9 @@ export default async (req: Request, context: Context): Promise<Response> => {
             jurisdiction: input.jurisdiction,
             notes: input.notes,
             anomalies: asanaAnomalies,
+            lifeStory: lifeStoryInput,
+            targetSectionName: isFirstScreen ? screeningsSectionName : undefined,
+            projectGidOverride: asanaProjectGid,
             eventType: input.eventType,
             integrity: screeningIntegrity,
             integrityReasons,
@@ -1965,6 +2118,8 @@ export default async (req: Request, context: Context): Promise<Response> => {
     skipped?: boolean;
     projectGid: string;
     projectName: string;
+    sectionName?: string;
+    sectionError?: string;
   } = input.createAsanaTask
     ? {
         ...asanaRes.value,

--- a/src/services/asanaSectionByName.ts
+++ b/src/services/asanaSectionByName.ts
@@ -1,0 +1,124 @@
+/**
+ * Asana Section By Name — tolerant name-based section lookup.
+ *
+ * The existing asanaSectionWriteBack.ts resolves a Kanban COLUMN to a
+ * section GID through the KANBAN_COLUMNS enum. That's the right layer
+ * for drag-drop. But the screening write-back needs to land a task in
+ * a named section ("The Screenings", "Transaction Monitor") on a
+ * specific MLRO project without introducing a new Kanban column. This
+ * module is the thin name-based lookup the screening path needs.
+ *
+ *   1. resolveSectionByName(projectGid, name) — case-insensitive
+ *      substring match against the project's section list
+ *   2. moveTaskToNamedSection(projectGid, taskGid, name) — one-shot
+ *      API for screening-run / continuous-monitor
+ *
+ * Fails soft: if the named section doesn't exist, the task stays at
+ * the top of the project (default Asana behaviour) and the caller
+ * gets a structured error it can surface on the verdict page.
+ *
+ * Regulatory basis:
+ *   - FDL No.10/2025 Art.24 (retention — section moves are logged in
+ *     Asana's native activity feed)
+ *   - Cabinet Res 134/2025 Art.19 (auditable workflow state)
+ */
+
+import {
+  fetchProjectSections,
+  moveTaskToSection,
+  type AsanaSection,
+} from './asanaSectionWriteBack';
+import { isAsanaConfigured } from './asanaClient';
+
+export interface NamedSectionResult {
+  ok: boolean;
+  projectGid: string;
+  sectionGid?: string;
+  sectionName?: string;
+  matchedAgainst?: string;
+  error?: string;
+}
+
+function normalise(s: string): string {
+  return s.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+/**
+ * Match a section name tolerantly: exact (case-insensitive) first,
+ * then startsWith, then substring. This mirrors the matcher used by
+ * asanaKanbanView's sectionNameToColumn so MLROs can rename sections
+ * slightly ("The Screenings (EDD)" still matches "the screenings")
+ * without code changes.
+ */
+function findSectionByName(
+  sections: readonly AsanaSection[],
+  needle: string
+): AsanaSection | undefined {
+  const n = normalise(needle);
+  if (!n) return undefined;
+  let bestExact: AsanaSection | undefined;
+  let bestPrefix: AsanaSection | undefined;
+  let bestContains: AsanaSection | undefined;
+  for (const s of sections) {
+    const hay = normalise(s.name);
+    if (hay === n) {
+      if (!bestExact) bestExact = s;
+    } else if (hay.startsWith(n) || n.startsWith(hay)) {
+      if (!bestPrefix) bestPrefix = s;
+    } else if (hay.includes(n) || n.includes(hay)) {
+      if (!bestContains) bestContains = s;
+    }
+  }
+  return bestExact ?? bestPrefix ?? bestContains;
+}
+
+export async function resolveSectionByName(
+  projectGid: string,
+  name: string
+): Promise<NamedSectionResult> {
+  if (!isAsanaConfigured()) {
+    return { ok: false, projectGid, error: 'Asana not configured' };
+  }
+  const fetched = await fetchProjectSections(projectGid);
+  if (!fetched.ok || !fetched.sections) {
+    return { ok: false, projectGid, error: fetched.error ?? 'failed to fetch sections' };
+  }
+  const hit = findSectionByName(fetched.sections, name);
+  if (!hit) {
+    const known = fetched.sections.map((s) => s.name).join(', ');
+    return {
+      ok: false,
+      projectGid,
+      matchedAgainst: name,
+      error: `no section named "${name}" on project ${projectGid}. Known sections: ${known || '(none)'}.`,
+    };
+  }
+  return {
+    ok: true,
+    projectGid,
+    sectionGid: hit.gid,
+    sectionName: hit.name,
+    matchedAgainst: name,
+  };
+}
+
+export async function moveTaskToNamedSection(
+  projectGid: string,
+  taskGid: string,
+  name: string
+): Promise<NamedSectionResult> {
+  const resolved = await resolveSectionByName(projectGid, name);
+  if (!resolved.ok || !resolved.sectionGid) return resolved;
+  const moved = await moveTaskToSection(taskGid, resolved.sectionGid);
+  if (!moved.ok) {
+    return {
+      ok: false,
+      projectGid,
+      sectionGid: resolved.sectionGid,
+      sectionName: resolved.sectionName,
+      matchedAgainst: name,
+      error: moved.error ?? 'failed to move task to section',
+    };
+  }
+  return resolved;
+}

--- a/src/services/lifeStoryReportBuilder.ts
+++ b/src/services/lifeStoryReportBuilder.ts
@@ -1,0 +1,277 @@
+/**
+ * Life-Story Report Builder — first-screen deep-dive markdown.
+ *
+ * When a subject is screened for the FIRST time (event types
+ * `new_customer_onboarding` or `periodic_review`), the MLRO needs the
+ * full life story in one place: name variants, sanctions coverage,
+ * 3-year historical adverse media, UBO + shell-company indicators,
+ * transaction-risk signals, and a regulatory-anchored action
+ * checklist. The output below becomes the Asana task description
+ * posted to "The Screenings" section (project 1214124911186857).
+ *
+ * Compact markdown layout — no horizontal rules between sections so
+ * the task description does not waste vertical space in the Asana
+ * board column preview. Tables keep information dense without
+ * sacrificing readability.
+ *
+ * Regulatory basis:
+ *   - FDL No.10/2025 Art.20-21 (name-variant due diligence)
+ *   - FDL Art.24 (10-yr retention — this document IS the audit record)
+ *   - FDL Art.26-27 (STR drafting inputs)
+ *   - FDL Art.29 (no tipping off — rendered as a footer)
+ *   - Cabinet Res 74/2020 Art.3-7 (sanctions + UN fallback)
+ *   - Cabinet Res 134/2025 Art.14 (EDD trigger)
+ *   - Cabinet Res 134/2025 Art.19 (periodic internal review — cadence)
+ *   - FATF Rec 10 (CDD + onboarding due diligence — 3-year lookback)
+ *   - LBMA RGG v9 (responsible gold — CAHRA sourcing controls)
+ *   - MoE Circular 08/AML/2021 (DPMS AED 55K CTR threshold)
+ */
+
+export interface LifeStoryPerListRow {
+  list: string;
+  status: 'ok' | 'snapshot' | 'fallback' | 'error';
+  topScore: number;
+  hitCount: number;
+  note?: string;
+}
+
+export interface LifeStoryAdverseHit {
+  date?: string;
+  source?: string;
+  title: string;
+  url: string;
+  relevance?: number;
+}
+
+export interface LifeStoryInput {
+  screeningId: string;
+  ranAt: string;
+  subjectName: string;
+  aliases?: string[];
+  nameVariants?: string[];
+  dob?: string;
+  nationality?: string;
+  entityType?: 'natural' | 'legal' | string;
+  jurisdiction?: string;
+  eventType?: string;
+
+  integrity: 'complete' | 'degraded' | 'incomplete';
+  integrityReasons?: string[];
+
+  verdict: 'clean' | 'monitor' | 'escalate' | 'freeze';
+  confidence?: number;
+  compositeRisk?: number;
+  riskRating?: 'low' | 'medium' | 'high' | 'critical' | string;
+  cddLevel?: 'SDD' | 'CDD' | 'EDD' | string;
+  reviewCadenceMonths?: number;
+
+  perList: LifeStoryPerListRow[];
+  sanctionsTopClassification: string;
+
+  pepHit?: boolean;
+  pepDetail?: string;
+
+  adverseMediaWindowDays?: number;
+  adverseMediaSinceDate?: string;
+  adverseMediaProviders?: string[];
+  adverseMediaHits?: LifeStoryAdverseHit[];
+  adverseMediaWhyItMatters?: string;
+
+  uboSelfHeldPercent?: number;
+  shellCompanyFlags?: string[];
+  layeringFlags?: string[];
+  vaspWallets?: string[];
+
+  mlroActions?: string[];
+  opusAdvisorInvoked?: boolean;
+  zkProofSealGid?: string;
+}
+
+const HYPHEN = '—';
+
+function fmt(n: number, digits = 2): string {
+  return Number.isFinite(n) ? n.toFixed(digits) : HYPHEN;
+}
+
+function fmtPct(n: number | undefined): string {
+  if (typeof n !== 'number' || !Number.isFinite(n)) return HYPHEN;
+  return n.toFixed(2);
+}
+
+function joinOr(xs: readonly string[] | undefined, dash = HYPHEN): string {
+  if (!xs || xs.length === 0) return dash;
+  return xs.join(', ');
+}
+
+function verdictLine(v: LifeStoryInput['verdict']): string {
+  switch (v) {
+    case 'freeze':
+      return 'FREEZE (asset freeze within 24h — Cabinet Res 74/2020 Art.4-7)';
+    case 'escalate':
+      return 'ESCALATE (EDD required, CO approval mandatory)';
+    case 'monitor':
+      return 'MONITOR (accept with ongoing monitoring)';
+    case 'clean':
+    default:
+      return 'CLEAN (standard CDD cadence)';
+  }
+}
+
+/**
+ * Build the compact life-story markdown. Every section is kept to
+ * a single visual block so Asana's board preview shows maximum
+ * density without horizontal rules between sections.
+ */
+export function buildLifeStoryMarkdown(input: LifeStoryInput): string {
+  const out: string[] = [];
+
+  out.push('# SCREENING — FULL LIFE STORY');
+  const variantLabel = input.nameVariants?.length
+    ? ` (also: ${input.nameVariants.filter((v) => v !== input.subjectName).join(', ')})`
+    : input.aliases?.length
+      ? ` (also: ${input.aliases.join(', ')})`
+      : '';
+  out.push(`**Subject:** ${input.subjectName}${variantLabel}`);
+  const hdrParts: string[] = [];
+  if (input.dob) hdrParts.push(`**DOB:** ${input.dob}`);
+  if (input.nationality) hdrParts.push(`**Nat:** ${input.nationality}`);
+  if (input.entityType) hdrParts.push(`**Type:** ${input.entityType}`);
+  if (input.jurisdiction) hdrParts.push(`**Jurisdiction:** ${input.jurisdiction}`);
+  if (hdrParts.length) out.push(hdrParts.join('  '));
+  const metaParts: string[] = [];
+  if (input.eventType) metaParts.push(`**Event:** ${input.eventType}`);
+  metaParts.push(`**Screening ID:** ${input.screeningId}`);
+  out.push(metaParts.join('  '));
+  const integrityEmoji =
+    input.integrity === 'complete' ? '✅' : input.integrity === 'degraded' ? '⚠️' : '❌';
+  out.push(
+    `**Run:** ${input.ranAt}  **Integrity:** ${input.integrity.toUpperCase()} ${integrityEmoji}`
+  );
+
+  out.push('');
+  out.push(`## 1. VERDICT — ${verdictLine(input.verdict)}`);
+  const vParts: string[] = [];
+  if (typeof input.confidence === 'number')
+    vParts.push(`Confidence ${fmtPct(input.confidence)}`);
+  if (input.opusAdvisorInvoked) vParts.push('Opus advisor invoked');
+  vParts.push('**do NOT notify the subject (FDL Art.29)**');
+  out.push(vParts.join(' — '));
+  out.push('| Composite risk | CDD level | Review cadence |');
+  out.push('|---:|:---:|:---:|');
+  const risk = typeof input.compositeRisk === 'number' ? `${input.compositeRisk} / 100` : HYPHEN;
+  const rating = input.riskRating ? ` — ${input.riskRating.toUpperCase()}` : '';
+  const cadence = input.reviewCadenceMonths ? `${input.reviewCadenceMonths} months` : HYPHEN;
+  out.push(`| **${risk}${rating}** | **${input.cddLevel ?? HYPHEN}** | ${cadence} |`);
+
+  out.push('');
+  const variantCount =
+    input.nameVariants?.length ?? (input.aliases ? input.aliases.length + 1 : 1);
+  out.push(
+    `## 2. SANCTIONS (${input.sanctionsTopClassification} — ${variantCount} name variants fanned out)`
+  );
+  out.push('| List | Status | Top | Note |');
+  out.push('|---|---|---:|---|');
+  for (const row of input.perList) {
+    out.push(
+      `| ${row.list} | ${row.status} | ${fmt(row.topScore)} | ${row.note ?? HYPHEN} |`
+    );
+  }
+
+  out.push('');
+  out.push(
+    `## 3. PEP — ${input.pepHit ? 'HIT' : 'Not PEP'}${input.pepDetail ? `. ${input.pepDetail}` : '. No PEP-by-association.'}`
+  );
+
+  out.push('');
+  const windowLabel = input.adverseMediaSinceDate
+    ? `${input.adverseMediaSinceDate} → ${input.ranAt.slice(0, 10)}`
+    : input.adverseMediaWindowDays
+      ? `last ${input.adverseMediaWindowDays} days`
+      : HYPHEN;
+  const hitCount = input.adverseMediaHits?.length ?? 0;
+  out.push(`## 4. ADVERSE MEDIA (FATF Rec 10)`);
+  out.push(
+    `**Window:** ${windowLabel} · **Providers:** ${joinOr(input.adverseMediaProviders)} · **${hitCount} hits deduped**`
+  );
+  if (hitCount > 0) {
+    out.push('| Date | Source | Headline | Rel |');
+    out.push('|---|---|---|---:|');
+    for (const h of input.adverseMediaHits!) {
+      const relStr = typeof h.relevance === 'number' ? h.relevance.toFixed(2) : HYPHEN;
+      out.push(
+        `| ${h.date ?? HYPHEN} | ${h.source ?? HYPHEN} | ${h.title} | ${relStr} |`
+      );
+    }
+  }
+  if (input.adverseMediaWhyItMatters) {
+    out.push(`**Why it matters:** ${input.adverseMediaWhyItMatters}`);
+  }
+
+  out.push('');
+  out.push('## 5. UBO & NETWORK');
+  const uboBits: string[] = [];
+  if (typeof input.uboSelfHeldPercent === 'number') {
+    uboBits.push(`${input.uboSelfHeldPercent}% self-held`);
+  }
+  const flagBits: string[] = [];
+  if (input.shellCompanyFlags?.length) flagBits.push(...input.shellCompanyFlags);
+  if (input.layeringFlags?.length) flagBits.push(...input.layeringFlags);
+  if (input.vaspWallets?.length) {
+    flagBits.push(`VASP wallets: ${input.vaspWallets.join(', ')}`);
+  } else {
+    flagBits.push('No VASP wallets');
+  }
+  if (flagBits.length > 0) uboBits.push(`**FLAGS:** ${flagBits.join('; ')}`);
+  out.push(uboBits.length ? uboBits.join('. ') + '.' : 'No UBO / network flags.');
+
+  out.push('');
+  out.push(
+    '## 6. TRANSACTION-RISK SIGNALS — If cash ≥ AED 55K → CTR via goAML (MoE Circular 08/AML/2021). If UN-1718/1737 derivative hit → 24h freeze (Cabinet Res 74/2020 Art.4-7).'
+  );
+
+  out.push('');
+  out.push('## 7. MLRO ACTIONS');
+  const actions = input.mlroActions?.length ? input.mlroActions : defaultActionsFor(input.verdict);
+  for (const a of actions) out.push(`- [ ] ${a}`);
+
+  out.push('');
+  out.push('## 8. AUDIT TRAIL (FDL Art.24 — 10y)');
+  const auditBits = [input.screeningId];
+  if (input.opusAdvisorInvoked) auditBits.push('Opus advisor trace (subtask)');
+  if (input.zkProofSealGid) auditBits.push(`zk-proof seal ${input.zkProofSealGid}`);
+  out.push(auditBits.join(' · '));
+
+  return out.join('\n');
+}
+
+function defaultActionsFor(verdict: LifeStoryInput['verdict']): string[] {
+  switch (verdict) {
+    case 'freeze':
+      return [
+        'FREEZE funds within 24h (Cabinet Res 74/2020 Art.4)',
+        'File EOCN notification within 24h',
+        'File CNMR within 5 business days',
+        'Do NOT notify subject (FDL Art.29)',
+      ];
+    case 'escalate':
+      return [
+        'BLOCK onboarding pending EDD (Cabinet Res 134/2025 Art.14)',
+        'Senior Mgmt approval before relationship opens',
+        'Obtain certified KYC + notarised UBO + source-of-wealth evidence',
+        'Pre-emptive STR draft (FDL Art.26-27) — attached as subtask',
+        'Add subject + name variants to continuous-monitor watchlist',
+      ];
+    case 'monitor':
+      return [
+        'Accept with enhanced ongoing monitoring',
+        'Add to continuous-monitor watchlist (daily re-screen)',
+        'Re-review in 6 months (Cabinet Res 134/2025 Art.19)',
+      ];
+    case 'clean':
+    default:
+      return [
+        'Standard CDD cadence — annual review (Cabinet Res 134/2025 Art.19)',
+        'Add to continuous-monitor watchlist (daily re-screen)',
+      ];
+  }
+}


### PR DESCRIPTION
## Summary

First screening (`new_customer_onboarding` or `periodic_review`) now produces a full life-story deep-dive as the Asana task body and lands in the **The Screenings** section of the MLRO board (project `1214124911186857`).

- `src/services/lifeStoryReportBuilder.ts` — compact 8-section markdown (verdict, sanctions per-list with snapshot/UN-fallback status, PEP, 3-year adverse media, UBO flags, action checklist, audit trail).
- `src/services/asanaSectionByName.ts` — tolerant case-insensitive section resolver on any project. No GID copying required from the MLRO.
- `netlify/functions/screening-run.mts` — routes first-screen events to the life-story body + moves the task to the named section. Fails soft when the section doesn't exist (task stays in the project, `asana.sectionError` surfaces the cause on the verdict response).

**Non-first-screen events** (ad-hoc, transaction-triggered) keep the existing compact line-list body unchanged.

**PR #2** will wire `continuous-monitor.mts` to the daily delta report (Sample 2) and route it to **Transaction Monitor**.

## Env vars

| Name | Default | Purpose |
|---|---|---|
| `ASANA_SCREENINGS_PROJECT_GID` | `1214124911186857` | MLRO board project |
| `ASANA_SECTION_SCREENINGS_NAME` | `The Screenings` | section for first-screen tasks |

## Regulatory basis

FDL No.10/2025 Art.20-21 (coverage), Art.24 (10-yr retention), Art.29 (no tipping off) · Cabinet Res 134/2025 Art.14 (EDD), Art.19 (periodic review) · Cabinet Res 74/2020 Art.3-7 (sanctions) · FATF Rec 10 (3-year onboarding lookback) · LBMA RGG v9 · MoE Circular 08/AML/2021.

## Test plan

- [ ] Deploy preview: run `/screen ozcan halac` with `new_customer_onboarding` → expect a new task in **The Screenings** with the life-story markdown body.
- [ ] Rename the Asana section to `The Screenings (EDD)` → tolerant matcher still finds it, task routes correctly.
- [ ] Delete the section → task still posts to the project (default column), `asana.sectionError` surfaces "no section named…" on the verdict response.
- [ ] Run `/screen ozcan halac` with `transaction_trigger` event → compact line-list body (unchanged), no section move.

https://claude.ai/code/session_01NS4gn3GsVrWGVzadLKB6y3