### PR TITLE
Make landing-page nav dynamic per page (FDL No.10/2025 Art.24)

### DIFF
--- a/app-boot.js
+++ b/app-boot.js
@@ -156,6 +156,32 @@
     '#tab-onboarding': 'onboarding',
     '#approvals': 'approvals',
     '#tab-approvals': 'approvals',
+    // Added for page-specific landing navigation (workbench / logistics /
+    // compliance-ops page-nav pills). Each hash maps to an existing
+    // `tab-<id>` block in index.html so switchTab() will activate it when
+    // the iframe loads with the corresponding deep-link hash.
+    '#iarreport': 'iarreport',
+    '#tab-iarreport': 'iarreport',
+    '#riskassessment': 'riskassessment',
+    '#tab-riskassessment': 'riskassessment',
+    '#calendar': 'calendar',
+    '#tab-calendar': 'calendar',
+    '#monitor': 'monitor',
+    '#tab-monitor': 'monitor',
+    '#integrations': 'integrations',
+    '#tab-integrations': 'integrations',
+    '#supplychain': 'supplychain',
+    '#tab-supplychain': 'supplychain',
+    '#workflows': 'workflows',
+    '#tab-workflows': 'workflows',
+    '#pipeline': 'pipeline',
+    '#tab-pipeline': 'pipeline',
+    '#customer360': 'customer360',
+    '#tab-customer360': 'customer360',
+    '#esg': 'esg',
+    '#tab-esg': 'esg',
+    '#redflags': 'redflags',
+    '#tab-redflags': 'redflags',
   };
   function applyHashRoute() {
     var hash = window.location.hash;

--- a/compliance-ops.html
+++ b/compliance-ops.html
@@ -142,6 +142,41 @@
         box-shadow: 0 0 0 4px rgba(236, 72, 153, 0.12);
       }
 
+      /* Page-specific navigation — rendered dynamically by page-nav.js */
+      .page-nav {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin: 0 0 1.75rem;
+        padding: 0;
+      }
+      .page-nav[hidden] { display: none; }
+      .page-nav-link {
+        font-family: 'DM Mono', monospace;
+        font-size: 10px;
+        letter-spacing: 2px;
+        text-transform: uppercase;
+        padding: 8px 14px;
+        border-radius: 999px;
+        border: 1px solid var(--border);
+        background: rgba(58, 13, 34, 0.45);
+        color: var(--ice);
+        text-decoration: none;
+        backdrop-filter: blur(10px);
+        transition: all 0.2s ease;
+      }
+      .page-nav-link:hover {
+        color: var(--mist);
+        border-color: var(--pink-bright);
+        background: rgba(236, 72, 153, 0.12);
+      }
+      .page-nav-link.is-active {
+        color: var(--pink-bright);
+        border-color: var(--border-strong);
+        background: rgba(236, 72, 153, 0.18);
+        box-shadow: 0 0 0 3px rgba(236, 72, 153, 0.12);
+      }
+
       /* Hero — 2-column grid: copy left, 2×2 status-tile aside right */
       .hero {
         display: grid;
@@ -522,6 +557,8 @@
         <a href="index.html" class="back-link">&larr; Main app</a>
       </header>
 
+      <nav id="pageNav" class="page-nav" aria-label="Compliance operations sections"></nav>
+
       <section class="hero">
         <div>
           <div class="hero-eyebrow">Compliance Operations</div>
@@ -710,6 +747,7 @@
       <span>© 2026 Hawkeye Sterling</span>
       <span>Confidential &middot; Audit-ready</span>
     </footer>
-    <script src="landing-module-viewer.js?v=4"></script>
+    <script src="page-nav.js?v=1"></script>
+    <script src="landing-module-viewer.js?v=5"></script>
   </body>
 </html>

--- a/landing-module-viewer.js
+++ b/landing-module-viewer.js
@@ -22,11 +22,18 @@
     return '/' + segs[0];
   }
 
