### PR TITLE
Fix compliance-ops module cards to stay within /compliance-ops

### DIFF
--- a/compliance-ops.html
+++ b/compliance-ops.html
@@ -561,7 +561,7 @@
       </div>
 
       <div class="grid">
-        <a class="card" href="#training" data-route="training">
+        <a class="card" href="/compliance-ops/training" data-route="training">
           <div class="card-icon" aria-hidden="true">🎓</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -588,7 +588,7 @@
           </div>
         </a>
 
-        <a class="card" href="#employees" data-route="employees">
+        <a class="card" href="/compliance-ops/employees" data-route="employees">
           <div class="card-icon" aria-hidden="true">👥</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -616,7 +616,7 @@
           </div>
         </a>
 
-        <a class="card" href="#incidents" data-route="incidents">
+        <a class="card" href="/compliance-ops/incidents" data-route="incidents">
           <div class="card-icon" aria-hidden="true">🚨</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -644,7 +644,7 @@
           </div>
         </a>
 
-        <a class="card" href="#reports" data-route="reports">
+        <a class="card" href="/compliance-ops/reports" data-route="reports">
           <div class="card-icon" aria-hidden="true">📊</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -710,6 +710,6 @@
       <span>© 2026 Hawkeye Sterling</span>
       <span>Confidential &middot; Audit-ready</span>
     </footer>
-    <script src="landing-module-viewer.js?v=3"></script>
+    <script src="landing-module-viewer.js?v=4"></script>
   </body>
 </html>

--- a/landing-module-viewer.js
+++ b/landing-module-viewer.js
@@ -5,25 +5,85 @@
   var closeBtn = document.getElementById('moduleViewClose');
   if (!view || !frame || !titleEl || !closeBtn) return;
 
-  function openModule(route, label) {
+  // Discover the set of valid routes + human labels from the cards in the
+  // page. Each landing page (compliance-ops, workbench, logistics) declares
+  // its own set of .card[data-route] elements; this viewer is generic.
+  var routes = {};
+  var cards = document.querySelectorAll('.card[data-route]');
+  for (var i = 0; i < cards.length; i++) {
+    var route = cards[i].getAttribute('data-route');
+    var labelEl = cards[i].querySelector('.card-title');
+    routes[route] = labelEl ? labelEl.textContent : 'Module';
+  }
+
+  function stripTrailingRoute(path) {
+    for (var route in routes) {
+      var suffix = '/' + route;
+      if (path === suffix || path.endsWith(suffix)) {
+        return path.slice(0, path.length - suffix.length);
+      }
+    }
+    return path;
+  }
+
+  function normalisePath(path) {
+    // Strip trailing slash, then strip .html, then strip a trailing route.
+    var p = (path || '/').replace(/\/+$/, '');
+    p = p.replace(/\.html$/, '');
+    return p;
+  }
+
+  // The base path is the landing page's own URL without any /<route>
+  // segment — e.g. "/compliance-ops" for this page, "/workbench" for the
+  // workbench landing. Derived from the current URL at boot so the
+  // viewer stays generic across landing pages.
+  var basePath = stripTrailingRoute(normalisePath(window.location.pathname));
+  if (!basePath) basePath = '/';
+
+  function routeFromPath(path) {
+    var normalised = normalisePath(path);
+    for (var route in routes) {
+      if (normalised.endsWith('/' + route)) return route;
+    }
+    return null;
+  }
+
+  function urlForRoute(route) {
+    if (!route) return basePath || '/';
+    var bp = basePath === '/' ? '' : basePath;
+    return bp + '/' + route;
+  }
+
+  function openModule(route, label, historyMode) {
+    if (!route || !(route in routes)) return;
     // ?embedded=1 is a belt-and-braces signal for the chrome-strip CSS in
-    // index.html. The primary detector is `window.self !== window.top`, but
-    // same-origin iframe detection has failed in the wild (cached HTML,
-    // SW shims, cross-frame Permission-Policy). The query param is a
-    // deterministic second channel the head-script also checks.
+    // index.html. The primary detector is `window.self !== window.top`,
+    // but same-origin iframe detection has failed in the wild (cached
+    // HTML, SW shims, cross-frame Permission-Policy). The query param is
+    // a deterministic second channel the head-script also checks.
     frame.src = 'index.html?embedded=1#' + route;
-    titleEl.textContent = label || 'Module';
+    titleEl.textContent = label || routes[route] || 'Module';
     view.classList.add('is-open');
     view.setAttribute('aria-hidden', 'false');
+    if (historyMode === 'push') {
+      history.pushState({ route: route }, '', urlForRoute(route));
+    } else if (historyMode === 'replace') {
+      history.replaceState({ route: route }, '', urlForRoute(route));
+    }
     requestAnimationFrame(function () {
       view.scrollIntoView({ behavior: 'smooth', block: 'start' });
     });
   }
 
-  function closeModule() {
+  function closeModule(historyMode) {
     view.classList.remove('is-open');
     view.setAttribute('aria-hidden', 'true');
     frame.src = 'about:blank';
+    if (historyMode === 'push') {
+      history.pushState({ route: null }, '', urlForRoute(null));
+    } else if (historyMode === 'replace') {
+      history.replaceState({ route: null }, '', urlForRoute(null));
+    }
   }
 
   document.addEventListener(
@@ -31,19 +91,41 @@
     function (event) {
       var card = event.target.closest && event.target.closest('.card[data-route]');
       if (!card) return;
+      // Allow modifier clicks (cmd/ctrl/shift/middle) to open in a new
+      // tab using the card's actual href — don't hijack those.
+      if (event.metaKey || event.ctrlKey || event.shiftKey || event.button === 1) return;
       event.preventDefault();
       event.stopPropagation();
       var route = card.getAttribute('data-route');
       var label = card.querySelector('.card-title');
-      openModule(route, label ? label.textContent : 'Module');
+      openModule(route, label ? label.textContent : 'Module', 'push');
     },
     true
   );
 
-  closeBtn.addEventListener('click', closeModule);
+  closeBtn.addEventListener('click', function () { closeModule('push'); });
   document.addEventListener('keydown', function (event) {
     if (event.key === 'Escape' && view.classList.contains('is-open')) {
-      closeModule();
+      closeModule('push');
     }
   });
+
+  window.addEventListener('popstate', function (event) {
+    var state = event.state && typeof event.state === 'object' ? event.state : null;
+    var route = state && state.route ? state.route : routeFromPath(window.location.pathname);
+    if (route && routes[route]) {
+      openModule(route, routes[route], null);
+    } else {
+      closeModule(null);
+    }
+  });
+
+  // Initialise from the URL on first load so deep-links like
+  // /compliance-ops/training boot directly into the training module.
+  var initialRoute = routeFromPath(window.location.pathname);
+  if (initialRoute) {
+    openModule(initialRoute, routes[initialRoute], 'replace');
+  } else {
+    history.replaceState({ route: null }, '', urlForRoute(null));
+  }
 })();

