### PR TITLE
Remove Compliance Tasks / Risk & CRA / Approvals / ESG tabs from landing nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -2410,12 +2410,12 @@
           <!-- Shipments moved to /logistics landing page -->
           <!-- Routines moved to /routines landing page -->
           <div class="tab active" data-action="switchTab" data-arg="iarreport">📝 IAR Report</div>
-          <div class="tab" data-action="switchTab" data-arg="asana">📋 Compliance Tasks</div>
+          <!-- Compliance Tasks tab removed per MLRO request -->
           <!-- Evidence Tracker removed -->
           <!-- Training moved to /compliance-ops landing page -->
           <!-- Employees moved to /compliance-ops landing page -->
           <!-- Onboarding moved to /workbench landing page -->
-          <div class="tab" data-action="switchTab" data-arg="riskassessment">⚖️ Risk & CRA</div>
+          <!-- Risk & CRA tab removed per MLRO request -->
           <!-- Incidents moved to /compliance-ops landing page -->
           <!-- Calendar tab removed per MLRO request -->
           <!-- Settings tab removed per MLRO request (previously removed on main) -->
@@ -2425,7 +2425,7 @@
           <!-- goAML Export removed -->
           <!-- Thresholds tab removed — DPMS AED 55K monitor surfaces automatically on relevant transaction pages -->
           <div class="tab" data-action="switchTab" data-arg="supplychain">⛏️ Supply</div>
-          <div class="tab" data-action="switchTab" data-arg="approvals">✅ Approvals</div>
+          <!-- Approvals tab removed per MLRO request -->
           <!-- Reg Changes tab removed — regulatory updates surface via Reg Monitor tab -->
 
           <!-- Workflows tab removed per MLRO request -->

--- a/index.html
+++ b/index.html
@@ -2434,7 +2434,7 @@
 
           <div class="tab" data-action="switchTab" data-arg="metalstrading">◈ Trading</div>
           <!-- Customer 360 tab removed per MLRO request -->
-          <div class="tab" data-action="switchTab" data-arg="esg">🌱 ESG</div>
+          <!-- ESG tab removed per MLRO request -->
           <!-- Data Upload removed -->
         </div>
 


### PR DESCRIPTION
## Summary

Per MLRO direction, four tabs are removed from the primary landing navigation. The **Integrations** tab is kept in place.

Removed:
- 📋 Compliance Tasks (`asana`)
- ⚖️ Risk & CRA (`riskassessment`)
- ✅ Approvals (`approvals`)
- 🌱 ESG (`esg`)

Kept:
- 📝 IAR Report, 🔗 Integrations, ⛏️ Supply, ◈ Trading

## Approach

Follows the pattern established in #322: only the nav buttons are deleted. The underlying `#tab-asana`, `#tab-riskassessment`, `#tab-approvals`, and `#tab-esg` content panels stay in the DOM so `switchTab()` and any deep-links continue to resolve against inert panels — no refactor risk to `app-core.js` / `compliance-suite.js` handlers.

Workflows that previously lived on these tabs remain reachable:
- Compliance Tasks → live Asana status on `/workbench`
- Risk & CRA → invoked via `/screen` and `/onboard` skills
- Approvals → maker-checker queue on `/workbench` (per #322)
- ESG → `esgRefresh()` / `esgExportCsv()` still callable programmatically; the scorecard panel is just unlinked from the nav

## Regulatory impact

None. These were UI entry points. No compliance logic, no constants, no filing/deadline paths touched. Supply-chain + metals-trading remain navigable for LBMA RGG v9 and UAE MoE DPMS workflows.

## Test plan

- [ ] Visit `hawkeye-sterling-v2.netlify.app` after deploy — confirm the four tabs no longer appear in the primary nav
- [ ] Confirm remaining tabs (IAR Report, Integrations, Supply, Trading) still switch correctly
- [ ] Confirm `/workbench` still surfaces approvals + Asana task status
- [ ] Grep confirms no other file referenced the removed nav buttons (the `switchTab` dispatch itself is argument-driven and unaffected)

https://claude.ai/code/session_01MButPf9MVyvNmqBEn1rioL