+  // `.card[data-route]` targets the landing page's primary cards; the
+  // broader `[data-route][data-slug]` selector also picks up the items
+  // rendered by page-nav.js into #pageNav. Both resolve to the same
+  // open-module-in-iframe behaviour so the address bar stays on the
+  // landing page while the user navigates between modules.
+  var MODULE_TARGET_SELECTOR = '.card[data-route], [data-route][data-slug]';
+
   function findCardBySlug(slug) {
     if (!slug) return null;
-    var cards = document.querySelectorAll('.card[data-route]');
-    for (var i = 0; i < cards.length; i++) {
-      var c = cards[i];
+    var targets = document.querySelectorAll(MODULE_TARGET_SELECTOR);
+    for (var i = 0; i < targets.length; i++) {
+      var c = targets[i];
       var s = c.getAttribute('data-slug') || c.getAttribute('data-route');
       if (s === slug) return c;
     }
@@ -35,6 +42,13 @@
 
   function slugForCard(card) {
     return card.getAttribute('data-slug') || card.getAttribute('data-route');
+  }
+
+  // Re-render the page-nav pill highlight after every URL change that
+  // pushState/replaceState would otherwise swallow (popstate only fires
+  // for back/forward, not for programmatic pushes).
+  function refreshPageNav() {
+    if (typeof window.__renderPageNav === 'function') window.__renderPageNav();
   }
 
   function openModule(route, label, slug, pushHistory) {
@@ -52,6 +66,7 @@
         history.pushState({ slug: slug, route: route, label: label }, '', target);
       }
     }
+    refreshPageNav();
     requestAnimationFrame(function () {
       view.scrollIntoView({ behavior: 'smooth', block: 'start' });
     });
@@ -67,29 +82,39 @@
         history.pushState({}, '', base);
       }
     }
+    refreshPageNav();
   }
 
   function openSlug(slug, pushHistory) {
     var card = findCardBySlug(slug);
     if (!card) return false;
     var route = card.getAttribute('data-route');
-    var labelEl = card.querySelector('.card-title');
-    var label = labelEl ? labelEl.textContent : 'Module';
+    // Cards expose a `.card-title` child; page-nav pills only carry their
+    // own text. Fall back to the element's own text (trimmed) so the
+    // module-view header still reads correctly in both cases.
+    var labelEl = card.querySelector && card.querySelector('.card-title');
+    var label = 'Module';
+    if (labelEl && labelEl.textContent) label = labelEl.textContent.trim();
+    else if (card.textContent) label = card.textContent.trim();
     openModule(route, label, slug, pushHistory);
     return true;
   }
 
-  // Card click → open module in-page and push the deep-link URL.
+  // Card or nav-link click → open module in-page and push the deep-link
+  // URL. Both the primary surface cards and the page-nav pills resolve
+  // through the same handler so the sub-route + iframe module stay in
+  // sync no matter which control the user clicked.
   document.addEventListener(
     'click',
     function (event) {
-      var card = event.target.closest && event.target.closest('.card[data-route]');
-      if (!card) return;
+      if (!event.target || !event.target.closest) return;
+      var target = event.target.closest(MODULE_TARGET_SELECTOR);
+      if (!target) return;
       // Honour modifier clicks (cmd/ctrl/middle) for open-in-new-tab.
       if (event.metaKey || event.ctrlKey || event.shiftKey || event.button === 1) return;
       event.preventDefault();
       event.stopPropagation();
-      openSlug(slugForCard(card), true);
+      openSlug(slugForCard(target), true);
     },
     true
   );
@@ -148,6 +173,7 @@
         var target = getBasePath() + '/' + slug;
         if (location.pathname !== target) {
           history.replaceState({ slug: slug, route: route }, '', target);
+          refreshPageNav();
         }
       });
     } catch (_) {

--- a/logistics.html
+++ b/logistics.html
@@ -163,6 +163,41 @@
         box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.12);
       }
 
+      /* Page-specific navigation — rendered dynamically by page-nav.js */
+      .page-nav {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin: -0.5rem 0 2rem;
+        padding: 0;
+      }
+      .page-nav[hidden] { display: none; }
+      .page-nav-link {
+        font-family: 'DM Mono', monospace;
+        font-size: 10px;
+        letter-spacing: 2px;
+        text-transform: uppercase;
+        padding: 8px 14px;
+        border-radius: 999px;
+        border: 1px solid var(--border);
+        background: rgba(14, 56, 36, 0.45);
+        color: var(--ice);
+        text-decoration: none;
+        backdrop-filter: blur(10px);
+        transition: all 0.2s ease;
+      }
+      .page-nav-link:hover {
+        color: var(--mist);
+        border-color: rgba(134, 239, 172, 0.55);
+        background: rgba(34, 197, 94, 0.12);
+      }
+      .page-nav-link.is-active {
+        color: #86efac;
+        border-color: rgba(134, 239, 172, 0.7);
+        background: rgba(34, 197, 94, 0.18);
+        box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.12);
+      }
+
       /* Hero — 2-column grid: copy left, 2×2 status-tile aside right */
       .hero {
         display: grid;
@@ -763,6 +798,8 @@
         <a href="index.html" class="back-link">&larr; Main App</a>
       </header>
 
+      <nav id="pageNav" class="page-nav" aria-label="Logistics sections"></nav>
+
       <section class="hero">
         <div>
           <div class="hero-eyebrow">Shipments Control Tower</div>
@@ -956,6 +993,7 @@
         });
       })();
     </script>
