### PR TITLE
Keep module + chip clicks inside the current landing page via URL sync

### DIFF
--- a/compliance-ops.html
+++ b/compliance-ops.html
@@ -561,7 +561,7 @@
       </div>
 
       <div class="grid">
-        <a class="card" href="#training" data-route="training">
+        <a class="card" href="/compliance-ops/training" data-route="training" data-slug="training">
           <div class="card-icon" aria-hidden="true">🎓</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -588,7 +588,7 @@
           </div>
         </a>
 
-        <a class="card" href="#employees" data-route="employees">
+        <a class="card" href="/compliance-ops/employees" data-route="employees" data-slug="employees">
           <div class="card-icon" aria-hidden="true">👥</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -616,7 +616,7 @@
           </div>
         </a>
 
-        <a class="card" href="#incidents" data-route="incidents">
+        <a class="card" href="/compliance-ops/incidents" data-route="incidents" data-slug="incidents">
           <div class="card-icon" aria-hidden="true">🚨</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -644,7 +644,7 @@
           </div>
         </a>
 
-        <a class="card" href="#reports" data-route="reports">
+        <a class="card" href="/compliance-ops/reports" data-route="reports" data-slug="reports">
           <div class="card-icon" aria-hidden="true">📊</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -710,6 +710,6 @@
       <span>© 2026 Hawkeye Sterling</span>
       <span>Confidential &middot; Audit-ready</span>
     </footer>
-    <script src="landing-module-viewer.js?v=3"></script>
+    <script src="landing-module-viewer.js?v=4"></script>
   </body>
 </html>

--- a/landing-module-viewer.js
+++ b/landing-module-viewer.js
@@ -5,45 +5,153 @@
   var closeBtn = document.getElementById('moduleViewClose');
   if (!view || !frame || !titleEl || !closeBtn) return;
 
