### PR TITLE
Add Approved Accounts module card to logistics landing

### DIFF
--- a/logistics.html
+++ b/logistics.html
@@ -798,7 +798,7 @@
 
       <div class="section-head">
         <span class="section-label">Regulated Surfaces</span>
-        <span class="section-count">03 / 03</span>
+        <span class="section-count">04 / 04</span>
       </div>
 
       <div class="grid">
@@ -857,11 +857,39 @@
           </div>
         </a>
 
+        <a class="card" href="/logistics/approved-accounts" data-route="approvedaccounts" data-slug="approved-accounts">
+          <div class="card-icon" aria-hidden="true">✅</div>
+          <div class="card-meta">
+            <span class="dot"></span>
+            <span>Module 03 · Counterparty</span>
+          </div>
+          <h2 class="card-title">Approved Accounts</h2>
+          <p class="card-desc">
+            Pre-vetted suppliers, refiners, and vault counterparties cleared
+            through CDD, sanctions screening, and UBO verification. Gates every
+            inbound, in-transit, and local movement to an approved list.
+          </p>
+          <div class="card-stats">
+            <div class="stat">
+              <span class="stat-val">CDD</span>
+              <span class="stat-key">Vetted</span>
+            </div>
+            <div class="stat">
+              <span class="stat-val">UBO</span>
+              <span class="stat-key">&gt;25% register</span>
+            </div>
+          </div>
+          <div class="card-cta">
+            <span>Open module</span>
+            <span class="card-cta-arrow" aria-hidden="true">&rarr;</span>
+          </div>
+        </a>
+
         <a class="card" href="/logistics/local-shipments" data-route="localshipments" data-slug="local-shipments">
           <div class="card-icon" aria-hidden="true">📦</div>
           <div class="card-meta">
             <span class="dot"></span>
-            <span>Module 03 · Local</span>
+            <span>Module 04 · Local</span>
           </div>
           <h2 class="card-title">Local Shipments</h2>
           <p class="card-desc">
@@ -913,8 +941,10 @@
           <div class="reg-title">Regulatory Basis</div>
           <div class="reg-text">
             <strong>MoE Circular 08/AML/2021</strong> (DPMS record-keeping) ·
+            <strong>FDL No.10/2025 Art.12-14</strong> (CDD) ·
             <strong>FDL No.10/2025 Art.24</strong> (10-year retention) ·
             <strong>Cabinet Res 134/2025 Art.16</strong> (cross-border cash AED 60,000) ·
+            <strong>Cabinet Decision 109/2023</strong> (UBO &gt;25%) ·
             <strong>LBMA RGG v9</strong> ·
             <strong>UAE MoE RSG framework</strong> (origin traceability).
           </div>


### PR DESCRIPTION
## Summary

- Adds a fourth regulated-surface card, **Approved Accounts**, to `/logistics` between Tracking and Local Shipments.
- Renumbers Local Shipments from Module 03 to Module 04 and updates the section count from `03 / 03` to `04 / 04`.
- Extends the Regulatory Basis strip on the page with the CDD and UBO citations that govern the new card.

The new card links to `/logistics/approved-accounts` (already covered by the existing `/logistics/*` redirect in `netlify.toml`) and uses the `#approvedaccounts` hash route on the embedded module iframe.

**Purpose:** surface the pre-vetted supplier, refiner, and vault-counterparty list that gates every inbound, in-transit, and local movement. This is the CDD/UBO control surface feeding the other three logistics modules.

## Regulatory citations

- **FDL No.10/2025 Art.12-14** — Customer Due Diligence.
- **Cabinet Res 134/2025 Art.7-10** — CDD tiers (SDD / CDD / EDD).
- **Cabinet Decision 109/2023** — UBO register, >25% beneficial ownership threshold.

## Scope

UI-only change on `logistics.html`. No new tab or handler was added in `index.html` — clicking the card opens the embedded module frame at `#approvedaccounts`, which currently falls back to the default empty state until the destination tab is built in a follow-up PR.

## Test plan

- [ ] Load `/logistics` and confirm four cards render in order: Inbound Advice, Tracking, Approved Accounts, Local Shipments.
- [ ] Section count reads `04 / 04`.
- [ ] Local Shipments card shows `Module 04 · Local`.
- [ ] Approved Accounts card hover glow and CTA arrow behave consistently with the other cards.
- [ ] Regulatory Basis strip at the bottom of the page lists the new FDL Art.12-14 and Cabinet Decision 109/2023 citations.
- [ ] Deep link `/logistics/approved-accounts` resolves to the logistics page (via the existing `/logistics/*` redirect) and does not 404.

https://claude.ai/code/session_01E4UM3HTxhc2BqnHqpA7xQQ