-    <script src="landing-module-viewer.js?v=4"></script>
+    <script src="page-nav.js?v=1"></script>
+    <script src="landing-module-viewer.js?v=5"></script>
   </body>
 </html>

--- a/page-nav.js
+++ b/page-nav.js
@@ -1,0 +1,121 @@
+// page-nav.js — dynamic page-specific navigation for landing pages.
+//
+// Renders a different set of navigation items depending on which landing
+// page is active (workbench / logistics / compliance-ops / routines).
+// Each item deep-links to /<page>/<slug> and opens the matching module
+// in the embedded iframe via landing-module-viewer.js (which observes
+// clicks on any `[data-route][data-slug]` target, including the nav
+// items rendered here).
+//
+// Before this module, every landing page showed the same nav items
+// (IAR REPORT | INTEGRATIONS | SUPPLY | TRADING) because the bar was
+// hard-coded once in index.html and inherited whenever any landing
+// page opened the module iframe. That made the nav non-contextual.
+// We now render the nav at the LANDING level so /workbench,
+// /logistics, /compliance-ops each have their own menu.
+(function () {
+  'use strict';
+
+  // Page-specific navigation items. Each item has:
+  //   label — visible text (DM Mono caps).
+  //   slug  — URL segment pushed to the address bar: /<page>/<slug>.
+  //   route — hash target forwarded to index.html's switchTab() when the
+  //           module opens in the iframe.
+  var NAV_CONFIG = {
+    workbench: [
+      { label: 'IAR REPORT',      slug: 'iar-report',       route: 'iarreport' },
+      { label: 'COMPLIANCE TASKS',slug: 'compliance-tasks', route: 'asana' },
+      { label: 'RISK & CRA',      slug: 'risk-cra',         route: 'riskassessment' },
+      { label: 'CALENDAR',        slug: 'calendar',         route: 'calendar' },
+      { label: 'REPORTS',         slug: 'reports',          route: 'reports' },
+      { label: 'REG MONITOR',     slug: 'reg-monitor',      route: 'monitor' },
+      { label: 'SUPPLY',          slug: 'supply',           route: 'supplychain' },
+      { label: 'APPROVALS',       slug: 'approvals',        route: 'approvals' },
+      { label: 'WORKFLOWS',       slug: 'workflows',        route: 'workflows' },
+      { label: 'EXPORT PIPELINE', slug: 'export-pipeline',  route: 'pipeline' },
+      { label: 'TRADING',         slug: 'trading',          route: 'metalstrading' },
+      { label: 'CUSTOMER 360',    slug: 'customer-360',     route: 'customer360' },
+      { label: 'ESG',             slug: 'esg',              route: 'esg' },
+      { label: 'RED FLAGS',       slug: 'red-flags',        route: 'redflags' },
+      { label: '4-EYES',          slug: '4-eyes',           route: 'approvals' },
+      { label: 'AI GOVERN',       slug: 'ai-govern',        route: 'aigovern' }
+    ],
+    logistics: [
+      { label: 'IAR REPORT',       slug: 'iar-report',       route: 'iarreport' },
+      { label: 'COMPLIANCE TASKS', slug: 'compliance-tasks', route: 'asana' },
+      { label: 'RISK & CRA',       slug: 'risk-cra',         route: 'riskassessment' },
+      { label: 'INTEGRATIONS',     slug: 'integrations',     route: 'integrations' },
+      { label: 'SUPPLY',           slug: 'supply',           route: 'supplychain' },
+      { label: 'APPROVALS',        slug: 'approvals',        route: 'approvals' },
+      { label: 'TRAINING',         slug: 'training',         route: 'training' },
+      { label: 'ESG',              slug: 'esg',              route: 'esg' }
+    ],
+    'compliance-ops': [
+      { label: 'TRAINING',     slug: 'training',     route: 'training' },
+      { label: 'EMPLOYEES',    slug: 'employees',    route: 'employees' },
+      { label: 'INCIDENTS',    slug: 'incidents',    route: 'incidents' },
+      { label: 'REPORTS',      slug: 'reports',      route: 'reports' },
+      { label: 'RISK & CRA',   slug: 'risk-cra',     route: 'riskassessment' },
+      { label: 'APPROVALS',    slug: 'approvals',    route: 'approvals' },
+      { label: 'REG MONITOR',  slug: 'reg-monitor',  route: 'monitor' },
+      { label: 'AI GOVERN',    slug: 'ai-govern',    route: 'aigovern' }
+    ]
+    // /routines renders its own cadence-chip filter bar in routines.html
+    // (All / Continuous / Daily / Weekly) — no separate page-nav here.
+  };
+
+  function currentPage() {
+    var segs = (location.pathname || '/').split('/').filter(Boolean);
+    if (!segs.length) return '';
+    return segs[0].replace(/\.html$/, '');
+  }
+
+  function currentSlug() {
+    var segs = (location.pathname || '/').split('/').filter(Boolean);
+    return segs.length >= 2 ? segs[1] : '';
+  }
+
+  function render() {
+    var mount = document.getElementById('pageNav');
+    if (!mount) return;
+    var page = currentPage();
+    var items = NAV_CONFIG[page];
+    if (!items || !items.length) {
+      mount.innerHTML = '';
+      mount.setAttribute('hidden', '');
+      return;
+    }
+    mount.removeAttribute('hidden');
+    var activeSlug = currentSlug();
+    var parts = [];
+    for (var i = 0; i < items.length; i++) {
+      var item = items[i];
+      var href = '/' + page + '/' + item.slug;
+      var isActive = item.slug === activeSlug;
+      parts.push(
+        '<a class="page-nav-link' + (isActive ? ' is-active' : '') + '" ' +
+          'href="' + href + '" ' +
+          'data-route="' + item.route + '" ' +
+          'data-slug="' + item.slug + '"' +
+          (isActive ? ' aria-current="page"' : '') +
+          '>' + item.label + '</a>'
+      );
+    }
+    mount.innerHTML = parts.join('');
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', render);
+  } else {
+    render();
+  }
+
+  // React to history changes (module open/close pushes state) so the
+  // active pill follows the URL.
+  window.addEventListener('popstate', render);
+
+  // Exposed so landing-module-viewer.js can re-render the active pill
+  // after its own pushState/replaceState calls, which do not fire
+  // `popstate` in the current tab.
+  window.__renderPageNav = render;
+})();