-  function openModule(route, label) {
+  // Landing slugs that resolve to a root-level .html via netlify.toml
+  // redirects. Any first URL segment outside this list is treated as a
+  // raw .html file (defensive: local file:// / preview deploys).
+  var LANDING_SLUGS = ['logistics', 'workbench', 'compliance-ops', 'routines'];
+
+  // Base path for the current landing page — never includes a module
+  // sub-slug. "/logistics", "/workbench", etc. Falls back to the raw
+  // first path segment when the current URL is something we do not
+  // recognise (still non-destructive — we just push "/<first>/<slug>").
+  function getBasePath() {
+    var segs = (location.pathname || '/').split('/').filter(Boolean);
+    if (!segs.length) return '/';
+    var first = segs[0].replace(/\.html$/, '');
+    if (LANDING_SLUGS.indexOf(first) !== -1) return '/' + first;
+    return '/' + segs[0];
+  }
+
+  function findCardBySlug(slug) {
+    if (!slug) return null;
+    var cards = document.querySelectorAll('.card[data-route]');
+    for (var i = 0; i < cards.length; i++) {
+      var c = cards[i];
+      var s = c.getAttribute('data-slug') || c.getAttribute('data-route');
+      if (s === slug) return c;
+    }
+    return null;
+  }
+
+  function slugForCard(card) {
+    return card.getAttribute('data-slug') || card.getAttribute('data-route');
+  }
+
+  function openModule(route, label, slug, pushHistory) {
     // ?embedded=1 is a belt-and-braces signal for the chrome-strip CSS in
-    // index.html. The primary detector is `window.self !== window.top`, but
-    // same-origin iframe detection has failed in the wild (cached HTML,
-    // SW shims, cross-frame Permission-Policy). The query param is a
-    // deterministic second channel the head-script also checks.
+    // index.html. Primary detector is `window.self !== window.top`, but
+    // the query param is a deterministic second channel the head-script
+    // also checks.
     frame.src = 'index.html?embedded=1#' + route;
     titleEl.textContent = label || 'Module';
     view.classList.add('is-open');
     view.setAttribute('aria-hidden', 'false');
+    if (pushHistory !== false && slug) {
+      var target = getBasePath() + '/' + slug;
+      if (location.pathname !== target) {
+        history.pushState({ slug: slug, route: route, label: label }, '', target);
+      }
+    }
     requestAnimationFrame(function () {
       view.scrollIntoView({ behavior: 'smooth', block: 'start' });
     });
   }
 
-  function closeModule() {
+  function closeModule(pushHistory) {
     view.classList.remove('is-open');
     view.setAttribute('aria-hidden', 'true');
     frame.src = 'about:blank';
+    if (pushHistory !== false) {
+      var base = getBasePath();
+      if (location.pathname !== base) {
+        history.pushState({}, '', base);
+      }
+    }
   }
 
+  function openSlug(slug, pushHistory) {
+    var card = findCardBySlug(slug);
+    if (!card) return false;
+    var route = card.getAttribute('data-route');
+    var labelEl = card.querySelector('.card-title');
+    var label = labelEl ? labelEl.textContent : 'Module';
+    openModule(route, label, slug, pushHistory);
+    return true;
+  }
+
+  // Card click → open module in-page and push the deep-link URL.
   document.addEventListener(
     'click',
     function (event) {
       var card = event.target.closest && event.target.closest('.card[data-route]');
       if (!card) return;
+      // Honour modifier clicks (cmd/ctrl/middle) for open-in-new-tab.
+      if (event.metaKey || event.ctrlKey || event.shiftKey || event.button === 1) return;
       event.preventDefault();
       event.stopPropagation();
-      var route = card.getAttribute('data-route');
-      var label = card.querySelector('.card-title');
-      openModule(route, label ? label.textContent : 'Module');
+      openSlug(slugForCard(card), true);
     },
     true
   );
 
-  closeBtn.addEventListener('click', closeModule);
+  closeBtn.addEventListener('click', function () { closeModule(true); });
   document.addEventListener('keydown', function (event) {
     if (event.key === 'Escape' && view.classList.contains('is-open')) {
-      closeModule();
+      closeModule(true);
+    }
+  });
+
+  // Browser back/forward: react to URL changes without pushing new state.
+  window.addEventListener('popstate', function () {
+    var segs = (location.pathname || '/').split('/').filter(Boolean);
+    var first = segs.length ? segs[0].replace(/\.html$/, '') : '';
+    var tail = segs.length >= 2 && LANDING_SLUGS.indexOf(first) !== -1 ? segs[1] : '';
+    if (tail) {
+      if (!openSlug(tail, false)) closeModule(false);
+    } else {
+      closeModule(false);
+    }
+  });
+
+  // Deep-link entry: /logistics/inbound-advice auto-opens that module on
+  // page load. The Netlify splat redirect serves logistics.html for any
+  // /logistics/* path while preserving the clean URL in the address bar.
+  (function initialDeepLink() {
+    var segs = (location.pathname || '/').split('/').filter(Boolean);
+    if (segs.length < 2) return;
+    var first = segs[0].replace(/\.html$/, '');
+    if (LANDING_SLUGS.indexOf(first) === -1) return;
+    openSlug(segs[1], false);
+  })();
+
+  // When the embedded app navigates internally (user clicks a nav-bar
+  // item inside index.html), mirror the new route into the parent URL
+  // so the address bar reflects the active module. replaceState (not
+  // pushState) keeps the history stack flat — internal nav in the
+  // iframe should not pollute browser back.
+  frame.addEventListener('load', function () {
+    var inner;
+    try { inner = frame.contentWindow; } catch (_) { return; }
+    if (!inner) return;
+    try {
+      inner.addEventListener('hashchange', function () {
+        if (!view.classList.contains('is-open')) return;
+        var raw;
+        try { raw = inner.location.hash || ''; } catch (_) { return; }
+        var route = raw.replace(/^#\/?/, '').split('?')[0];
+        if (!route) return;
+        // Prefer an existing card's slug (nicer URL) when one matches
+        // the hash; otherwise kebab-case the raw hash as a fallback.
+        var card = findCardBySlug(route);
+        var slug = card ? slugForCard(card) : route.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+        if (!slug) return;
+        var target = getBasePath() + '/' + slug;
+        if (location.pathname !== target) {
+          history.replaceState({ slug: slug, route: route }, '', target);
+        }
+      });
+    } catch (_) {
+      // Cross-origin iframe — can't observe. Fine; card clicks still push URL.
     }
   });
 })();

--- a/logistics.html
+++ b/logistics.html
@@ -802,7 +802,7 @@
       </div>
 
       <div class="grid">
-        <a class="card" href="#shipments" data-route="shipments">
+        <a class="card" href="/logistics/inbound-advice" data-route="shipments" data-slug="inbound-advice">
           <div class="card-icon" aria-hidden="true">🚚</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -830,7 +830,7 @@
           </div>
         </a>
 
-        <a class="card" href="#tracking" data-route="tracking">
+        <a class="card" href="/logistics/tracking" data-route="tracking" data-slug="tracking">
           <div class="card-icon" aria-hidden="true">✈️</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -857,7 +857,7 @@
           </div>
         </a>
 
-        <a class="card" href="#localshipments" data-route="localshipments">
+        <a class="card" href="/logistics/local-shipments" data-route="localshipments" data-slug="local-shipments">
           <div class="card-icon" aria-hidden="true">📦</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -956,6 +956,6 @@
         });
       })();
     </script>