--- a/logistics.html
+++ b/logistics.html
@@ -802,7 +802,7 @@
       </div>
 
       <div class="grid">
-        <a class="card" href="#shipments" data-route="shipments">
+        <a class="card" href="/logistics/shipments" data-route="shipments">
           <div class="card-icon" aria-hidden="true">🚚</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -830,7 +830,7 @@
           </div>
         </a>
 
-        <a class="card" href="#tracking" data-route="tracking">
+        <a class="card" href="/logistics/tracking" data-route="tracking">
           <div class="card-icon" aria-hidden="true">✈️</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -857,7 +857,7 @@
           </div>
         </a>
 
-        <a class="card" href="#localshipments" data-route="localshipments">
+        <a class="card" href="/logistics/localshipments" data-route="localshipments">
           <div class="card-icon" aria-hidden="true">📦</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -956,6 +956,6 @@
         });
       })();
     </script>
-    <script src="landing-module-viewer.js?v=3"></script>
+    <script src="landing-module-viewer.js?v=4"></script>
   </body>
 </html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -48,8 +48,21 @@
   to = "/workbench.html"
   status = 200
 
+# Sub-routes like /workbench/asana, /workbench/onboarding, /workbench/approvals
+# serve the same workbench landing; landing-module-viewer.js reads the path
+# and opens the matching module in-page so the user stays on the landing.
+[[redirects]]
+  from = "/workbench/*"
+  to = "/workbench.html"
+  status = 200
+
 [[redirects]]
   from = "/logistics"
+  to = "/logistics.html"
+  status = 200
+
+[[redirects]]
+  from = "/logistics/*"
   to = "/logistics.html"
   status = 200
 
@@ -60,6 +73,15 @@
 
 [[redirects]]
   from = "/compliance-ops"
