### PR TITLE
Fix screening UX: pre-flight auth, focus-on-error, tolerant result render

### DIFF
--- a/screening-command.html
+++ b/screening-command.html
@@ -3399,6 +3399,6 @@
       src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"
       onerror="console.warn('jsPDF CDN failed — PDF export unavailable')"
     ></script>
-    <script src="screening-command.js?v=3"></script>
+    <script src="screening-command.js?v=4"></script>
   </body>
 </html>

--- a/screening-command.js
+++ b/screening-command.js
@@ -534,6 +534,38 @@
     el.appendChild(div);
   }
 
+  // Flash + scroll to a field the user needs to action. When screening
+  // validation fails because the Main MLRO name or password/token live
+  // high up on a long page, the error text next to the Run Screening
+  // button is easy to miss. This helper makes the missing field the
+  // obvious next step (FDL Art.20-21 — MLRO attestation must precede
+  // every screening; we must make that precondition easy to satisfy).
+  function focusRequiredField(el) {
+    if (!el || typeof el.focus !== 'function') return;
+    try {
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    } catch (_e) {
+      /* older browsers — ignore */
+    }
+    try {
+      el.focus({ preventScroll: true });
+    } catch (_e) {
+      try {
+        el.focus();
+      } catch (_e2) {
+        /* ignore */
+      }
+    }
+    const prevOutline = el.style.outline;
+    const prevShadow = el.style.boxShadow;
+    el.style.outline = '2px solid #ec4899';
+    el.style.boxShadow = '0 0 0 4px rgba(236, 72, 153, 0.25)';
+    setTimeout(() => {
+      el.style.outline = prevOutline;
+      el.style.boxShadow = prevShadow;
+    }, 1800);
+  }
+
   function escapeHTML(s) {
     return String(s ?? '')
       .replace(/&/g, '&amp;')
@@ -1345,7 +1377,21 @@
   }
 
   function renderScreeningResult(data) {
-    if (!data || !data.ok) {
+    // Accept any response shape that carries the screening payload. The
+    // server currently sets `ok: true` but it also returns a usable body
+    // (subject, sanctions, ranAt, …) — if the `ok` flag is ever dropped
+    // or renamed on the server, the MLRO still gets the evidence they
+    // need (FDL Art.20-21 — CO must see what was screened).
+    if (!data) {
+      screenResult.innerHTML = '';
+      return;
+    }
+    const hasScreeningPayload =
+      data.ok === true ||
+      (data.subject && typeof data.subject === 'object') ||
+      (data.sanctions && typeof data.sanctions === 'object') ||
+      typeof data.ranAt === 'string';
+    if (!hasScreeningPayload) {
       screenResult.innerHTML = '';
       return;
     }
@@ -1763,24 +1809,41 @@
     if (screenBtn.disabled) return;
 
     saveToken();
+
+    // Pre-flight: sign-in must have already happened. A missing/invalid
+    // token means the Authorization header will be rejected server-side
+    // (401), so fail fast with a helpful pointer at the password field
+    // instead of letting the MLRO fill out the whole form for nothing.
+    const preflightToken = tokenInput ? tokenInput.value.trim() : '';
+    const preflightTokenErr = tokenFormatError(preflightToken);
+    if (preflightTokenErr) {
+      showMessage(screenMsg, preflightTokenErr, 'error');
+      focusRequiredField(loginPasswordInput || tokenInput);
+      return;
+    }
+
     const name = subjectNameInput.value.trim();
     if (!name) {
       showMessage(screenMsg, 'Name screened is required.', 'error');
+      focusRequiredField(subjectNameInput);
       return;
     }
     const entityType = entityTypeSelect.value;
     if (entityType !== 'individual' && entityType !== 'legal_entity') {
       showMessage(screenMsg, 'Entity type is required.', 'error');
+      focusRequiredField(entityTypeSelect);
       return;
     }
     const eventType = eventTypeSelect.value;
     if (!eventType) {
       showMessage(screenMsg, 'Screening event type is required.', 'error');
+      focusRequiredField(eventTypeSelect);
       return;
     }
     const dobRaw = dobInput.value.trim();
     if (dobRaw && !/^\d{2}\/\d{2}\/\d{4}$/.test(dobRaw)) {
       showMessage(screenMsg, 'DoB / registration must be dd/mm/yyyy.', 'error');
+      focusRequiredField(dobInput);
       return;
     }
     const screener = activeMlroName();
@@ -1790,6 +1853,7 @@
         'Main MLRO name required — fill it in above before running a screening.',
         'error'
       );
+      focusRequiredField(mlroMainNameInput);
       return;
     }
 


### PR DESCRIPTION
## Summary

When a MLRO clicked **Run Screening** without first signing in or
setting the Main MLRO name, the error message appeared next to the
button at the bottom of a long page while the field requiring
action was at the top. The button looked broken because the
remediation path was off-screen.

- `runScreening()` now runs a token pre-flight **before** asking for
  subject fields. A missing / malformed bearer aborts early and
  points the MLRO at the password field (same `tokenFormatError`
  gate `apiPost` already runs, lifted to the top of the flow).
- New `focusRequiredField(el)` helper smooth-scrolls the offending
  input into view, focuses it, and flashes a pink outline for 1.8s.
  Every validation branch now calls it — subject name, entity
  type, event type, DoB / registration, Main MLRO name.
- `renderScreeningResult()` no longer hard-requires `data.ok === true`
  to paint. Any response with a recognisable screening payload
  (`subject`, `sanctions`, or `ranAt`) is rendered — defensive
  against a future server refactor that drops / renames the flag.
- Cache-buster on `screening-command.js` bumped `v=3` → `v=4`.

## Regulatory basis

- FDL No.10/2025 Art.20-21 (CO situational awareness — pre-condition
  fields must be easy to satisfy)
- FDL No.10/2025 Art.24 (10-yr retention — every screening must
  still produce a rendered audit record even if the response shape
  drifts)

## Test plan

- [x] `npx vitest run tests/screeningRunEndpoint.test.ts` — 28/28 pass
- [x] Playwright scenario: no token → error + focus lands on `#loginPassword`
- [x] Playwright scenario: token but no MLRO → error + focus lands on `#mlroMainName`
- [x] Playwright scenario: server returns screening payload **without** `ok` → `#screenResult` still renders (1708 chars)
- [x] `node -c screening-command.js` — syntax OK
- [ ] Deploy preview: click Run Screening in every pre-auth state and confirm focus flash is visible
- [ ] Deploy preview: full end-to-end screen on a real subject (clean, weak, potential)

https://claude.ai/code/session_01MkVSKyJZz5VBw285dXv5PV