-    <script src="landing-module-viewer.js?v=3"></script>
+    <script src="landing-module-viewer.js?v=4"></script>
   </body>
 </html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -68,6 +68,33 @@
   to = "/screening-command.html"
   status = 200
 
+# Sub-path deep links. Every module inside a landing page is a
+# client-side view (history.pushState in landing-module-viewer.js, or
+# the inline filter handler in routines.html); Netlify serves the
+# landing .html for any /<page>/<slug> path so a refresh, share, or
+# direct open resolves correctly. The splat is discarded server-side —
+# the client JS reads location.pathname on load and auto-opens the
+# matching module or selects the matching filter chip.
+[[redirects]]
+  from = "/workbench/*"
+  to = "/workbench.html"
+  status = 200
+
+[[redirects]]
+  from = "/logistics/*"
+  to = "/logistics.html"
+  status = 200
+
+[[redirects]]
+  from = "/routines/*"
+  to = "/routines.html"
+  status = 200
+
+[[redirects]]
+  from = "/compliance-ops/*"
+  to = "/compliance-ops.html"
+  status = 200
+
 [[headers]]
   for = "/*"
   [headers.values]

--- a/routines.html
+++ b/routines.html
@@ -747,17 +747,44 @@
         document.getElementById('weeklyCount').textContent = counts.weekly || 0;
       })();
 
-      // Filter chip handlers
+      // URL ↔ filter sync. A deep link like /routines/continuous selects
+      // the "continuous" chip on load; clicking a chip pushes the matching
+      // URL so the address bar reflects the active cadence.
+      const FILTER_SLUGS = ['all', 'continuous', 'daily', 'weekly'];
+
+      function filterFromLocation() {
+        const segs = (location.pathname || '/').split('/').filter(Boolean);
+        const first = segs.length ? segs[0].replace(/\.html$/, '') : '';
+        if (first !== 'routines' || segs.length < 2) return 'all';
+        return FILTER_SLUGS.indexOf(segs[1]) !== -1 ? segs[1] : 'all';
+      }
+
+      function applyFilter(filter, pushHistory) {
+        ACTIVE_FILTER = FILTER_SLUGS.indexOf(filter) !== -1 ? filter : 'all';
+        document.querySelectorAll('.chip').forEach(c => {
+          c.setAttribute('aria-pressed', c.getAttribute('data-filter') === ACTIVE_FILTER ? 'true' : 'false');
+        });
+        render(ACTIVE_FILTER);
+        if (pushHistory !== false) {
+          const base = '/routines';
+          const target = ACTIVE_FILTER === 'all' ? base : base + '/' + ACTIVE_FILTER;
+          if (location.pathname !== target) {
+            history.pushState({ filter: ACTIVE_FILTER }, '', target);
+          }
+        }
+      }
+
       document.querySelectorAll('.chip').forEach(chip => {
         chip.addEventListener('click', () => {
-          document.querySelectorAll('.chip').forEach(c => c.setAttribute('aria-pressed', 'false'));
-          chip.setAttribute('aria-pressed', 'true');
-          ACTIVE_FILTER = chip.getAttribute('data-filter');
-          render(ACTIVE_FILTER);
+          applyFilter(chip.getAttribute('data-filter'), true);
         });
       });
 
-      render(ACTIVE_FILTER);
+      window.addEventListener('popstate', () => {
+        applyFilter(filterFromLocation(), false);
+      });
+
+      applyFilter(filterFromLocation(), false);
 
       // ── Drawer (routine detail) ────────────────────────────────────
       const drawer = document.getElementById('routineDrawer');

--- a/workbench.html
+++ b/workbench.html
@@ -479,7 +479,7 @@
       </div>
 
       <div class="cards">
-        <a class="card" data-tone="orange" href="#asana" data-route="asana">
+        <a class="card" data-tone="orange" href="/workbench/compliance-tasks" data-route="asana" data-slug="compliance-tasks">
           <div class="card-icon" aria-hidden="true">📋</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -507,7 +507,7 @@
           </div>
         </a>
 