+  to = "/compliance-ops.html"
+  status = 200
+
+# Sub-routes like /compliance-ops/training, /compliance-ops/employees,
+# /compliance-ops/incidents, /compliance-ops/reports serve the same
+# compliance-ops landing; landing-module-viewer.js reads the path and
+# opens the matching module in-page.
+[[redirects]]
+  from = "/compliance-ops/*"
   to = "/compliance-ops.html"
   status = 200
 

--- a/workbench.html
+++ b/workbench.html
@@ -479,7 +479,7 @@
       </div>
 
       <div class="cards">
-        <a class="card" data-tone="orange" href="#asana" data-route="asana">
+        <a class="card" data-tone="orange" href="/workbench/asana" data-route="asana">
           <div class="card-icon" aria-hidden="true">📋</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -507,7 +507,7 @@
           </div>
         </a>
 
-        <a class="card" data-tone="yellow" href="#onboarding" data-route="onboarding">
+        <a class="card" data-tone="yellow" href="/workbench/onboarding" data-route="onboarding">
           <div class="card-icon" aria-hidden="true">👤</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -535,7 +535,7 @@
           </div>
         </a>
 
-        <a class="card" data-tone="green" href="#approvals" data-route="approvals">
+        <a class="card" data-tone="green" href="/workbench/approvals" data-route="approvals">
           <div class="card-icon" aria-hidden="true">✅</div>
           <div class="card-meta">
             <span class="dot"></span>
@@ -605,6 +605,6 @@
       <span class="footer-text">© 2026 Hawkeye Sterling</span>
       <span class="footer-text">Confidential · Audit-ready</span>
     </footer>
-    <script src="landing-module-viewer.js?v=3"></script>
+    <script src="landing-module-viewer.js?v=4"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

- Module cards on `/compliance-ops` (and `/workbench`, `/logistics`) now deep-link to sub-routes like `/compliance-ops/training`, `/compliance-ops/employees`, `/compliance-ops/incidents`, `/compliance-ops/reports` instead of navigating to the main app.
- URL is updated via `history.pushState`; the "Back to surfaces" button and the browser back button return to the `/compliance-ops` landing. Direct loads of a sub-route auto-open the matching module.
- Netlify wildcard rewrites (`/compliance-ops/*`, `/workbench/*`, `/logistics/*`) serve the corresponding landing HTML, and `landing-module-viewer.js` reads the path to open the right module.

## Files changed

- `landing-module-viewer.js` — derive base path from URL, push/replace history state on open/close, handle `popstate`, initialise from URL, pass modifier clicks through to the real `href`.
- `netlify.toml` — add `/compliance-ops/*`, `/workbench/*`, `/logistics/*` 200 rewrites.
- `compliance-ops.html` / `workbench.html` / `logistics.html` — card `href` values now point at real sub-route paths; viewer script bumped to `v=4`.

## Not touched (regulatory carve-outs)

- Training attendance logging — MoE Circular 08/AML/2021 §9
- Employees RBAC + four-eyes pool — Cabinet Res 134/2025 Art.19
- Incident 24h EOCN / 5 bd CNMR countdowns — Cabinet Res 74/2020 Art.4-7
- goAML STR/SAR/CTR/DPMSR/CNMR XML export — FDL No.(10)/2025 Art.26-27
- `index.html` iframe-embed chrome-strip behaviour (`?embedded=1`)
- Hawkeye Sterling branding / pink-magenta theme

## Test plan

- [ ] Visit `/compliance-ops` — four module cards render as before.
- [ ] Click "Open module" on Training — address bar shows `/compliance-ops/training`; Training opens in-page via iframe.
- [ ] Click "Open module" on Employees / Incidents / Reports — address bar shows the matching sub-route; module opens in-page.
- [ ] Click "← Back to surfaces" — address bar returns to `/compliance-ops`; four cards render.
- [ ] Browser back button from `/compliance-ops/incidents` → `/compliance-ops` (and closes the iframe view).
- [ ] Deep-load `/compliance-ops/training` directly — Training module auto-opens.
- [ ] Cmd/Ctrl-click a card → opens `/compliance-ops/<route>` in a new tab (still deep-loads correctly).
- [ ] Repeat on `/workbench` (asana / onboarding / approvals) and `/logistics` (shipments / tracking / localshipments).

https://claude.ai/code/session_01M4NSTHzw7iRqJbJz3hRLAV