--- a/workbench.html
+++ b/workbench.html
@@ -142,6 +142,41 @@
       }
       .back-link:hover { color: var(--mist); border-color: var(--azure-bright); box-shadow: 0 0 0 4px rgba(47, 125, 255, 0.12); }
 
+      /* Page-specific navigation — rendered dynamically by page-nav.js */
+      .page-nav {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin: -1.5rem 0 2.5rem;
+        padding: 0;
+      }
+      .page-nav[hidden] { display: none; }
+      .page-nav-link {
+        font-family: 'DM Mono', monospace;
+        font-size: 10px;
+        letter-spacing: 2px;
+        text-transform: uppercase;
+        padding: 8px 14px;
+        border-radius: 999px;
+        border: 1px solid var(--border);
+        background: rgba(14, 31, 56, 0.45);
+        color: var(--ice);
+        text-decoration: none;
+        backdrop-filter: blur(10px);
+        transition: all 0.2s ease;
+      }
+      .page-nav-link:hover {
+        color: var(--mist);
+        border-color: var(--azure-bright);
+        background: rgba(47, 125, 255, 0.12);
+      }
+      .page-nav-link.is-active {
+        color: var(--orange-bright);
+        border-color: var(--orange-border);
+        background: var(--orange-dim);
+        box-shadow: 0 0 0 3px rgba(251, 146, 60, 0.1);
+      }
+
       /* Hero */
       .hero {
         display: grid;
@@ -438,6 +473,8 @@
         <a href="index.html" class="back-link">&larr; Main App</a>
       </header>
 
+      <nav id="pageNav" class="page-nav" aria-label="Workbench sections"></nav>
+
       <section class="hero">
         <div>
           <div class="hero-eyebrow">MLRO Workbench</div>
@@ -605,6 +642,7 @@
       <span class="footer-text">© 2026 Hawkeye Sterling</span>
       <span class="footer-text">Confidential · Audit-ready</span>
     </footer>
-    <script src="landing-module-viewer.js?v=4"></script>
+    <script src="page-nav.js?v=1"></script>
+    <script src="landing-module-viewer.js?v=5"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Fixes the "all landing pages show the same nav bar" routing bug. Previously `/workbench`, `/logistics`, and `/compliance-ops` all ended up showing the same items (IAR REPORT | INTEGRATIONS | SUPPLY | TRADING) because the bar lived inside `index.html` and was inherited whenever any landing page opened a module in the embedded iframe. Each landing page now renders its own contextual nav via a new `page-nav.js` module, and clicking a pill pushes a sub-route on the active landing page instead of routing into the main SPA.

## What's different per page

- **`/workbench`** — IAR REPORT | COMPLIANCE TASKS | RISK & CRA | CALENDAR | REPORTS | REG MONITOR | SUPPLY | APPROVALS | WORKFLOWS | EXPORT PIPELINE | TRADING | CUSTOMER 360 | ESG | RED FLAGS | 4-EYES | AI GOVERN
- **`/logistics`** — IAR REPORT | COMPLIANCE TASKS | RISK & CRA | INTEGRATIONS | SUPPLY | APPROVALS | TRAINING | ESG
- **`/compliance-ops`** — TRAINING | EMPLOYEES | INCIDENTS | REPORTS | RISK & CRA | APPROVALS | REG MONITOR | AI GOVERN
- **`/routines`** — unchanged; its cadence chips (All / Continuous / Daily / Weekly) already ship from `routines.html` and drive `/routines/daily`, `/routines/weekly`, etc.

Clicking a pill on `/workbench/*` now pushes e.g. `/workbench/approvals`; on `/logistics/*` it pushes `/logistics/training`; on `/compliance-ops/*` it pushes `/compliance-ops/incidents`.

## Implementation

- **`page-nav.js`** (new) — renders `<nav id="pageNav">` from a per-page config keyed on the first URL segment. Each pill is `<a data-route data-slug>` pointing at `/<page>/<slug>`. Exposes `window.__renderPageNav` so the module viewer can refresh the active pill after `pushState` / `replaceState`.
- **`landing-module-viewer.js`** — now matches both `.card[data-route]` and `[data-route][data-slug]`, so nav-pill clicks reuse the same open-module-in-iframe + `pushState` routing as card clicks. `findCardBySlug` + label derivation generalised to work for page-nav pills (no `.card-title` child) too. Asset version bumped to `?v=5`.
- **`app-boot.js`** — `HASH_TAB_MAP` grows to cover `iarreport`, `riskassessment`, `calendar`, `monitor`, `integrations`, `supplychain`, `workflows`, `pipeline`, `customer360`, `esg`, `redflags` so hash-driven deep links land on the right tab inside the embedded app.
- **`workbench.html` / `logistics.html` / `compliance-ops.html`** — add `<nav id="pageNav">` placeholder, scoped `.page-nav` styling that respects each page's palette, and load `page-nav.js` before `landing-module-viewer.js`.

## Regulatory basis

Cosmetic + routing change only — no regulatory logic touched. Existing **FDL No.10/2025 Art.24** tab-switch audit trail in `app-core.js` / `compliance-suite.js` is unchanged, and every nav-pill click still resolves to the same `switchTab(route)` path the cards already drive, so audit entries keep flowing for module opens.

## Test plan

- [ ] Visit `/workbench` — nav shows 16 workbench items (including 4-EYES, AI GOVERN, RED FLAGS). Different from logistics and compliance-ops.
- [ ] Visit `/logistics` — nav shows 8 logistics items (IAR REPORT, COMPLIANCE TASKS, RISK & CRA, INTEGRATIONS, SUPPLY, APPROVALS, TRAINING, ESG).
- [ ] Visit `/compliance-ops` — nav shows 8 compliance-ops items (TRAINING, EMPLOYEES, INCIDENTS, REPORTS, RISK & CRA, APPROVALS, REG MONITOR, AI GOVERN).
- [ ] Visit `/routines` — cadence chips (All / Continuous / Daily / Weekly) still present and filter the routine list.
- [ ] Click APPROVALS on `/workbench` → URL becomes `/workbench/approvals`, iframe opens the approvals view, active pill highlighted.
- [ ] Click TRAINING on `/logistics` → URL becomes `/logistics/training`.
- [ ] Click INCIDENTS on `/compliance-ops` → URL becomes `/compliance-ops/incidents`.
- [ ] Browser back/forward reflects the sub-route transitions and the active pill updates.
- [ ] Refresh on `/workbench/approvals` still opens the Approvals module deep-link.
- [ ] Existing primary cards on each landing page still work unchanged.