-        <a class="card" data-tone="yellow" href="#onboarding" data-route="onboarding">
+        <a class="card" data-tone="yellow" href="/workbench/onboarding" data-route="onboarding" data-slug="onboarding">
           <div class="card-icon" aria-hidden="true">👤</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -535,7 +535,7 @@
           </div>
         </a>
 
-        <a class="card" data-tone="green" href="#approvals" data-route="approvals">
+        <a class="card" data-tone="green" href="/workbench/approvals" data-route="approvals" data-slug="approvals">
           <div class="card-icon" aria-hidden="true">✅</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -605,6 +605,6 @@
       <span class="footer-text">© 2026 Hawkeye Sterling</span>
       <span class="footer-text">Confidential · Audit-ready</span>
     </footer>
-    <script src="landing-module-viewer.js?v=3"></script>
+    <script src="landing-module-viewer.js?v=4"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Module cards on the logistics, workbench, and compliance-ops landing pages opened an embedded iframe but never updated the address bar — users saw `/logistics` while clearly "inside" a module, and a refresh or share dumped them back on the surfaces list. Same problem for the routines cadence chips (ALL / CONTINUOUS / DAILY / WEEKLY).

This PR makes every module / filter click push a clean sub-URL (`/logistics/inbound-advice`, `/workbench/approvals`, `/compliance-ops/training`, `/routines/continuous`, …) while keeping the user on the same landing page.

## What changed

- **`landing-module-viewer.js`** — pushes `/<page>/<slug>` when a card opens, pops back to `/<page>` on close, restores state on browser back/forward, and auto-opens the matching module when a user arrives via a deep link. A post-load `hashchange` listener on the iframe mirrors internal `index.html` navigation into the parent URL via `replaceState` so the history stack stays flat.
- **`routines.html`** — filter chips push `/routines/<cadence>` on click and read the filter from `location.pathname` on load + `popstate`.
- **`netlify.toml`** — splat redirects (`/workbench/*`, `/logistics/*`, `/routines/*`, `/compliance-ops/*`) so direct hits and refreshes of any sub-URL serve the landing `.html`; the client JS resolves the sub-slug to a module or filter.
- **`workbench.html`, `logistics.html`, `compliance-ops.html`** — each card gets a `data-slug` attribute to bridge the iframe route (`shipments`, `asana`, `localshipments`) to the user-facing URL slug (`inbound-advice`, `compliance-tasks`, `local-shipments`) without breaking the existing iframe `#`-route wiring. Cache-bust on the viewer script bumped to `v=4`.

## Behaviour after fix

| Click | URL |
|---|---|
| Inbound Advice on `/logistics` | `/logistics/inbound-advice` |
| Tracking on `/logistics` | `/logistics/tracking` |
| Local Shipments on `/logistics` | `/logistics/local-shipments` |
| Back to Surfaces | `/logistics` |
| Compliance Tasks on `/workbench` | `/workbench/compliance-tasks` |
| Onboarding on `/workbench` | `/workbench/onboarding` |
| Approvals on `/workbench` | `/workbench/approvals` |
| Training on `/compliance-ops` | `/compliance-ops/training` |
| Incidents on `/compliance-ops` | `/compliance-ops/incidents` |
| CONTINUOUS chip on `/routines` | `/routines/continuous` |
| DAILY chip on `/routines` | `/routines/daily` |

Direct navigation / refresh / share of any of those URLs now works the same as a click.

## Compliance

No compliance-decision code changed. URL sync is a client-side presentation concern; the 10-year audit-trail (FDL No.10/2025 Art.24) is unaffected. Iframe `#`-route contract with `index.html` is preserved — existing deep-link consumers keep working.

## Test plan

- [ ] `/logistics` → click each of the three cards, confirm URL updates in the address bar and the card's module opens inline (no navigation away).
- [ ] Click "← BACK TO SURFACES" → URL returns to `/logistics`, card grid visible again.
- [ ] Browser back / forward buttons cycle between surfaces and the opened module without a full page reload.
- [ ] Visit `/logistics/inbound-advice` directly → Netlify serves the logistics landing; module auto-opens on load.
- [ ] Repeat on `/workbench` and `/compliance-ops`.
- [ ] On `/routines`, click each cadence chip → URL updates to `/routines/continuous`, `/routines/daily`, `/routines/weekly`; reloading each deep link selects the matching chip.
- [ ] Cmd/Ctrl-click a card → opens in a new tab at the deep-link URL (preserved modifier-click behaviour).

https://claude.ai/code/session_01XBT2BnGRgAMTPJoQ1tND8S