### PR TITLE
Redesign screening-command.html as a landing hub

### DIFF
--- a/landing-module-viewer.js
+++ b/landing-module-viewer.js
@@ -8,7 +8,7 @@
   // Landing slugs that resolve to a root-level .html via netlify.toml
   // redirects. Any first URL segment outside this list is treated as a
   // raw .html file (defensive: local file:// / preview deploys).
-  var LANDING_SLUGS = ['logistics', 'workbench', 'compliance-ops', 'routines'];
+  var LANDING_SLUGS = ['logistics', 'workbench', 'compliance-ops', 'routines', 'screening-command'];
 
   // Base path for the current landing page — never includes a module
   // sub-slug. "/logistics", "/workbench", etc. Falls back to the raw

--- a/netlify.toml
+++ b/netlify.toml
@@ -95,6 +95,11 @@
   to = "/compliance-ops.html"
   status = 200
 
+[[redirects]]
+  from = "/screening-command/*"
+  to = "/screening-command.html"
+  status = 200
+
 [[headers]]
   for = "/*"
   [headers.values]

--- a/screening-command.html
+++ b/screening-command.html
@@ -1,88 +1,57 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta http-equiv="X-Content-Type-Options" content="nosniff" />
-    <title>Screening Command — Hawkeye Sterling</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex, nofollow" />
+    <meta name="theme-color" content="#120a20" />
+    <title>Hawkeye Sterling V2 &mdash; Screening Command</title>
     <link rel="icon" type="image/svg+xml" href="assets/logos/hawkeye-icon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@600;700;800&display=swap"
+      rel="stylesheet"
     />
     <style>
       :root {
-        /* Purple / lilac / fuchsia system — mirrors routines.html blue tokens */
-        --gold: #a855f7;
-        --gold-bright: #c084fc;
-        --gold-dim: rgba(168, 85, 247, 0.6);
-        --gold-grad: linear-gradient(135deg, #e879f9 0%, #a855f7 45%, #8b5cf6 100%);
+        /* Purple / lilac / fuchsia palette — unchanged from the previous
+           screening-command build. Layout below is re-skinned to match
+           compliance-ops.html but every colour token stays purple. */
         --ink: #0c0614;
         --midnight: #120a20;
         --navy: #1a0f2e;
         --navy-2: #241538;
-        --bg: #0c0614;
-        --bg-elev: #1a0f2e;
-        --surface: rgba(168, 85, 247, 0.04);
-        --surface2: rgba(168, 85, 247, 0.08);
-        --border: rgba(232, 121, 249, 0.16);
-        --border-strong: rgba(232, 121, 249, 0.38);
-        --text: #fae8ff;
-        --muted: rgba(240, 171, 252, 0.55);
+        --surface: #2b1846;
+        --surface-2: #3a2160;
+        --steel: #7e5e95;
+        --steel-dim: #4f3768;
         --royal: #8b5cf6;
         --azure: #a855f7;
         --azure-bright: #c084fc;
         --sky: #e879f9;
         --ice: #f0abfc;
         --mist: #fae8ff;
-        --steel: #7e5e95;
-        --accent: #e879f9;
-        --red: #f43f5e;
-        --amber: #f59e0b;
-        --green: #34d399;
-        --blue: #818cf8;
-        --shadow-lg: 0 24px 60px rgba(0, 0, 0, 0.6), 0 2px 6px rgba(0, 0, 0, 0.3);
-        --shadow-md: 0 8px 24px rgba(0, 0, 0, 0.4);
-        --shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.04);
-        --hairline: rgba(232, 121, 249, 0.18);
+        --border: rgba(232, 121, 249, 0.18);
+        --border-strong: rgba(232, 121, 249, 0.4);
+        --glow: rgba(168, 85, 247, 0.55);
+        --muted: rgba(240, 171, 252, 0.6);
       }
-      * {
-        box-sizing: border-box;
-        margin: 0;
-        padding: 0;
-      }
-      html,
-      body {
-        overscroll-behavior-y: contain;
-      }
+
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+
       body {
         background: var(--midnight);
-        color: var(--text);
-        font-family:
-          'Inter',
-          -apple-system,
-          BlinkMacSystemFont,
-          'Segoe UI',
-          sans-serif;
-        font-weight: 400;
-        max-width: 1680px;
-        margin: 0 auto;
-        padding: 20px 32px 60px;
-        padding-top: calc(20px + env(safe-area-inset-top, 0px));
-        padding-bottom: calc(60px + env(safe-area-inset-bottom, 0px));
-        font-size: 15px;
-        line-height: 1.55;
-        letter-spacing: 0.01em;
+        color: var(--mist);
+        font-family: 'Inter', system-ui, -apple-system, sans-serif;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        overflow-x: hidden;
         -webkit-font-smoothing: antialiased;
-        -moz-osx-font-smoothing: grayscale;
-        font-feature-settings:
-          'liga' 1,
-          'calt' 1,
-          'kern' 1,
-          'ss01' 1;
       }
+
       body::before {
         content: '';
         position: fixed;
@@ -94,6 +63,7 @@
           radial-gradient(ellipse 60% 50% at 85% 10%, rgba(139, 92, 246, 0.18), transparent 55%),
           radial-gradient(ellipse 70% 40% at 50% 100%, rgba(63, 40, 98, 0.55), transparent 60%);
       }
+
       body::after {
         content: '';
         position: fixed;
@@ -101,34 +71,31 @@
         pointer-events: none;
         z-index: 0;
         background-image:
-          linear-gradient(to right, rgba(240, 171, 252, 0.035) 1px, transparent 1px),
-          linear-gradient(to bottom, rgba(240, 171, 252, 0.035) 1px, transparent 1px);
-        background-size: 56px 56px;
-        mask-image: radial-gradient(ellipse 90% 70% at 50% 30%, #000 40%, transparent 80%);
-        -webkit-mask-image: radial-gradient(ellipse 90% 70% at 50% 30%, #000 40%, transparent 80%);
+          linear-gradient(rgba(240, 171, 252, 0.06) 1px, transparent 1px),
+          linear-gradient(90deg, rgba(240, 171, 252, 0.06) 1px, transparent 1px);
+        background-size: 72px 72px;
+        background-position: -1px -1px;
+        mask-image: radial-gradient(ellipse 95% 80% at 50% 40%, black 55%, transparent 100%);
+        -webkit-mask-image: radial-gradient(ellipse 95% 80% at 50% 40%, black 55%, transparent 100%);
       }
-      body > * {
+
+      .shell {
         position: relative;
         z-index: 1;
+        max-width: 1680px;
+        margin: 0 auto;
+        padding: 1.5rem 2.25rem 3rem;
+        flex: 1;
       }
-      @media (min-width: 1400px) {
-        .grid-2 {
-          grid-template-columns: 1fr 1fr !important;
-        }
-        .grid-3 {
-          grid-template-columns: 1fr 1fr 1fr;
-          gap: 14px;
-          display: grid;
-        }
-      }
-      header {
+
+      .topbar {
         display: flex;
         justify-content: space-between;
         align-items: center;
         flex-wrap: wrap;
         gap: 12px;
         padding: 6px 0 22px;
-        margin-bottom: 22px;
+        margin-bottom: 18px;
         border-bottom: 1px solid var(--border);
       }
       .title-group {
@@ -138,6 +105,7 @@
       }
       .header-logo {
         flex-shrink: 0;
+        width: 56px; height: 56px;
         border-radius: 10px;
         display: block;
         box-shadow:
@@ -145,168 +113,71 @@
           0 8px 24px rgba(168, 85, 247, 0.35),
           inset 0 1px 0 rgba(255, 255, 255, 0.18);
       }
-      header a.muted {
-        color: var(--ice);
-        text-decoration: none;
-        font-size: 11px;
-        font-family: 'DM Mono', monospace;
-        letter-spacing: 2px;
-        text-transform: uppercase;
-        border: 1px solid var(--border-strong);
-        padding: 10px 18px;
-        border-radius: 999px;
-        display: inline-flex;
-        align-items: center;
-        gap: 8px;
-        background: rgba(26, 15, 46, 0.6);
-        backdrop-filter: blur(12px);
-        transition: all 0.25s ease;
-      }
-      header a.muted:hover {
-        color: var(--mist);
-        border-color: var(--azure-bright);
-        box-shadow: 0 0 0 4px rgba(168, 85, 247, 0.14);
-      }
-      h1 {
+      .page-h1 {
         font-family: 'Playfair Display', serif;
         font-size: clamp(32px, 3.4vw, 44px);
         font-weight: 700;
         letter-spacing: -0.01em;
-        text-transform: none;
-        background: linear-gradient(180deg, #ffffff 0%, var(--ice) 45%, var(--sky) 100%);
+        margin: 0;
+        background: linear-gradient(180deg, #ffffff 0%, var(--ice) 45%, var(--azure-bright) 100%);
         -webkit-background-clip: text;
         background-clip: text;
-        color: transparent;
-        text-shadow: none;
-        line-height: 1.2;
-        padding-bottom: 0.12em;
-        margin: 0;
+        -webkit-text-fill-color: transparent;
       }
-      h1 .badge {
-        display: inline-block;
-        background: var(--gold-grad);
-        color: #ffffff;
-        font-size: 10px;
-        padding: 4px 10px;
+      .back-link {
+        font-family: 'DM Mono', monospace;
+        font-size: 11px; letter-spacing: 2.5px; text-transform: uppercase;
+        color: var(--steel);
+        text-decoration: none;
+        padding: 9px 18px;
+        border: 1px solid var(--border);
         border-radius: 999px;
-        margin-left: 12px;
-        vertical-align: middle;
-        font-weight: 700;
-        letter-spacing: 1.5px;
-        font-family: 'DM Mono', monospace;
-        box-shadow:
-          0 1px 0 rgba(255, 255, 255, 0.2) inset,
-          0 4px 12px rgba(168, 85, 247, 0.45);
+        transition: all 0.2s ease;
       }
-      h2 {
-        color: var(--sky);
-        font-family: 'DM Mono', monospace;
-        font-size: 11px;
-        font-weight: 500;
-        letter-spacing: 3px;
-        text-transform: uppercase;
-        margin-bottom: 8px;
-        display: flex;
-        align-items: center;
-        gap: 10px;
-        position: relative;
-        padding-bottom: 6px;
+      .back-link:hover {
+        color: var(--mist);
+        border-color: var(--azure-bright);
+        box-shadow: 0 0 0 4px rgba(168, 85, 247, 0.12);
       }
-      h2::after {
-        content: '';
-        position: absolute;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        height: 1px;
-        background: linear-gradient(
-          to right,
-          var(--hairline) 0%,
-          rgba(168, 85, 247, 0.08) 40%,
-          transparent 100%
-        );
-      }
-      .tag {
-        font-size: 9px;
-        padding: 2px 6px;
-        border-radius: 2px;
-        border: 1px solid var(--border-strong);
-        color: var(--muted);
-        letter-spacing: 1px;
-        text-transform: uppercase;
-        font-weight: 600;
-      }
-      /* Hero (mirrors routines.html hero, rotated to purple) */
+
       .hero {
         display: grid;
         grid-template-columns: 1.3fr 1fr;
         gap: 48px;
         align-items: start;
-        margin: 10px 0 36px;
+        margin: 10px 0 2.75rem;
       }
-      @keyframes pulse {
-        0%,
-        100% {
-          opacity: 1;
-          transform: scale(1);
-        }
-        50% {
-          opacity: 0.55;
-          transform: scale(1.25);
-        }
-      }
-      .hero-title {
-        font-family: 'Playfair Display', serif;
-        font-weight: 700;
-        font-size: clamp(36px, 4.4vw, 56px);
-        line-height: 1.15;
-        letter-spacing: -0.02em;
-        margin: 0 0 1.25rem;
-        padding-bottom: 0.12em;
-        background: linear-gradient(180deg, #ffffff 0%, var(--ice) 45%, var(--sky) 100%);
-        -webkit-background-clip: text;
-        background-clip: text;
-        -webkit-text-fill-color: transparent;
-      }
-      .hero-title .nowrap {
-        white-space: nowrap;
-      }
-      @media (max-width: 640px) {
-        .hero-title .nowrap {
-          white-space: normal;
-        }
-      }
-      .hero-title em {
-        font-style: italic;
-        font-weight: 600;
-        color: var(--azure-bright);
-        -webkit-text-fill-color: var(--azure-bright);
-      }
-      @media (max-width: 900px) {
-        .hero {
-          grid-template-columns: 1fr;
-          gap: 28px;
-        }
+      @media (max-width: 920px) {
+        .hero { grid-template-columns: 1fr; gap: 28px; }
       }
 
-      /* Summary panel — 2×2 stats aside */
-      .summary {
+      .hero-summary {
         background: linear-gradient(160deg, rgba(36, 21, 56, 0.8) 0%, rgba(12, 6, 20, 0.6) 100%);
         border: 1px solid var(--border);
         border-radius: 18px;
-        padding: 1.5rem;
+        padding: 1.25rem;
         backdrop-filter: blur(18px);
+        -webkit-backdrop-filter: blur(18px);
         display: grid;
         grid-template-columns: 1fr 1fr;
         gap: 14px;
+        position: relative;
+        overflow: hidden;
       }
-      .summary-cell {
+      .hero-summary::before {
+        content: '';
+        position: absolute;
+        top: 0; left: 0; right: 0;
+        height: 1px;
+        background: linear-gradient(90deg, transparent, var(--azure-bright), transparent);
+      }
+      .hero-summary-cell {
         padding: 12px 14px;
         border: 1px solid var(--border);
         border-radius: 12px;
         background: rgba(12, 6, 20, 0.5);
       }
-      .summary-cell .k {
+      .hero-summary-cell .k {
         font-family: 'DM Mono', monospace;
         font-size: 9px;
         letter-spacing: 2px;
@@ -314,3091 +185,525 @@
         color: var(--steel);
         margin-bottom: 4px;
       }
-      .summary-cell .v {
+      .hero-summary-cell .v {
         font-family: 'Playfair Display', serif;
         font-weight: 700;
         font-size: 26px;
         color: var(--mist);
         line-height: 1;
       }
-      .summary-cell .v small {
+      .hero-summary-cell .v small {
         font-family: 'DM Mono', monospace;
         font-size: 11px;
-        color: var(--sky);
+        color: var(--azure-bright);
         margin-left: 6px;
         letter-spacing: 0;
+        font-weight: 400;
+      }
+      .hero-summary-cell .dot {
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: var(--azure-bright);
+        box-shadow: 0 0 10px var(--azure-bright);
+        display: inline-block;
+        margin-right: 8px;
+        vertical-align: middle;
+      }
+      .hero-summary-cell[data-state="amber"] .dot {
+        background: #f59e0b;
+        box-shadow: 0 0 10px #f59e0b;
+      }
+
+      .hero-eyebrow {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        font-family: 'DM Mono', monospace;
+        font-size: 11px;
+        letter-spacing: 3px;
+        text-transform: uppercase;
+        color: var(--azure-bright);
+        margin-bottom: 1rem;
+      }
+      .hero-eyebrow::before {
+        content: '';
+        width: 7px; height: 7px; border-radius: 50%;
+        background: var(--azure);
+        box-shadow: 0 0 12px var(--azure);
+        animation: pulse 2.2s ease-in-out infinite;
+      }
+      @keyframes pulse {
+        0%, 100% { opacity: 1; transform: scale(1); }
+        50% { opacity: 0.55; transform: scale(1.25); }
+      }
+
+      .hero-title {
+        font-family: 'Playfair Display', serif;
+        font-weight: 700;
+        font-size: clamp(36px, 4.4vw, 56px);
+        line-height: 1.15;
+        letter-spacing: -0.02em;
+        color: var(--mist);
+        margin: 0 0 1.25rem;
+        padding-bottom: 0.12em;
+        background: linear-gradient(180deg, #ffffff 0%, var(--ice) 45%, var(--azure-bright) 100%);
+        -webkit-background-clip: text;
+        background-clip: text;
+        -webkit-text-fill-color: transparent;
+      }
+      .hero-title .nowrap { white-space: nowrap; }
+      @media (max-width: 720px) { .hero-title .nowrap { white-space: normal; } }
+      .hero-title em {
+        font-style: italic; font-weight: 600;
+        color: var(--azure-bright);
+        background: none;
+        -webkit-text-fill-color: var(--azure-bright);
+      }
+      .hero-lede {
+        color: var(--ice);
+        font-size: 15px;
+        line-height: 1.65;
+        max-width: 860px;
+        margin: 0;
+        opacity: 0.82;
+      }
+
+      .section-head {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-end;
+        margin: 0 0 1.25rem;
+        padding-bottom: 0.75rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .section-label {
+        font-family: 'DM Mono', monospace;
+        font-size: 11px; letter-spacing: 3px; text-transform: uppercase;
+        color: var(--muted);
+      }
+      .section-count {
+        font-family: 'DM Mono', monospace;
+        font-size: 11px; letter-spacing: 2px;
+        color: var(--azure-bright);
       }
 
       .grid {
         display: grid;
-        grid-template-columns: 1fr;
-        gap: 14px;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 18px;
       }
-      @media (min-width: 860px) {
-        .grid-2 {
-          grid-template-columns: 1fr 1fr;
-        }
+      @media (max-width: 1200px) {
+        .grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      }
+      @media (max-width: 700px) {
+        .grid { grid-template-columns: 1fr; }
       }
       .card {
-        background: linear-gradient(
-          180deg,
-          rgba(36, 21, 56, 0.85) 0%,
-          rgba(18, 10, 32, 0.95) 100%
-        );
-        border: 1px solid var(--border);
+        display: flex;
+        flex-direction: column;
+        gap: 14px;
+        padding: 1.4rem;
         border-radius: 16px;
-        padding: 22px 24px;
-        backdrop-filter: blur(14px);
-        box-shadow: var(--shadow-md), var(--shadow-inset);
+        border: 1px solid var(--border);
+        background: linear-gradient(160deg, rgba(36, 21, 56, 0.72) 0%, rgba(18, 10, 32, 0.7) 100%);
+        backdrop-filter: blur(18px);
+        -webkit-backdrop-filter: blur(18px);
+        text-decoration: none;
+        color: inherit;
+        transition: all 0.2s ease;
         position: relative;
         overflow: hidden;
-        transition: border-color 0.3s ease, box-shadow 0.3s ease;
       }
       .card:hover {
-        border-color: var(--border-strong);
-        box-shadow: 0 16px 40px -20px rgba(168, 85, 247, 0.35);
+        transform: translateY(-3px);
+        border-color: var(--azure);
+        box-shadow: 0 22px 48px -24px rgba(168, 85, 247, 0.45);
       }
       .card::before {
         content: '';
         position: absolute;
-        top: 0;
-        left: 20%;
-        right: 20%;
+        top: 0; left: 0; right: 0;
         height: 1px;
-        background: linear-gradient(
-          90deg,
-          transparent,
-          rgba(232, 121, 249, 0.55),
-          transparent
-        );
-        opacity: 0.5;
+        background: linear-gradient(90deg, transparent, var(--azure-bright), transparent);
+        opacity: 0.6;
       }
-      label {
-        display: block;
-        margin-top: 14px;
-        margin-bottom: 6px;
-        color: var(--muted);
-        font-size: 12px;
-        text-transform: uppercase;
-        letter-spacing: 0.5px;
-      }
-      label:first-of-type {
-        margin-top: 8px;
-      }
-      input,
-      select,
-      textarea {
-        width: 100%;
-        padding: 12px;
-        background: rgba(12, 6, 20, 0.75);
+      .card-icon {
+        width: 52px; height: 52px; border-radius: 12px;
+        display: grid; place-items: center;
+        font-size: 24px;
+        background: linear-gradient(135deg, rgba(168, 85, 247, 0.22), rgba(139, 92, 246, 0.18));
         border: 1px solid var(--border-strong);
-        color: var(--text);
-        border-radius: 8px;
-        font-size: 16px;
-        font-family: inherit;
-        -webkit-appearance: none;
-        appearance: none;
-        transition: border-color 0.2s ease, box-shadow 0.2s ease;
       }
-      input[type='checkbox'],
-      input[type='radio'] {
-        width: auto;
-        padding: 0;
-        font-size: 0;
-        border-radius: 3px;
-        background: transparent;
-      }
-      textarea {
-        resize: vertical;
-        min-height: 80px;
-      }
-      input:focus,
-      select:focus,
-      textarea:focus {
-        outline: none;
-        border-color: var(--azure-bright);
-        box-shadow: 0 0 0 3px rgba(168, 85, 247, 0.18);
-      }
-      select {
-        background-image:
-          linear-gradient(45deg, transparent 50%, var(--muted) 50%),
-          linear-gradient(135deg, var(--muted) 50%, transparent 50%);
-        background-position:
-          calc(100% - 18px) 50%,
-          calc(100% - 12px) 50%;
-        background-size:
-          6px 6px,
-          6px 6px;
-        background-repeat: no-repeat;
-        padding-right: 38px;
-      }
-      button {
-        width: 100%;
-        padding: 14px;
-        background: transparent;
-        color: var(--ice);
-        border: 1px solid var(--border-strong);
-        border-radius: 10px;
-        font-size: 13px;
-        font-weight: 600;
-        letter-spacing: 1.5px;
-        text-transform: uppercase;
-        cursor: pointer;
-        margin-top: 18px;
-        min-height: 48px;
-        touch-action: manipulation;
-        font-family: 'DM Mono', monospace;
-        transition:
-          background-color 0.18s ease,
-          border-color 0.18s ease,
-          color 0.18s ease,
-          box-shadow 0.18s ease,
-          transform 0.12s ease;
-      }
-      button:hover:not(:disabled) {
-        background: rgba(168, 85, 247, 0.12);
-        border-color: var(--azure-bright);
-        color: var(--mist);
-        box-shadow: 0 0 0 4px rgba(168, 85, 247, 0.14);
-      }
-      button:active {
-        transform: translateY(1px);
-      }
-      button:disabled {
-        background: transparent;
-        border-color: #555;
-        cursor: not-allowed;
-        color: var(--muted);
-      }
-      .btn-secondary {
-        background: transparent;
-        color: var(--gold);
-        border: 1px solid var(--gold);
-      }
-      .btn-small {
-        width: auto;
-        padding: 8px 12px;
-        margin: 0 0 0 8px;
-        font-size: 12px;
-        min-height: 32px;
-      }
-      .msg {
-        padding: 12px;
-        border-radius: 4px;
-        margin-top: 14px;
-        font-size: 13px;
-        line-height: 1.5;
-        word-break: break-word;
-      }
-      .msg-success {
-        background: rgba(61, 168, 118, 0.12);
-        border: 1px solid var(--green);
-        color: var(--green);
-      }
-      .msg-error {
-        background: rgba(217, 79, 79, 0.12);
-        border: 1px solid var(--red);
-        color: var(--red);
-      }
-      .msg-info {
-        background: rgba(74, 144, 226, 0.1);
-        border: 1px solid var(--blue);
-        color: var(--blue);
-      }
-      .muted {
-        color: var(--muted);
-        font-size: 12px;
-      }
-      .token-hint {
-        display: block;
-        margin-top: 6px;
-        color: var(--muted);
-        font-size: 11px;
-      }
-      .token-hint code {
+      .card-meta {
+        display: flex; align-items: center; gap: 10px;
         font-family: 'DM Mono', monospace;
         font-size: 10.5px;
-        color: var(--accent);
-      }
-      .token-row {
-        display: flex;
-        gap: 6px;
-        align-items: stretch;
-      }
-      .token-row input {
-        flex: 1;
-        min-width: 0;
-      }
-      .token-gen-btn {
-        padding: 0 12px;
-        font-family: 'DM Mono', monospace;
-        font-size: 11px;
-        letter-spacing: 1px;
-        text-transform: uppercase;
-        background: transparent;
-        color: var(--accent);
-        border: 1px solid var(--border);
-        border-radius: 4px;
-        cursor: pointer;
-        white-space: nowrap;
-      }
-      .token-gen-btn:hover {
-        background: rgba(255, 255, 255, 0.04);
-      }
-      .token-msg {
-        margin-top: 6px;
-        font-size: 11px;
-        color: var(--accent);
-        min-height: 14px;
-      }
-      .token-msg.err {
-        color: #ff6b6b;
-      }
-      .auth-card {
-        padding: 12px 16px;
-        transition: background 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
-      }
-      /* STR Case Management */
-      .str-card {
-        padding: 18px 22px;
-        background: linear-gradient(180deg, rgba(40, 28, 10, 0.45) 0%, rgba(28, 18, 6, 0.6) 100%);
-      }
-      .str-top {
-        display: grid;
-        grid-template-columns: auto 1fr auto;
-        gap: 14px;
-        align-items: center;
-        margin-bottom: 14px;
-      }
-      .str-title {
-        font-family: 'DM Mono', monospace;
-        font-size: 13px;
         letter-spacing: 2px;
         text-transform: uppercase;
-        color: var(--gold) !important;
-        margin: 0 !important;
-      }
-      .str-cite {
-        font-family: 'DM Mono', monospace;
-        font-size: 10px;
-        letter-spacing: 1px;
         color: var(--muted);
-        text-align: center;
       }
-      .str-new-btn {
+      .card-meta .dot {
+        width: 6px; height: 6px; border-radius: 50%;
+        background: var(--azure-bright);
+        box-shadow: 0 0 8px var(--azure-bright);
+      }
+      .card-title {
+        font-family: 'Playfair Display', serif;
+        font-weight: 700;
+        font-size: 28px;
+        color: var(--mist);
+        margin: 0;
+        letter-spacing: -0.01em;
+      }
+      .card-desc {
+        color: var(--ice);
+        font-size: 14px;
+        line-height: 1.6;
+        margin: 0;
+        opacity: 0.82;
+      }
+      .card-stats {
+        display: flex;
+        gap: 18px;
+        margin-top: 4px;
+        padding-top: 14px;
+        border-top: 1px solid var(--border);
+      }
+      .stat { display: flex; flex-direction: column; gap: 2px; }
+      .stat-val {
+        font-family: 'Playfair Display', serif;
+        font-weight: 700;
+        font-size: 20px;
+        color: var(--azure-bright);
+      }
+      .stat-key {
+        font-family: 'DM Mono', monospace;
+        font-size: 9.5px;
+        letter-spacing: 1.5px;
+        text-transform: uppercase;
+        color: var(--muted);
+      }
+      .card-cta {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-top: auto;
+        padding-top: 16px;
         font-family: 'DM Mono', monospace;
         font-size: 11px;
         letter-spacing: 2px;
         text-transform: uppercase;
         color: var(--azure-bright);
-        border: 1px solid var(--azure);
-        background: rgba(47, 125, 255, 0.1);
-        padding: 8px 14px;
-        border-radius: 6px;
-        text-decoration: none;
-        white-space: nowrap;
-        transition: all 0.15s ease;
       }
-      .str-new-btn:hover {
-        background: rgba(47, 125, 255, 0.22);
-        color: #fff;
-      }
-      .str-conf-notice {
-        display: flex;
-        align-items: flex-start;
-        gap: 10px;
-        background: rgba(217, 79, 79, 0.1);
-        border: 1px solid rgba(217, 79, 79, 0.4);
-        border-radius: 6px;
-        padding: 10px 14px;
-        margin-bottom: 14px;
-        font-size: 12px;
-        line-height: 1.5;
-        color: #f87171;
-      }
-      .str-conf-icon { font-size: 14px; line-height: 1; margin-top: 1px; }
-      .str-metrics {
-        display: grid;
-        grid-template-columns: repeat(4, 1fr);
-        gap: 10px;
-        margin-bottom: 10px;
-      }
-      .str-metric {
-        padding: 18px 14px;
-        border: 1px solid var(--border);
-        border-radius: 8px;
-        background: rgba(10, 10, 14, 0.55);
-        text-align: center;
-      }
-      .str-m-num {
-        font-family: 'Playfair Display', serif;
-        font-size: 32px;
-        font-weight: 700;
-        line-height: 1;
-      }
-      .str-m-lbl {
-        font-family: 'DM Mono', monospace;
-        font-size: 10px;
-        letter-spacing: 2px;
-        text-transform: uppercase;
-        color: var(--muted);
-        margin-top: 6px;
-      }
-      .str-m-draft .str-m-num { color: #ef4444; }
-      .str-m-review .str-m-num { color: #f59e0b; }
-      .str-m-pending .str-m-num { color: #3b82f6; }
-      .str-m-filed .str-m-num { color: #22c55e; }
-      .str-empty {
-        text-align: center;
-        color: var(--muted);
-        font-size: 13px;
-        padding: 1.5rem 0 0.5rem;
-        margin: 0;
-      }
-      .str-empty.hidden { display: none; }
-      @media (max-width: 720px) {
-        .str-top { grid-template-columns: 1fr; text-align: center; }
-        .str-cite { text-align: center; }
-        .str-metrics { grid-template-columns: repeat(2, 1fr); }
-      }
-
-      .brain-strip-card {
-        display: grid;
-        grid-template-columns: auto 1fr auto auto auto;
-        gap: 14px;
-        align-items: center;
-        padding: 12px 18px !important;
-        background: linear-gradient(180deg, rgba(60, 20, 110, 0.35) 0%, rgba(30, 10, 60, 0.45) 100%);
-        box-shadow: 0 0 0 1px rgba(168, 85, 247, 0.1) inset,
-          0 10px 30px -20px rgba(168, 85, 247, 0.55);
-      }
-      .brain-dot-sc {
-        width: 10px; height: 10px; border-radius: 50%;
-        background: #a855f7;
-        box-shadow: 0 0 14px #a855f7, 0 0 28px rgba(168, 85, 247, 0.5);
-        animation: pulse 2.2s ease-in-out infinite;
-      }
-      .brain-label-sc {
-        font-family: 'Playfair Display', serif;
-        font-size: 15px; color: #fff; line-height: 1.3;
-      }
-      .brain-label-sc em { color: #e9d5ff; font-style: italic; }
-      .brain-badge-sc {
-        font-family: 'DM Mono', monospace; font-size: 10px;
-        letter-spacing: 2px; text-transform: uppercase; color: #e9d5ff;
-        padding: 6px 12px; border-radius: 999px;
-        border: 1px solid rgba(168, 85, 247, 0.45);
-        background: rgba(168, 85, 247, 0.12); white-space: nowrap;
-      }
-      @media (max-width: 860px) {
-        .brain-strip-card { grid-template-columns: 1fr; text-align: center; }
-      }
-      .auth-card h2 {
-        font-size: 11px !important;
-        margin: 0 0 10px !important;
-      }
-      .auth-card label {
-        font-size: 10px;
-        letter-spacing: 1.5px;
-        text-transform: uppercase;
-        color: var(--muted);
-        display: block;
-        margin-bottom: 4px;
-      }
-      .auth-card input[type='password'] {
-        padding: 8px 10px;
-        font-size: 13px;
-        border-radius: 4px;
-        margin-bottom: 6px;
-      }
-      .auth-card .token-gen-btn {
-        height: 34px;
-        padding: 0 14px;
-        font-size: 11px;
-        line-height: 1;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-      }
-      .auth-card input[type='text'],
-      .auth-card input[type='password'] {
-        height: 34px;
-        padding: 0 12px;
-        font-size: 13px;
-        border-radius: 4px;
-        box-sizing: border-box;
-      }
-      .auth-card .token-row {
-        margin-top: 8px;
-      }
-      .auth-card .auth-icon-btn {
-        width: 34px;
-        height: 34px;
-        padding: 0;
-        font-size: 18px;
-        font-weight: 600;
-        line-height: 1;
-        flex: 0 0 auto;
-      }
-      .auth-card.authenticated {
-        background: linear-gradient(135deg, rgba(52, 211, 153, 0.18) 0%, rgba(52, 211, 153, 0.06) 100%);
-        border-color: var(--green) !important;
-        box-shadow: 0 0 0 1px var(--green) inset, 0 8px 24px rgba(52, 211, 153, 0.22);
-      }
-      .auth-card.authenticated h2 {
-        color: var(--green) !important;
-      }
-      .auth-card.authenticated .tag {
-        background: var(--green);
-        color: #0b0b0b;
-        border-color: var(--green);
-      }
-      .auth-body {
-        margin-top: 0;
-      }
-      .stat {
-        display: flex;
-        gap: 10px;
-        margin-bottom: 12px;
-        flex-wrap: wrap;
-      }
-      .stat-item {
-        flex: 1;
-        min-width: 110px;
-        text-align: center;
-        padding: 12px 8px;
-        background: var(--surface2);
-        border-radius: 4px;
-        border: 1px solid var(--border);
-      }
-      .stat-value {
-        font-size: 22px;
-        font-weight: 700;
-        color: var(--stat-color, var(--gold));
-        line-height: 1;
-      }
-      .stat-label {
-        font-size: 10px;
-        text-transform: uppercase;
-        color: var(--stat-color, var(--muted));
-        margin-top: 6px;
-        letter-spacing: 1px;
-        font-weight: 600;
-      }
-      .subject-row {
-        padding: 10px 0;
-        border-bottom: 1px solid var(--border);
-        display: flex;
-        align-items: center;
-        gap: 10px;
-        flex-wrap: wrap;
-      }
-      .subject-row:last-child {
-        border-bottom: none;
-      }
-      .subject-info {
-        flex: 1;
-        min-width: 150px;
-      }
-      .subject-name {
-        font-weight: 500;
-        font-size: 14px;
-        word-break: break-word;
-      }
-      .subject-id {
-        font-size: 10px;
-        color: var(--muted);
-        font-family: 'DM Mono', 'Courier New', monospace;
-        margin-top: 2px;
-      }
-      .compliance-description {
-        margin-top: 8px;
-        padding: 8px 12px;
-        background: rgba(168, 85, 247, 0.06);
-        border-left: 2px solid var(--accent);
-        border-radius: 0 4px 4px 0;
-        font-size: 11px;
-        line-height: 1.55;
-        color: var(--ice, #c9d6e8);
-      }
-      .compliance-line { margin-bottom: 3px; }
-      .compliance-line:last-child { margin-bottom: 0; }
-      .compliance-line b { color: var(--accent); font-weight: 600; }
-      .compliance-flag {
-        display: inline-block;
-        padding: 1px 8px;
-        border-radius: 4px;
-        font-family: 'DM Mono', monospace;
-        font-size: 10px;
-        letter-spacing: 0.5px;
-        font-weight: 600;
-        margin-left: 4px;
-      }
-      .compliance-flag-clean { background: rgba(34, 197, 94, 0.15); color: #22c55e; border: 1px solid rgba(34, 197, 94, 0.4); }
-      .compliance-flag-hit { background: rgba(239, 68, 68, 0.15); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.4); }
-
-      /* STR modal */
-      .str-modal {
-        position: fixed; inset: 0; z-index: 9999;
-        background: rgba(2, 4, 10, 0.82);
-        display: flex; align-items: center; justify-content: center;
-        padding: 20px;
-      }
-      .str-modal[hidden] { display: none; }
-      .str-modal-card {
-        background: #0a0812;
-        border: 1px solid var(--gold);
-        border-radius: 10px;
-        padding: 26px;
-        width: 100%; max-width: 560px;
-        max-height: 90vh; overflow-y: auto;
-        position: relative;
-        box-shadow: 0 16px 40px rgba(0,0,0,0.6);
-      }
-      .str-modal-card-wide { max-width: 780px; }
-      .str-redflags {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        gap: 8px 18px;
-        max-height: 180px;
-        overflow-y: auto;
-        padding: 10px 12px;
-        border: 1px solid var(--border);
-        border-radius: 4px;
-        background: rgba(10, 10, 14, 0.55);
-      }
-      .str-redflag {
-        display: flex;
-        align-items: flex-start;
-        gap: 8px;
-        font-size: 12px;
-        line-height: 1.35;
-        color: var(--mist);
-        font-family: inherit;
-        letter-spacing: 0;
-        text-transform: none;
-        cursor: pointer;
-      }
-      .str-redflag input[type=checkbox] {
-        width: auto;
-        margin: 2px 0 0;
-        accent-color: var(--gold);
-        flex-shrink: 0;
-      }
-      @media (max-width: 640px) {
-        .str-redflags { grid-template-columns: 1fr; max-height: 220px; }
-      }
-      .str-modal-close {
-        position: absolute; top: 10px; right: 10px;
-        background: transparent; border: 0; cursor: pointer;
-        color: var(--muted); font-size: 24px; line-height: 1;
-        width: 32px; height: 32px;
-      }
-      .str-modal-close:hover { color: #fff; }
-      .str-modal-title {
-        font-family: 'Playfair Display', serif;
-        font-size: 22px; margin: 0 0 4px; color: var(--gold);
-      }
-      .str-modal-cite {
-        font-family: 'DM Mono', monospace;
-        font-size: 10px; letter-spacing: 1px;
-        color: var(--muted); margin: 0 0 18px;
-      }
-      .str-modal-row { margin-bottom: 14px; }
-      .str-modal-row-2 {
-        display: grid; grid-template-columns: 1fr 1fr;
-        gap: 12px; margin-bottom: 14px;
-      }
-      .str-modal-row label, .str-modal-row-2 label {
-        display: block; font-family: 'DM Mono', monospace;
-        font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase;
-        color: var(--muted); margin-bottom: 4px;
-      }
-      .str-modal-row input, .str-modal-row textarea,
-      .str-modal-row-2 input, .str-modal-row-2 select {
-        width: 100%; box-sizing: border-box;
-        padding: 8px 10px; font-size: 13px;
-        background: rgba(10, 10, 14, 0.8);
-        border: 1px solid var(--border);
-        border-radius: 4px; color: var(--mist);
-        font-family: inherit;
-      }
-      .str-modal-row textarea { resize: vertical; min-height: 80px; }
-      .str-modal-actions {
-        display: flex; gap: 10px; justify-content: flex-end;
-        margin-top: 18px;
-      }
-      .str-modal-btn {
-        padding: 8px 16px; font-size: 12px;
-        font-family: 'DM Mono', monospace;
-        letter-spacing: 1.5px; text-transform: uppercase;
-        border-radius: 4px; cursor: pointer;
-        border: 1px solid var(--border); background: transparent;
-      }
-      .str-modal-btn-primary {
-        color: var(--gold); border-color: var(--gold);
-        background: rgba(212, 175, 55, 0.1);
-      }
-      .str-modal-btn-primary:hover { background: rgba(212, 175, 55, 0.22); color: #fff; }
-      .str-modal-btn-secondary { color: var(--muted); }
-      .str-modal-btn-secondary:hover { color: #fff; border-color: var(--mist); }
-      .str-modal-help {
-        font-size: 10px; color: var(--muted);
-        margin: 14px 0 0; font-family: 'DM Mono', monospace;
-        letter-spacing: 0.3px;
-      }
-      .str-modal-help code { color: var(--accent); }
-      .subject-details {
-        margin-top: 10px;
-        padding: 10px 12px;
-        background: rgba(168, 85, 247, 0.05);
-        border: 1px solid rgba(168, 85, 247, 0.2);
-        border-radius: 4px;
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-        gap: 8px 16px;
-      }
-      .subject-detail-item {
-        font-size: 11px;
-      }
-      .subject-detail-label {
-        color: var(--muted);
-        text-transform: uppercase;
-        font-size: 9px;
-        letter-spacing: 0.8px;
-        margin-bottom: 2px;
-      }
-      .subject-detail-value {
-        color: var(--text);
-        font-weight: 500;
-        word-break: break-word;
-      }
-      .asana-destination {
-        margin-top: 10px;
-        padding: 8px 12px;
-        background: rgba(74, 144, 226, 0.06);
-        border-left: 3px solid var(--blue);
-        border-radius: 2px;
-        font-size: 11px;
-        color: var(--muted);
-      }
-      .asana-destination strong {
-        color: var(--text);
-      }
-      .asana-destination a {
-        color: var(--blue);
-        text-decoration: none;
-      }
-      .asana-destination a:hover {
-        text-decoration: underline;
-      }
-      .subject-actions {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        margin-left: auto;
-        flex-shrink: 0;
-      }
-      .classification {
-        font-size: 10px;
-        padding: 3px 8px;
-        border-radius: 3px;
-        text-transform: uppercase;
-        font-weight: 700;
-        letter-spacing: 0.5px;
-        white-space: nowrap;
-      }
-      .classification.confirmed {
-        background: rgba(217, 79, 79, 0.18);
-        color: var(--red);
-      }
-      .classification.potential {
-        background: rgba(232, 160, 48, 0.18);
-        color: var(--amber);
-      }
-      .classification.weak {
-        background: rgba(74, 144, 226, 0.15);
-        color: var(--blue);
-      }
-      .classification.none {
-        background: rgba(61, 168, 118, 0.12);
-        color: var(--green);
-      }
-      .btn-delete-subject {
-        background: transparent;
-        border: none;
-        color: var(--red);
-        font-size: 18px;
-        line-height: 1;
-        padding: 0 4px;
-        cursor: pointer;
-        font-weight: 700;
-        transition: opacity 0.12s ease;
-      }
-      .btn-delete-subject:hover {
-        opacity: 0.7;
-      }
-      .btn-delete-subject:disabled {
-        opacity: 0.4;
-        cursor: not-allowed;
-      }
-      .list-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-        gap: 8px;
-        margin-top: 8px;
-      }
-      .list-item {
-        padding: 10px;
-        background: var(--surface2);
-        border: 1px solid var(--border);
-        border-radius: 4px;
-        font-size: 12px;
-      }
-      .list-item .list-name {
-        font-weight: 600;
-        color: var(--gold);
-        font-size: 11px;
-        letter-spacing: 0.5px;
-        text-transform: uppercase;
-      }
-      .list-item .list-score {
+      .card-cta-arrow {
         font-size: 16px;
-        font-weight: 600;
-        margin-top: 4px;
+        transition: transform 0.2s ease;
       }
-      .list-item .list-count {
-        font-size: 10px;
-        color: var(--muted);
+      .card:hover .card-cta-arrow { transform: translateX(4px); }
+
+      .module-view {
+        display: none;
+        margin-top: 1.5rem;
+        border-radius: 16px;
+        border: 1px solid var(--border);
+        background: rgba(18, 10, 32, 0.6);
+        backdrop-filter: blur(18px);
+        -webkit-backdrop-filter: blur(18px);
+        overflow: hidden;
       }
-      .hit-row {
-        padding: 8px 10px;
-        background: var(--surface2);
-        border-radius: 4px;
-        margin-top: 6px;
-        font-size: 12px;
+      .module-view.is-open { display: block; }
+      .module-view-head {
         display: flex;
+        align-items: center;
         justify-content: space-between;
-        gap: 8px;
-        flex-wrap: wrap;
-      }
-      .hit-row .hit-name {
-        flex: 1;
-        min-width: 140px;
-        word-break: break-word;
-      }
-      .hit-row .hit-score {
-        font-family: 'DM Mono', 'Courier New', monospace;
-        color: var(--gold);
-      }
-      .btn-resolve-subject,
-      .btn-resolve-dismiss,
-      .btn-resolve-save,
-      .btn-resolve-cancel {
-        background: transparent;
-        color: var(--gold);
-        border: 1px solid var(--gold);
-        border-radius: 4px;
-        padding: 4px 10px;
-        font-size: 11px;
-        cursor: pointer;
-        width: auto;
-        min-height: 0;
-        margin: 0 0 0 6px;
-      }
-      .btn-resolve-subject:hover,
-      .btn-resolve-save:hover {
-        background: rgba(212, 175, 55, 0.15);
-      }
-      .btn-resolve-dismiss,
-      .btn-resolve-cancel {
-        color: var(--muted);
-        border-color: var(--border);
-      }
-      .btn-resolve-dismiss:hover,
-      .btn-resolve-cancel:hover {
-        color: var(--text);
-        background: rgba(255, 255, 255, 0.04);
-      }
-      .resolve-form {
-        flex-basis: 100%;
-        margin-top: 8px;
-        padding: 10px;
-        background: var(--surface);
-        border: 1px solid var(--border);
-        border-radius: 4px;
-      }
-      .resolve-form[hidden] {
-        display: none;
-      }
-      .resolve-form-grid {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        gap: 8px;
-      }
-      .resolve-form-grid label {
-        display: flex;
-        flex-direction: column;
-        font-size: 11px;
-        color: var(--muted);
-        gap: 3px;
-      }
-      .resolve-form-grid label.span2 {
-        grid-column: span 2;
-      }
-      .resolve-form-grid input,
-      .resolve-form-grid select,
-      .resolve-form-grid textarea {
-        background: var(--surface2);
-        border: 1px solid var(--border);
-        color: var(--text);
-        padding: 6px 8px;
-        border-radius: 3px;
-        font-size: 12px;
-        font-family: inherit;
-      }
-      .resolve-form-actions {
-        display: flex;
-        align-items: center;
-        gap: 6px;
-        margin-top: 10px;
-      }
-      .resolve-status {
-        font-size: 11px;
-        margin-left: 8px;
-      }
-      .factor-row {
-        padding: 6px 0;
-        border-bottom: 1px dashed var(--border);
-        font-size: 12px;
-      }
-      .factor-row:last-child {
-        border-bottom: none;
-      }
-      .factor-row .factor-name {
-        color: var(--text);
-        font-weight: 500;
-      }
-      .factor-row .factor-reg {
-        color: var(--muted);
-        font-size: 10px;
-        display: block;
-        margin-top: 2px;
-      }
-      .factor-row .factor-contrib {
-        float: right;
-        color: var(--gold);
-        font-family: 'DM Mono', 'Courier New', monospace;
-      }
-      .alert-row {
-        padding: 10px;
-        background: var(--surface2);
-        border-left: 3px solid var(--amber);
-        margin-top: 8px;
-        border-radius: 4px;
-        font-size: 12px;
-      }
-      .alert-row.critical {
-        border-left-color: var(--red);
-      }
-      .alert-row.high {
-        border-left-color: var(--amber);
-      }
-      .alert-row.medium {
-        border-left-color: var(--blue);
-      }
-      .alert-row .alert-rule {
-        font-weight: 600;
-        color: var(--text);
-      }
-      .alert-row .alert-reg {
-        color: var(--muted);
-        font-size: 10px;
-        margin-top: 4px;
-      }
-      .alert-row .alert-message {
-        margin-top: 6px;
-        line-height: 1.5;
-      }
-      .tx-row {
-        padding: 10px;
-        background: var(--surface2);
-        border-radius: 4px;
-        margin-top: 8px;
-        font-size: 12px;
-        display: grid;
-        grid-template-columns: 1fr auto auto auto;
-        gap: 8px;
-        align-items: center;
-      }
-      .footer {
-        text-align: center;
-        margin-top: 30px;
-        color: var(--muted);
-        font-size: 11px;
-        letter-spacing: 0.5px;
-      }
-      .footer a {
-        color: var(--gold);
-        text-decoration: none;
-      }
-      .row-2 {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
         gap: 12px;
+        padding: 14px 18px;
+        border-bottom: 1px solid var(--border);
+        background: rgba(36, 21, 56, 0.55);
       }
-      .row-3 {
-        display: grid;
-        grid-template-columns: 1fr 1fr 1fr;
-        gap: 12px;
-      }
-      @media (max-width: 500px) {
-        .row-2,
-        .row-3 {
-          grid-template-columns: 1fr;
-        }
-      }
-      .spinner {
-        display: inline-block;
-        width: 12px;
-        height: 12px;
-        border: 2px solid var(--border-strong);
-        border-top-color: var(--gold);
-        border-radius: 50%;
-        animation: spin 0.8s linear infinite;
-        vertical-align: middle;
-        margin-right: 6px;
-      }
-      @keyframes spin {
-        to {
-          transform: rotate(360deg);
-        }
-      }
-      details {
-        margin-top: 10px;
-      }
-      summary {
-        cursor: pointer;
-        color: var(--gold);
-        font-size: 12px;
-        padding: 6px 0;
-      }
-      .help-text {
-        color: var(--muted);
-        font-size: 11px;
-        margin-top: 6px;
-        line-height: 1.5;
-      }
-      /* List selector panels (mandatory vs enhanced) */
-      .list-tier {
-        border-left: 3px solid var(--blue);
-      }
-      .list-tier.enhanced {
-        border-left-color: var(--blue);
-      }
-      .list-tier h2 .tier-badge {
-        font-size: 9px;
-        padding: 2px 5px;
-        border-radius: 2px;
-        letter-spacing: 1px;
-        background: rgba(74, 144, 226, 0.2);
-        color: var(--blue);
-      }
-      .list-tier.enhanced h2 .tier-badge {
-        background: rgba(74, 144, 226, 0.2);
-        color: var(--blue);
-      }
-      .list-check {
-        display: flex;
-        align-items: flex-start;
-        gap: 10px;
-        padding: 10px 8px;
-        margin: 0 -8px;
-        border-top: 1px solid var(--border);
-        cursor: pointer;
-        border-radius: 4px;
-        transition: background-color 0.18s ease;
-      }
-      .list-check:first-of-type {
-        border-top: none;
-      }
-      .list-check:hover:not(.locked):not(.disabled) {
-        background-color: rgba(255, 255, 255, 0.03);
-      }
-      .list-check:active:not(.locked):not(.disabled) {
-        background-color: rgba(255, 255, 255, 0.06);
-      }
-      .list-check input[type='checkbox'] {
-        appearance: none;
-        -webkit-appearance: none;
-        margin-top: 3px;
-        width: 14px;
-        height: 14px;
-        min-width: 14px;
-        padding: 0;
-        font-size: 0;
-        flex-shrink: 0;
-        border: 1.5px solid var(--blue);
-        border-radius: 3px;
-        background: transparent;
-        cursor: pointer;
-        position: relative;
-        transition:
-          background-color 0.18s ease,
-          border-color 0.18s ease,
-          box-shadow 0.18s ease,
-          transform 0.12s ease;
-      }
-      .list-check:hover input[type='checkbox']:not(:disabled) {
-        transform: scale(1.04);
-      }
-      .list-check input[type='checkbox']:checked {
-        background: linear-gradient(135deg, #5aa0ea 0%, var(--blue) 100%);
-        border-color: var(--blue);
-        box-shadow:
-          0 0 0 2px rgba(74, 144, 226, 0.15),
-          0 2px 6px rgba(74, 144, 226, 0.35);
-      }
-      .list-check input[type='checkbox']:checked::after {
-        content: '';
-        position: absolute;
-        left: 50%;
-        top: 50%;
-        width: 3px;
-        height: 7px;
-        border: solid #fff;
-        border-width: 0 2px 2px 0;
-        transform: translate(-50%, -60%) rotate(45deg);
-      }
-      .list-check input[type='checkbox']:focus-visible {
-        outline: 2px solid var(--blue);
-        outline-offset: 2px;
-      }
-      .list-check.locked {
-        cursor: not-allowed;
-        opacity: 1;
-      }
-      .list-check.locked input[type='checkbox'] {
-        opacity: 1;
-        cursor: not-allowed;
-      }
-      .list-check.disabled {
-        opacity: 0.85;
-        cursor: not-allowed;
-      }
-      .list-check.disabled input[type='checkbox'] {
-        opacity: 1;
-        cursor: not-allowed;
-      }
-      .list-check .list-label {
-        font-size: 13px;
-        line-height: 1.4;
-      }
-      .list-check .list-sub {
-        display: block;
-        font-size: 10px;
-        color: var(--muted);
-        margin-top: 2px;
-      }
-      .list-footnote {
-        color: var(--muted);
-        font-size: 10px;
-        margin-top: 10px;
-        line-height: 1.5;
-        padding-top: 8px;
-        border-top: 1px dashed var(--border);
-      }
-      .list-refresh {
-        position: absolute;
-        top: 14px;
-        right: 14px;
-        width: 26px;
-        height: 26px;
-        min-height: 0;
-        margin: 0;
-        padding: 0;
-        appearance: none;
-        background: transparent;
-        color: var(--blue);
-        border: 1px solid rgba(74, 144, 226, 0.5);
-        border-radius: 50%;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        cursor: pointer;
-        transition:
-          background-color 0.18s ease,
-          border-color 0.18s ease,
-          box-shadow 0.18s ease,
-          transform 0.3s ease;
-      }
-      .list-refresh svg {
-        width: 14px;
-        height: 14px;
-        display: block;
-        /* The SVG is decorative — bubble clicks to the <button>. */
-        pointer-events: none;
-      }
-      .list-refresh:hover {
-        background: rgba(74, 144, 226, 0.12);
-        border-color: var(--blue);
-        box-shadow: 0 0 0 2px rgba(74, 144, 226, 0.15);
-        transform: rotate(90deg);
-      }
-      .list-refresh:active {
-        transform: rotate(180deg);
-      }
-      .list-refresh:focus-visible {
-        outline: 2px solid var(--blue);
-        outline-offset: 2px;
-      }
-      /* Disposition section (hidden until a screening result is rendered) */
-      .disposition {
-        margin-top: 16px;
-        padding-top: 16px;
-        border-top: 1px dashed var(--border-strong);
-        display: none;
-      }
-      .disposition.active {
-        display: block;
-      }
-      .coverage-card {
-        border-left: 3px solid #a855f7;
-      }
-      .coverage-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-        gap: 14px 26px;
-        margin-top: 4px;
-      }
-      .coverage-grid .c-h {
+      .module-view-title {
         font-family: 'Playfair Display', serif;
-        font-size: 11.5px;
-        font-weight: 600;
-        letter-spacing: 1.3px;
-        text-transform: uppercase;
-        color: #a855f7;
-        margin-bottom: 4px;
-      }
-      .coverage-grid .c-sub {
-        color: var(--muted);
-        font-size: 12px;
-        line-height: 1.55;
-      }
-      .coverage-grid .c-sub b {
-        color: var(--text);
-        font-weight: 500;
-      }
-      .coverage-grid > .coverage-wide {
-        grid-column: 1 / -1;
-        padding-top: 10px;
-        margin-top: 2px;
-        border-top: 1px dashed var(--border);
-      }
-      .coverage-foot {
-        margin-top: 2px;
-        padding-top: 0;
-        font-size: 11px;
-        color: var(--muted);
-      }
-      .disposition h3 {
-        color: var(--gold);
-        font-size: 13px;
-        font-weight: 500;
-        margin-bottom: 10px;
-        text-transform: uppercase;
-        letter-spacing: 1px;
-      }
-      .outcome-grid {
-        display: grid;
-        grid-template-columns: repeat(2, 1fr);
-        gap: 10px;
-        margin-top: 6px;
-      }
-      @media (min-width: 860px) {
-        .outcome-grid {
-          grid-template-columns: repeat(4, 1fr);
-        }
-      }
-      .outcome-btn {
-        position: relative;
-        background: var(--surface);
-        border: 1px solid var(--border);
-        color: var(--text);
-        padding: 14px 14px 12px;
-        border-radius: 4px;
-        cursor: pointer;
-        display: flex;
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 8px;
-        text-align: left;
-        line-height: 1.3;
-        transition:
-          border-color 0.15s ease,
-          background 0.15s ease,
-          transform 0.08s ease;
-      }
-      .outcome-btn:hover {
-        border-color: var(--border-strong);
-        background: var(--surface2);
-      }
-      .outcome-btn:active {
-        transform: translateY(1px);
-      }
-      .outcome-btn .outcome-head {
-        display: flex;
-        align-items: center;
-        gap: 10px;
-        width: 100%;
-      }
-      .outcome-btn .glyph {
-        width: 26px;
-        height: 26px;
-        border-radius: 50%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        font-size: 14px;
         font-weight: 700;
-        color: var(--bg);
-        flex-shrink: 0;
-        background: var(--muted);
-        font-family: 'DM Mono', ui-monospace, monospace;
-      }
-      .outcome-btn .label {
-        font-family: 'Playfair Display', serif;
-        font-size: 12px;
-        font-weight: 600;
-        letter-spacing: 1.2px;
-        text-transform: uppercase;
-        color: var(--text);
-      }
-      .outcome-btn .impact {
-        font-size: 11px;
-        color: var(--muted);
-        line-height: 1.35;
-        letter-spacing: 0.2px;
-      }
-      .outcome-btn[data-outcome='negative_no_match'] .glyph {
-        background: var(--green);
-      }
-      .outcome-btn[data-outcome='false_positive'] .glyph {
-        background: var(--muted);
-      }
-      .outcome-btn[data-outcome='partial_match'] .glyph {
-        background: var(--amber);
-      }
-      .outcome-btn[data-outcome='confirmed_match'] .glyph {
-        background: var(--red);
-        color: var(--text);
-      }
-      .outcome-btn.selected {
-        box-shadow: 0 0 0 1px currentColor inset;
-      }
-      .outcome-btn.selected[data-outcome='negative_no_match'] {
-        border-color: var(--green);
-        background: rgba(61, 168, 118, 0.14);
-        color: var(--green);
-      }
-      .outcome-btn.selected[data-outcome='false_positive'] {
-        border-color: rgba(245, 240, 232, 0.45);
-        background: rgba(245, 240, 232, 0.06);
-        color: var(--text);
-      }
-      .outcome-btn.selected[data-outcome='partial_match'] {
-        border-color: var(--amber);
-        background: rgba(232, 160, 48, 0.14);
-        color: var(--amber);
-      }
-      .outcome-btn.selected[data-outcome='confirmed_match'] {
-        border-color: var(--red);
-        background: rgba(217, 79, 79, 0.16);
-        color: var(--red);
-      }
-      .outcome-btn.selected .label,
-      .outcome-btn.selected .impact {
-        color: var(--text);
-      }
-      /* Post-save compliance-disposition report. Adapts border colour
-         to outcome severity so the MLRO sees the level at a glance. */
-      .compliance-report {
-        margin-top: 16px;
-        padding: 18px 20px;
-        border: 2px solid var(--border);
-        border-radius: 8px;
-        background: var(--surface);
-        font-size: 13px;
-        line-height: 1.55;
-      }
-      .compliance-report.level-clear {
-        border-color: var(--green);
-      }
-      .compliance-report.level-false {
-        border-color: rgba(245, 240, 232, 0.45);
-      }
-      .compliance-report.level-escalate {
-        border-color: var(--amber);
-      }
-      .compliance-report.level-freeze {
-        border-color: var(--red);
-      }
-      .compliance-report h3 {
-        margin: 0 0 4px 0;
-        font-family: 'Playfair Display', serif;
-        font-size: 14px;
-        letter-spacing: 1px;
-        text-transform: uppercase;
-        color: var(--gold);
-      }
-      .compliance-report h4 {
-        margin: 14px 0 4px 0;
-        font-family: 'DM Mono', monospace;
-        font-size: 11px;
-        letter-spacing: 1.5px;
-        text-transform: uppercase;
-        color: var(--muted);
-      }
-      .compliance-report .cr-banner {
-        margin: 10px 0;
-        padding: 10px 12px;
-        border-radius: 4px;
-        font-weight: 600;
-      }
-      .compliance-report .cr-banner.freeze {
-        background: rgba(217, 79, 79, 0.14);
-        color: var(--red);
-        border: 1px solid var(--red);
-      }
-      .compliance-report .cr-banner.escalate {
-        background: rgba(232, 160, 48, 0.14);
-        color: var(--amber);
-        border: 1px solid var(--amber);
-      }
-      .compliance-report .cr-banner.clear {
-        background: rgba(61, 168, 118, 0.12);
-        color: var(--green);
-        border: 1px solid var(--green);
-      }
-      .compliance-report dl {
-        display: grid;
-        grid-template-columns: max-content 1fr;
-        gap: 4px 14px;
-        margin: 6px 0 0 0;
-      }
-      .compliance-report dt {
-        color: var(--muted);
-        font-family: 'DM Mono', monospace;
-        font-size: 11px;
-        letter-spacing: 0.5px;
-        text-transform: uppercase;
-      }
-      .compliance-report dd {
+        font-size: 20px;
+        color: var(--mist);
         margin: 0;
-        color: var(--text);
-        word-break: break-word;
       }
-      .compliance-report .cr-rationale,
-      .compliance-report .cr-findings {
-        margin: 6px 0 0 0;
-        padding: 10px 12px;
-        background: var(--bg-elev);
-        border-left: 3px solid var(--border);
-        white-space: pre-wrap;
-        font-family: 'DM Mono', monospace;
-        font-size: 12px;
-      }
-      .compliance-report .cr-footer {
-        margin-top: 14px;
-        padding-top: 10px;
-        border-top: 1px solid var(--border);
-        font-size: 11px;
-        color: var(--muted);
-      }
-      .compliance-report .cr-actions {
-        display: flex;
-        gap: 8px;
-        margin-top: 12px;
-        flex-wrap: wrap;
-      }
-      .compliance-report .cr-actions button,
-      .compliance-report .cr-actions a {
-        flex: 1;
-        min-width: 160px;
-        padding: 10px 14px;
-        border-radius: 4px;
+      .module-view-close {
         font-family: 'DM Mono', monospace;
         font-size: 11px;
-        letter-spacing: 1px;
-        text-transform: uppercase;
-        text-align: center;
-        cursor: pointer;
-        text-decoration: none;
-      }
-      .compliance-report .cr-pdf-btn {
-        background: transparent;
-        border: 1px solid var(--gold);
-        color: var(--gold);
-      }
-      .compliance-report .cr-pdf-btn:hover {
-        background: rgba(168, 85, 247, 0.08);
-      }
-      .compliance-report .cr-asana-link {
-        background: transparent;
-        border: 1px solid #273a58;
-        color: #4a90e2;
-      }
-      .compliance-report .cr-asana-link:hover {
-        background: rgba(74, 144, 226, 0.08);
-      }
-      .disposition-preview {
-        margin-top: 12px;
-        padding: 12px 14px;
-        border: 1px solid var(--border);
-        border-left: 3px solid var(--gold);
-        border-radius: 3px;
-        background: var(--surface);
-        display: grid;
-        grid-template-columns: minmax(110px, auto) 1fr;
-        column-gap: 14px;
-        row-gap: 6px;
-        font-size: 12px;
-      }
-      .disposition-preview .dp-label {
-        color: var(--gold);
-        text-transform: uppercase;
-        letter-spacing: 1px;
-        font-size: 10px;
-        font-weight: 600;
-        padding-top: 2px;
-      }
-      .disposition-preview .dp-value {
-        color: var(--text);
-        line-height: 1.45;
-      }
-      .disposition-preview .dp-value.muted {
-        color: var(--muted);
-        font-style: italic;
-      }
-      .disposition-preview .dp-value strong {
-        color: var(--gold);
-      }
-      .disposition-preview.level-freeze {
-        border-left-color: var(--red);
-        background: rgba(217, 79, 79, 0.06);
-      }
-      .disposition-preview.level-escalate {
-        border-left-color: var(--amber);
-        background: rgba(232, 160, 48, 0.06);
-      }
-      .disposition-preview.level-clear {
-        border-left-color: var(--green);
-        background: rgba(61, 168, 118, 0.06);
-      }
-      .char-counter {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        gap: 10px;
-        font-size: 11px;
-        color: var(--muted);
-        margin-top: 4px;
-      }
-      .char-counter .count {
-        font-family: 'DM Mono', ui-monospace, monospace;
-        color: var(--text);
-      }
-      .char-counter.short .count {
-        color: var(--red);
-      }
-      .char-counter.ok .count {
-        color: var(--green);
-      }
-      .four-eyes {
-        margin-top: 14px;
-        padding: 14px 16px;
-        border-left: 3px solid var(--amber);
-        border-radius: 4px;
-        background: rgba(232, 160, 48, 0.06);
-        display: none;
-      }
-      .four-eyes.required {
-        display: block;
-      }
-      .four-eyes h4 {
-        margin: 0 0 6px 0;
-        font-family: 'Playfair Display', serif;
-        font-size: 13px;
         letter-spacing: 2px;
         text-transform: uppercase;
-        color: var(--amber);
-      }
-      .four-eyes p {
-        font-size: 12.5px;
-        line-height: 1.55;
-        color: var(--muted);
-        margin: 0 0 10px 0;
-      }
-      .four-eyes label {
-        display: block;
-        font-size: 11px;
-        font-weight: 600;
-        letter-spacing: 1.5px;
-        text-transform: uppercase;
-        color: var(--muted);
-        margin: 8px 0 4px 0;
-      }
-      .four-eyes input[type='text'] {
-        width: 100%;
-        padding: 9px 12px;
-        border-radius: 4px;
-        background: rgba(0, 0, 0, 0.25);
-        border: 1px solid var(--hairline);
-        color: var(--text);
-        font-family: 'DM Mono', ui-monospace, monospace;
-        font-size: 13px;
-      }
-      .four-eyes .ack {
-        display: flex;
-        gap: 8px;
-        align-items: flex-start;
-        margin-top: 10px;
-        font-size: 12px;
-      }
-      .action-row {
-        display: grid;
-        grid-template-columns: 1fr;
-        gap: 8px;
-        margin-top: 12px;
-      }
-      @media (min-width: 560px) {
-        .action-row {
-          grid-template-columns: 2fr 2fr 1fr;
-        }
-      }
-      button.btn-save,
-      button.btn-rerun,
-      button.btn-cancel {
-        font-family: 'Playfair Display', serif;
-        font-size: 12px;
-        font-weight: 600;
-        letter-spacing: 2.4px;
-        text-transform: uppercase;
-        padding: 13px 18px;
-        border-radius: 4px;
+        color: var(--steel);
+        background: transparent;
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        padding: 7px 14px;
         cursor: pointer;
-        transition:
-          transform 0.08s ease,
-          box-shadow 0.18s ease,
-          background 0.18s ease,
-          border-color 0.18s ease;
-        position: relative;
+        transition: all 0.2s ease;
       }
-      button.btn-save {
-        background: var(--gold-grad);
-        color: #ffffff;
-        border: 1px solid rgba(232, 121, 249, 0.5);
-        box-shadow:
-          0 1px 0 rgba(255, 255, 255, 0.2) inset,
-          0 -1px 0 rgba(0, 0, 0, 0.25) inset,
-          0 8px 20px rgba(168, 85, 247, 0.35);
+      .module-view-close:hover {
+        color: var(--mist);
+        border-color: var(--azure-bright);
+        box-shadow: 0 0 0 4px rgba(168, 85, 247, 0.12);
       }
-      button.btn-save:hover {
-        transform: translateY(-1px);
-        box-shadow:
-          0 1px 0 rgba(255, 255, 255, 0.25) inset,
-          0 -1px 0 rgba(0, 0, 0, 0.25) inset,
-          0 14px 30px rgba(168, 85, 247, 0.3);
+      .module-view-frame {
+        width: 100%;
+        height: 78vh;
+        min-height: 640px;
+        border: 0;
+        background: var(--midnight);
+        display: block;
       }
-      button.btn-save:active {
-        transform: translateY(0);
+
+      .reg-basis {
+        margin-top: 2.5rem;
+        padding: 1.25rem 1.5rem;
+        border-radius: 14px;
+        border: 1px solid var(--border);
+        background: rgba(36, 21, 56, 0.45);
+        backdrop-filter: blur(18px);
+        -webkit-backdrop-filter: blur(18px);
       }
-      button.btn-rerun {
-        background: rgba(74, 144, 226, 0.1);
-        color: var(--blue);
-        border: 1px solid rgba(74, 144, 226, 0.5);
-        box-shadow: 0 1px 0 rgba(255, 255, 255, 0.04) inset;
+      .reg-title {
+        font-family: 'DM Mono', monospace;
+        font-size: 10.5px;
+        letter-spacing: 2.5px;
+        text-transform: uppercase;
+        color: var(--azure-bright);
+        margin-bottom: 8px;
       }
-      button.btn-rerun:hover {
-        background: rgba(74, 144, 226, 0.16);
-        border-color: rgba(74, 144, 226, 0.75);
+      .reg-text {
+        color: var(--ice);
+        font-size: 13px;
+        line-height: 1.65;
+        opacity: 0.82;
       }
-      button.btn-cancel {
-        background: transparent;
+      .reg-text strong { color: var(--mist); }
+
+      .footer {
+        margin-top: auto;
+        padding: 1.5rem 2rem;
+        border-top: 1px solid var(--border);
+        background: rgba(12, 6, 20, 0.5);
+        display: flex;
+        justify-content: space-between;
+        font-family: 'DM Mono', monospace;
+        font-size: 10.5px;
+        letter-spacing: 2px;
+        text-transform: uppercase;
         color: var(--muted);
-        border: 1px solid var(--border-strong);
-      }
-      button.btn-cancel:hover {
-        color: var(--text);
-        border-color: var(--hairline);
-      }
-      button.btn-save[disabled],
-      button.btn-rerun[disabled] {
-        opacity: 0.5;
-        cursor: not-allowed;
-      }
-      input[type='text'],
-      input[type='date'],
-      input[type='email'],
-      input[type='number'],
-      textarea,
-      select {
-        transition:
-          border-color 0.15s ease,
-          box-shadow 0.15s ease,
-          background 0.15s ease;
-      }
-      input[type='number']::-webkit-inner-spin-button,
-      input[type='number']::-webkit-outer-spin-button {
-        -webkit-appearance: none;
-        appearance: none;
-        margin: 0;
-      }
-      input[type='number'] {
-        -moz-appearance: textfield;
-        appearance: textfield;
-      }
-      input[type='text']:focus,
-      input[type='date']:focus,
-      input[type='email']:focus,
-      input[type='number']:focus,
-      textarea:focus,
-      select:focus {
-        outline: none;
-        border-color: var(--gold) !important;
-        box-shadow:
-          0 0 0 1px rgba(168, 85, 247, 0.2),
-          0 0 0 4px rgba(168, 85, 247, 0.08);
-      }
-      ::selection {
-        background: rgba(168, 85, 247, 0.3);
-        color: var(--text);
-      }
-      /* Refined scrollbar for the luxury language. */
-      ::-webkit-scrollbar {
-        width: 10px;
-        height: 10px;
-      }
-      ::-webkit-scrollbar-track {
-        background: transparent;
-      }
-      ::-webkit-scrollbar-thumb {
-        background: var(--hairline);
-        border-radius: 10px;
-        border: 2px solid var(--bg);
-      }
-      ::-webkit-scrollbar-thumb:hover {
-        background: var(--border-strong);
       }
     </style>
   </head>
   <body>
-    <header>
-      <div class="title-group">
-        <img
-          src="assets/logos/hawkeye-icon.svg"
-          alt="Hawkeye Sterling"
-          class="header-logo"
-          width="56"
-          height="56"
-        />
-        <h1>Hawkeye Sterling V2 &mdash; Screening Command</h1>
-      </div>
-      <a href="/" class="muted">&larr; Main tool</a>
-    </header>
-    <div
-      id="sanctionsStaleBanner"
-      role="status"
-      hidden
-      style="
-        margin: 12px 24px 0;
-        padding: 10px 14px;
-        border: 1px solid var(--azure);
-        border-left: 3px solid var(--sky);
-        border-radius: 3px;
-        background: rgba(168, 85, 247, 0.08);
-        color: var(--mist);
-        font-size: 13px;
-        line-height: 1.4;
-      "
-    ></div>
-    <script>
-      // Sanctions-list freshness banner. Reads the same localStorage key
-      // the legacy TFS tab wrote to (fgl_tfs_lists) and surfaces the count
-      // of lists past the 24h refresh window. FATF Rec 6-7 / FDL Art.35 /
-      // Cabinet Res 74/2020 Art.4 — screening on stale lists is a finding.
-      (function () {
-        try {
-          var key = 'fgl_tfs_lists';
-          var raw = null;
-          try {
-            raw = localStorage.getItem(key);
-          } catch (_) {
-            return;
-          }
-          if (!raw) return;
-          var lists = JSON.parse(raw);
-          if (!Array.isArray(lists) || lists.length === 0) return;
-          var now = Date.now();
-          var STALE_MS = 24 * 60 * 60 * 1000;
-          var stale = lists.filter(function (l) {
-            if (!l || !l.lastRefreshed) return true;
-            var t = new Date(l.lastRefreshed).getTime();
-            return isNaN(t) || now - t > STALE_MS;
-          });
-          if (stale.length === 0) return;
-          var el = document.getElementById('sanctionsStaleBanner');
-          if (!el) return;
-          el.hidden = false;
-          el.textContent =
-            stale.length +
-            ' sanctions list(s) need refresh (>24h since last pull). Upload the latest UAE EOCN circular via /api/sanctions/eocn-upload and re-run the /api/sanctions-ingest-cron job before the next screening batch.';
-        } catch (_) {
-          /* swallow — banner is best-effort */
-        }
-      })();
-
-      // STR Case Management — live counts + inline STR Case File modal.
-      // Previously these two IIFEs ran immediately at parse time, BEFORE
-      // the #strNewCaseBtn and #strModal elements were in the DOM (the
-      // STR section sits below this <script> block in the document). So
-      // getElementById returned null and the "+ New STR Case" button was
-      // never wired. Wrapping in DOMContentLoaded guarantees the handler
-      // binds after every element exists.
-      // FDL No.(10)/2025 Art.26-27 (STR filing) + Art.21 (no tipping off).
-      (function () {
-        function setStrCount(id, n) {
-          var el = document.getElementById(id);
-          if (el) el.textContent = String(n);
-        }
-        function strCountsFromCases(cases) {
-          var counts = { draft: 0, review: 0, pending: 0, filed: 0 };
-          cases.forEach(function (c) {
-            var s = (c && c.status) || 'Draft';
-            if (s === 'Draft') counts.draft++;
-            else if (s === 'Under Review') counts.review++;
-            else if (s.indexOf('Pending Filing') !== -1 || s.indexOf('Approved') === 0) counts.pending++;
-            else if (s.indexOf('Filed') !== -1) counts.filed++;
-          });
-          return counts;
-        }
-        function loadStrCases() {
-          try {
-            var raw = localStorage.getItem('fgl_str_cases_v2');
-            var cases = raw ? JSON.parse(raw) : [];
-            return Array.isArray(cases) ? cases : [];
-          } catch (_) {
-            return [];
-          }
-        }
-        function recount() {
-          var cases = loadStrCases();
-          var counts = strCountsFromCases(cases);
-          setStrCount('strCountDraft', counts.draft);
-          setStrCount('strCountReview', counts.review);
-          setStrCount('strCountPending', counts.pending);
-          setStrCount('strCountFiled', counts.filed);
-          var empty = document.getElementById('strEmpty');
-          if (empty) {
-            if (cases.length > 0) empty.classList.add('hidden');
-            else empty.classList.remove('hidden');
-          }
-        }
-        function initStrCaseManager() {
-          recount();
-          var openBtn = document.getElementById('strNewCaseBtn');
-          var modal = document.getElementById('strModal');
-          if (!openBtn || !modal) return;
-          var closeBtn = document.getElementById('strModalClose');
-          var cancelBtn = document.getElementById('strModalCancel');
-          var saveBtn = document.getElementById('strModalSave');
-          var reportTypeSel = document.getElementById('strCaseReportType');
-          var prioritySel = document.getElementById('strCasePriority');
-          var subjectInput = document.getElementById('strCaseSubject');
-          var subjectTypeSel = document.getElementById('strCaseSubjectType');
-          var suspicionDateInput = document.getElementById('strCaseSuspicionDate');
-          var filingDeadlineInput = document.getElementById('strCaseFilingDeadline');
-          var redFlagsContainer = document.getElementById('strCaseRedFlags');
-          var suspicionInput = document.getElementById('strCaseSuspicion');
-          var txnAmountInput = document.getElementById('strCaseTxnAmount');
-          var txnDatesInput = document.getElementById('strCaseTxnDates');
-          var investigatorInput = document.getElementById('strCaseInvestigator');
-          var statusSel = document.getElementById('strCaseStatus');
-          var goamlRefInput = document.getElementById('strCaseGoamlRef');
-          var internalNotesInput = document.getElementById('strCaseInternalNotes');
-
-          function clearForm() {
-            if (reportTypeSel) reportTypeSel.value = '';
-            if (prioritySel) prioritySel.value = 'Without Delay';
-            if (subjectInput) subjectInput.value = '';
-            if (subjectTypeSel) subjectTypeSel.value = '';
-            if (suspicionDateInput) suspicionDateInput.value = '';
-            if (filingDeadlineInput) filingDeadlineInput.value = '';
-            if (redFlagsContainer) {
-              var boxes = redFlagsContainer.querySelectorAll('input[type=checkbox]');
-              for (var i = 0; i < boxes.length; i++) boxes[i].checked = false;
-            }
-            if (suspicionInput) suspicionInput.value = '';
-            if (txnAmountInput) txnAmountInput.value = '';
-            if (txnDatesInput) txnDatesInput.value = '';
-            if (investigatorInput) investigatorInput.value = '';
-            if (statusSel) statusSel.value = 'Draft';
-            if (goamlRefInput) goamlRefInput.value = '';
-            if (internalNotesInput) internalNotesInput.value = '';
-          }
-          function openModal() {
-            modal.hidden = false;
-            if (subjectInput) subjectInput.focus();
-          }
-          function closeModal() {
-            modal.hidden = true;
-            clearForm();
-          }
-          function collectRedFlags() {
-            if (!redFlagsContainer) return [];
-            var checked = redFlagsContainer.querySelectorAll('input[type=checkbox]:checked');
-            var arr = [];
-            for (var i = 0; i < checked.length; i++) arr.push(checked[i].value);
-            return arr;
-          }
-          function save() {
-            var subject = subjectInput ? subjectInput.value.trim() : '';
-            var suspicion = suspicionInput ? suspicionInput.value.trim() : '';
-            var reportType = reportTypeSel ? reportTypeSel.value : '';
-            var suspicionDate = suspicionDateInput ? suspicionDateInput.value.trim() : '';
-            var redFlags = collectRedFlags();
-            // FDL Art.26-27 requires subject + suspicion + report type +
-            // suspicion date + at least one red flag. Reject silently to
-            // the offending field instead of saving an incomplete case.
-            if (!subject) { if (subjectInput) subjectInput.focus(); return; }
-            if (!reportType) { if (reportTypeSel) reportTypeSel.focus(); return; }
-            if (!suspicionDate) { if (suspicionDateInput) suspicionDateInput.focus(); return; }
-            if (redFlags.length === 0) {
-              if (redFlagsContainer) {
-                var first = redFlagsContainer.querySelector('input[type=checkbox]');
-                if (first) first.focus();
-              }
-              return;
-            }
-            if (!suspicion) { if (suspicionInput) suspicionInput.focus(); return; }
-            try {
-              var cases = loadStrCases();
-              var now = new Date();
-              var rand = Math.random().toString(36).slice(2, 7).toUpperCase();
-              cases.push({
-                id: 'STR-' + now.getTime().toString(36).toUpperCase() + '-' + rand,
-                reportType: reportType,
-                priority: prioritySel ? prioritySel.value : 'Without Delay',
-                subject: subject,
-                subjectType: subjectTypeSel ? subjectTypeSel.value : '',
-                suspicionDate: suspicionDate,
-                filingDeadline: filingDeadlineInput ? filingDeadlineInput.value.trim() : '',
-                redFlags: redFlags,
-                suspicion: suspicion,
-                txnAmount: txnAmountInput ? txnAmountInput.value.trim() : '',
-                txnDates: txnDatesInput ? txnDatesInput.value.trim() : '',
-                investigator: investigatorInput ? investigatorInput.value.trim() : '',
-                status: statusSel ? statusSel.value : 'Draft',
-                goamlRef: goamlRefInput ? goamlRefInput.value.trim() : '',
-                internalNotes: internalNotesInput ? internalNotesInput.value.trim() : '',
-                createdAt: now.toISOString(),
-                updatedAt: now.toISOString(),
-              });
-              localStorage.setItem('fgl_str_cases_v2', JSON.stringify(cases));
-            } catch (_) {}
-            closeModal();
-            recount();
-          }
-
-          openBtn.addEventListener('click', openModal);
-          if (closeBtn) closeBtn.addEventListener('click', closeModal);
-          if (cancelBtn) cancelBtn.addEventListener('click', closeModal);
-          if (saveBtn) saveBtn.addEventListener('click', save);
-          modal.addEventListener('click', function (e) {
-            if (e.target === modal) closeModal();
-          });
-          document.addEventListener('keydown', function (e) {
-            if (e.key === 'Escape' && !modal.hidden) closeModal();
-          });
-        }
-        if (document.readyState === 'loading') {
-          document.addEventListener('DOMContentLoaded', initStrCaseManager);
-        } else {
-          initStrCaseManager();
-        }
-      })();
-
-      // Safety-net event delegation — binds at script parse time against
-      // `document`, so clicks on #strNewCaseBtn open the modal regardless
-      // of the initStrCaseManager IIFE's DOM-ready timing. Cheap
-      // insurance against any browser that delivers DOMContentLoaded
-      // oddly or any init path that bails silently.
-      (function () {
-        document.addEventListener('click', function (e) {
-          var t = e && e.target;
-          if (!t || typeof t.closest !== 'function') return;
-          if (t.closest('#strNewCaseBtn')) {
-            var m = document.getElementById('strModal');
-            if (m) m.hidden = false;
-          }
-          if (t.closest('#strModalClose') || t.closest('#strModalCancel')) {
-            var m2 = document.getElementById('strModal');
-            if (m2) m2.hidden = true;
-          }
-        }, false);
-      })();
-    </script>
-    <section class="hero">
-      <div>
-        <h1 class="hero-title">
-          <span class="nowrap">Your subjects, <em>screened</em>.</span><br />
-          <span class="nowrap">All audit-logged.</span>
-        </h1>
-      </div>
-      <aside class="summary" aria-label="Screening coverage summary">
-        <div class="summary-cell">
-          <div class="k">Sanctions Lists</div>
-          <div class="v">6</div>
-        </div>
-        <div class="summary-cell">
-          <div class="k">Mandatory</div>
-          <div class="v">2 <small>UN &middot; EOCN</small></div>
-        </div>
-        <div class="summary-cell">
-          <div class="k">Match Algorithms</div>
-          <div class="v">5</div>
-        </div>
-        <div class="summary-cell">
-          <div class="k">Daily Crons (UTC)</div>
-          <div class="v">2 <small>06:00 &middot; 14:00</small></div>
-        </div>
-      </aside>
-    </section>
-
-    <!-- Super Brain / Intelligence strip ───────────────────────────── -->
-    <div class="card brain-strip-card" style="margin-top: 14px; border-color: #a855f7">
-      <span class="brain-dot-sc" aria-hidden="true"></span>
-      <div class="brain-label-sc">
-        Routed through the <em>Weaponized Super Brain</em> &mdash; 19 subsystems + Opus advisor for highest-intelligence compliance decisions.
-      </div>
-      <span class="brain-badge-sc">19 Subsystems</span>
-      <span class="brain-badge-sc">Opus Advisor</span>
-      <span class="brain-badge-sc">Highest Intelligence</span>
-    </div>
-
-    <!-- MLRO Identity + Authentication (single-row compact) ──────────
-         All three inputs (Main, Deputy, Password) + sign-in / sign-out
-         icons share one flex row. Labels live as placeholders; the
-         "Screened by" badge carries the audit context under the row. -->
-    <div
-      id="mlroAuth"
-      class="card auth-card"
-      style="margin-top: 14px; border-color: #ec4899; padding: 10px 14px"
-    >
-      <div
-        class="auth-head"
-        style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap"
-      >
-        <h2
-          style="
-            color: #ec4899;
-            margin: 0;
-            font-size: 13px;
-            letter-spacing: 0.08em;
-            text-transform: uppercase;
-            flex-shrink: 0;
-          "
-        >
-          MLRO Auth
-        </h2>
-        <input
-          type="text"
-          id="mlroMainName"
-          placeholder="Main MLRO *"
-          autocomplete="off"
-          maxlength="128"
-          aria-label="Main MLRO"
-          style="flex: 1 1 140px; margin: 0"
-        />
-        <input
-          type="text"
-          id="mlroDeputyName"
-          placeholder="Deputy MLRO"
-          autocomplete="off"
-          maxlength="128"
-          aria-label="Deputy MLRO"
-          style="flex: 1 1 140px; margin: 0"
-        />
-        <input
-          type="password"
-          id="loginPassword"
-          placeholder="Password"
-          autocomplete="current-password"
-          spellcheck="false"
-          aria-label="MLRO password"
-          style="flex: 1 1 140px; margin: 0"
-        />
-        <button
-          type="button"
-          id="loginBtn"
-          class="token-gen-btn auth-icon-btn"
-          style="color: #22c55e; border-color: #ec4899"
-          title="Sign in — exchange password for a signed 1-year session token"
-          aria-label="Sign in"
-        >
-          &rarr;
-        </button>
-        <button
-          type="button"
-          id="logoutBtn"
-          class="token-gen-btn auth-icon-btn"
-          style="color: #ef4444; border-color: #ec4899"
-          title="Sign out — forget the saved session token"
-          aria-label="Sign out"
-        >
-          &times;
-        </button>
-      </div>
-      <div id="loginMsg" class="token-msg"></div>
-      <!-- Hidden token store. The screening-command.js auth helpers
-           read/write `#token` to keep the bearer in localStorage and
-           attach it to every API call. After sign-in the JWT lands
-           here; the field is never shown to the MLRO. -->
-      <input type="hidden" id="token" autocomplete="off" />
-    </div>
-
-    <!-- Data coverage contract ────────────────────────────────────── -->
-    <div class="card coverage-card" style="margin-top: 14px; border-color: #a855f7">
-      <h2 style="color: #a855f7">Data Coverage</h2>
-      <div class="coverage-grid">
-        <div>
-          <div class="c-h">Aliases &amp; alternative spellings</div>
-          <div class="c-sub">
-            Multi-modal matcher (Jaro-Winkler + Levenshtein + Soundex + Double Metaphone + token-
-            set). 20+ Latin-alphabet languages + 40+ non-Latin scripts via ICU / UAX #35
-            transliteration.
-          </div>
-        </div>
-        <div>
-          <div class="c-h">Structured record categorisation</div>
-          <div class="c-sub">
-            Every record tagged by: country &middot; type of crime (FATF 40+9 predicate offences)
-            &middot; political party &middot; organisation &middot; individual vs. legal entity.
-          </div>
-        </div>
-        <div>
-          <div class="c-h">Politically Exposed Persons</div>
-          <div class="c-sub">
-            PEPs, close associates and family members identified per Cabinet Res 134/2025 Art.14 —
-            domestic, foreign and international-organisation tiers.
-          </div>
-        </div>
-        <div>
-          <div class="c-h">Biographical information</div>
-          <div class="c-sub">
-            Titles, positions / roles, passport number(s), citizenship, DoB / registration date,
-            organisation &amp; political-party affiliation — all captured in the screening event and
-            retained 10 years (FDL Art.24).
-          </div>
-        </div>
-        <div>
-          <div class="c-h">List coverage &mdash; 700+ target</div>
-          <div class="c-sub">
-            <b>Live now:</b> UAE EOCN, UN 1267/1988/1989/2253, OFAC SDN + Consolidated, EU CFSP, UK
-            OFSI (&#x2265;&nbsp;5 lists). <b>Roadmap:</b> Interpol, FCA, FINRA, FinCEN, SEC, DOJ,
-            EuroPol, national debarments, PEP vendor feeds, CAPTA, CMIC, sectoral &amp; NS-SDN, UN
-            consolidated variants &amp; local jurisdiction lists &mdash; cumulative 700+ sanction /
-            watch / regulatory / LE lists.
-          </div>
-        </div>
-        <div>
-          <div class="c-h">UBO &amp; control-chain coverage</div>
-          <div class="c-sub">
-            Beneficial owners &#x2265;&nbsp;25% traced per Cabinet Decision 109/2023, re-verified
-            within 15 working days of any ownership change. Multi-hop ownership graph captures
-            nominee directors, mass-incorporation addresses and suspected shell / pass-through
-            structures for MoE UBO-register reconciliation.
-          </div>
-        </div>
-        <div>
-          <div class="c-h">Source-of-wealth / source-of-funds</div>
-          <div class="c-sub">
-            SoW &amp; SoF evidence captured for every EDD customer &mdash; salary, business revenue,
-            investment, inheritance, sale proceeds &mdash; with supporting documents hashed into the
-            screening event. Cabinet Res 134/2025 Art.14 &middot; FATF Rec 10.
-          </div>
-        </div>
-        <div>
-          <div class="c-h">Transaction-monitoring signals</div>
-          <div class="c-sub">
-            Cash-deposit velocity, structuring near the AED&nbsp;55,000 DPMS CTR trigger and the
-            AED&nbsp;60,000 cross-border cash threshold, wire-transfer chains, trade-based
-            laundering indicators and counterparty-risk scoring &mdash; all tied to the subject on
-            the screening event. MoE Circular 08/AML/2021 &middot; Cabinet Res 134/2025 Art.16
-            &middot; FATF Rec 10 / 20.
-          </div>
-        </div>
-        <div>
-          <div class="c-h">Device / session / screener context</div>
-          <div class="c-sub">
-            Every screening event binds the MLRO identity, token hash, IP, user-agent, session id
-            and server timestamp to the result &mdash; sealed into an append-only audit record so
-            repudiation is impossible. FDL No.10/2025 Art.20-21 (CO accountability) &middot; Art.24
-            (10-year retention).
-          </div>
-        </div>
-        <div>
-          <div class="c-h">List provenance &amp; lineage</div>
-          <div class="c-sub">
-            Every source list carries a full provenance envelope &mdash; origin URL, publisher
-            signature, SHA-256 checksum, <i>fetchedAt</i> and <i>listPublishedAt</i> &mdash; so MoE
-            / LBMA / internal audit can reproduce the exact data surface that fed any prior
-            screening. FATF Rec 22 / 23 traceability.
-          </div>
-        </div>
-        <div class="coverage-wide">
-          <div class="c-h">Record-update ranking</div>
-          <div class="c-sub">
-            Every list entry carries <i>fetchedAt</i>, <i>listPublishedAt</i> and
-            <i>changeImportance</i> (critical / material / minor) so updates rank by regulatory
-            impact, not recency alone. FATF Rec 10 / 22 / 23 traceability.
-          </div>
-        </div>
-      </div>
-      <p class="coverage-foot">
-        Coverage guarantees logged on every screening event (FDL Art.24 — 10-year retention) so MoE
-        / LBMA / internal audit can reproduce the exact data surface at any prior point in time.
-      </p>
-    </div>
-
-    <!-- List selector ────────────────────────────────────────────── -->
-    <div class="grid grid-2" style="margin-top: 14px">
-      <div class="card list-tier mandatory" style="border-color: var(--blue)">
-        <button
-          type="button"
-          class="list-refresh"
-          data-refresh-scope="mandatory"
-          title="Reset to default selection"
-          aria-label="Reset Mandatory UAE Lists to default selection"
-        >
-          <svg
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            aria-hidden="true"
-          >
-            <path d="M3 12a9 9 0 0 1 15.3-6.4L21 8" />
-            <path d="M21 3v5h-5" />
-            <path d="M21 12a9 9 0 0 1-15.3 6.4L3 16" />
-            <path d="M3 21v-5h5" />
-          </svg>
-        </button>
-        <h2 style="color: var(--blue)">Mandatory UAE Lists</h2>
-        <label class="list-check locked">
-          <input
-            type="checkbox"
-            data-list="UAE_EOCN"
-            data-tier="mandatory"
-            checked
-            disabled
-            aria-label="UAE Local Terrorist List (EOCN) — mandatory"
+    <div class="shell">
+      <header class="topbar">
+        <div class="title-group">
+          <img
+            src="assets/logos/hawkeye-icon.svg"
+            alt="Hawkeye Sterling"
+            class="header-logo"
+            width="56"
+            height="56"
           />
-          <span class="list-label"
-            >UAE Local Terrorist List — EOCN / Executive Office
-            <span class="list-sub">Executive Office for Control &amp; Non-Proliferation</span>
-          </span>
-        </label>
-        <label class="list-check locked">
-          <input
-            type="checkbox"
-            data-list="UN"
-            data-tier="mandatory"
-            checked
-            disabled
-            aria-label="UNSC Consolidated Sanctions List — mandatory"
-          />
-          <span class="list-label"
-            >UNSC Consolidated Sanctions List — UN Security Council
-            <span class="list-sub"
-              >Security Council resolutions + 1267/1988/1989/2253 sanctions</span
-            >
-          </span>
-        </label>
-        <p class="list-footnote">
-          <strong>Cabinet Decision No.(74)/2020.</strong> These two lists are legally mandatory for
-          all UAE reporting entities (DPMS, DNFBP, FI). Failure to screen against either list
-          constitutes a regulatory offence under FDL No.10/2025 Art.35 and is subject to
-          administrative penalty under Cabinet Res 71/2024 (AED 10K–100M range).
-        </p>
-      </div>
-      <div class="card list-tier enhanced" style="border-color: var(--blue)">
-        <button
-          type="button"
-          class="list-refresh"
-          data-refresh-scope="enhanced"
-          title="Reset to default selection"
-          aria-label="Reset Enhanced Controls to default selection"
-        >
-          <svg
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            aria-hidden="true"
-          >
-            <path d="M3 12a9 9 0 0 1 15.3-6.4L21 8" />
-            <path d="M21 3v5h-5" />
-            <path d="M21 12a9 9 0 0 1-15.3 6.4L3 16" />
-            <path d="M3 21v-5h5" />
-          </svg>
-        </button>
-        <h2 style="color: var(--blue)">Enhanced Controls</h2>
-        <label class="list-check">
-          <input type="checkbox" data-list="OFAC" data-tier="enhanced" checked />
-          <span class="list-label"
-            >OFAC SDN — US unilateral sanctions
-            <span class="list-sub"
-              >US Treasury OFAC Specially Designated Nationals + Consolidated</span
-            >
-          </span>
-        </label>
-        <label class="list-check">
-          <input type="checkbox" data-list="EU" data-tier="enhanced" checked />
-          <span class="list-label"
-            >EU Consolidated Sanctions
-            <span class="list-sub"
-              >European Union consolidated financial sanctions list (CFSP)</span
-            >
-          </span>
-        </label>
-        <label class="list-check">
-          <input type="checkbox" data-list="UK_OFSI" data-tier="enhanced" checked />
-          <span class="list-label"
-            >UK OFSI Consolidated
-            <span class="list-sub">Office of Financial Sanctions Implementation (HMT)</span>
-          </span>
-        </label>
-        <label class="list-check disabled">
-          <input type="checkbox" data-list="INTERPOL" data-tier="enhanced" checked disabled />
-          <span class="list-label"
-            >Interpol Red Notices
-            <span class="list-sub">Integration pending — manual check at interpol.int/wanted</span>
-          </span>
-        </label>
-        <p class="list-footnote">
-          <strong>EOCN Guidance.</strong> For non-UAE unilateral / multilateral lists, consult your
-          supervisory authority for appropriate course of action. Opting out is permitted; every
-          opt-out is logged with the screening event (FDL Art.24 — 10-year retention).
-        </p>
-      </div>
-    </div>
-
-    <!-- Risk categories ────────────────────────────────────────────── -->
-    <div class="card list-tier enhanced" style="margin-top: 14px; border-color: var(--blue)">
-      <button
-        type="button"
-        class="list-refresh"
-        data-refresh-scope="risk"
-        title="Reset to default selection"
-        aria-label="Reset Risk Categories to default selection"
-      >
-        <svg
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M3 12a9 9 0 0 1 15.3-6.4L21 8" />
-          <path d="M21 3v5h-5" />
-          <path d="M21 12a9 9 0 0 1-15.3 6.4L3 16" />
-          <path d="M3 21v-5h5" />
-        </svg>
-      </button>
-      <h2 style="color: var(--blue)">Risk Categories</h2>
-      <p class="help-text" style="margin-top: -4px">
-        Content categories screened against every selected list + adverse-media corpus. Default: all
-        ON. Turning a category OFF is logged on the screening event (FDL Art.24 — 10-year
-        retention).
-      </p>
-      <div class="grid grid-2" style="gap: 6px 14px">
-        <label class="list-check">
-          <input type="checkbox" data-category="pep" data-tier="enhanced" checked />
-          <span class="list-label"
-            >Politically Exposed Persons (PEP), close associates &amp; family members
-            <span class="list-sub"
-              >Cabinet Res 134/2025 Art.14 — domestic, foreign, IO PEPs + RCAs</span
-            >
-          </span>
-        </label>
-        <label class="list-check">
-          <input type="checkbox" data-category="stateOwnedEntities" data-tier="enhanced" checked />
-          <span class="list-label"
-            >State-owned entities &amp; state-invested enterprises
-            <span class="list-sub">SOE ownership screen — FATF Rec 12 / 24 beneficial control</span>
-          </span>
-        </label>
-        <label class="list-check">
-          <input type="checkbox" data-category="adverseMedia" data-tier="enhanced" checked />
-          <span class="list-label"
-            >Adverse media
-            <span class="list-sub"
-              >Open-source negative-news sweep covering the full FATF 40+9 predicate offence
-              taxonomy (bribery &amp; corruption, organized crime, terrorism / TF, human
-              trafficking, cybercrime, sanctions evasion, tax evasion, war crimes, environmental
-              crimes, securities fraud, and 30+ more). FATF Rec 10 / 12; FDL No.10/2025 Art.2.</span
-            >
-          </span>
-        </label>
-        <label class="list-check">
-          <input
-            type="checkbox"
-            data-category="proliferationFinancing"
-            data-tier="enhanced"
-            checked
-          />
-          <span class="list-label"
-            >Proliferation financing &amp; dual-use goods
-            <span class="list-sub"
-              >PF risk screen — WMD-linked entities, strategic / dual-use end-users, diversion
-              networks, front companies. Cabinet Res 156/2025 · UNSCR 1540 · FATF Rec 7 · DPMS
-              gold-provenance exposure.</span
-            >
-          </span>
-        </label>
-        <label class="list-check">
-          <input type="checkbox" data-category="terrorismFinancing" data-tier="enhanced" checked />
-          <span class="list-label"
-            >Terrorism financing &amp; designated terrorist entities
-            <span class="list-sub"
-              >TF risk screen — UNSCR 1267 / 1373 / 2462 designations, terrorist organisations,
-              foreign terrorist fighters, NPO / charity abuse channels, hawala / informal-value
-              routes. FDL No.10/2025 Art.35 · Cabinet Res 74/2020 · FATF Rec 5 / 6 / 8.</span
-            >
-          </span>
-        </label>
-        <label class="list-check">
-          <input type="checkbox" data-category="taxEvasion" data-tier="enhanced" checked />
-          <span class="list-label"
-            >Tax evasion &amp; tax crimes
-            <span class="list-sub"
-              >Tax-crime predicate screen — direct / indirect tax evasion, VAT carousel fraud,
-              customs undervaluation, trade-based laundering, OECD CRS / FATCA non-compliance, UAE
-              Federal Tax Authority enforcement. FDL No.10/2025 Art.2 (predicate offence) · FATF Rec
-              3.</span
-            >
-          </span>
-        </label>
-      </div>
-    </div>
-
-    <div class="grid grid-2" style="margin-top: 14px">
-      <!-- Screen subject ────────────────────────────────────────────── -->
-      <div class="card" style="border-color: #ec4899">
-        <h2 style="color: #ec4899">Screen a Subject</h2>
-        <p class="help-text">
-          Runs multi-modal fuzzy matching (Jaro-Winkler + Levenshtein + Soundex + Double Metaphone +
-          token-set) against every selected list, searches adverse media, and computes an
-          explainable risk score. Regulatory basis: FDL Art.12-14, 20-21, 24, 26-27, 29; Cabinet Res
-          134/2025 Art.7-10, 14, 19; Cabinet Res 74/2020 Art.4-7.
-        </p>
-
-        <label for="subjectName">Name screened *</label>
-        <input
-          type="text"
-          id="subjectName"
-          placeholder="Full legal name of individual or entity"
-          autocomplete="off"
-        />
-
-        <label for="aliases">Aliases &amp; alternative spellings</label>
-        <input
-          type="text"
-          id="aliases"
-          placeholder="Comma-separated — incl. non-Latin transliterations (e.g. Usama bin Ladin, UBL, أسامة بن لادن, 奥萨马·本·拉登)"
-          autocomplete="off"
-          maxlength="512"
-        />
-        <div class="row-2">
-          <div>
-            <label for="entityType">Entity type *</label>
-            <select id="entityType">
-              <option value="individual" selected>Individual</option>
-              <option value="legal_entity">Legal entity</option>
-            </select>
-          </div>
-          <div>
-            <label for="dob">Date of birth / registration</label>
-            <input
-              type="text"
-              id="dob"
-              placeholder="dd/mm/yyyy"
-              autocomplete="off"
-              maxlength="10"
-            />
-          </div>
+          <h1 class="page-h1">Hawkeye Sterling V2 &mdash; Screening Command</h1>
         </div>
+        <a href="index.html" class="back-link">&larr; Main app</a>
+      </header>
 
-        <div class="row-2">
-          <div>
-            <label for="eventType">Screening event type *</label>
-            <select id="eventType">
-              <option value="new_customer_onboarding" selected>New customer onboarding</option>
-              <option value="periodic_review">Periodic review</option>
-              <option value="transaction_trigger">Transaction trigger</option>
-              <option value="name_change">Name change</option>
-              <option value="adverse_media_hit">Adverse media hit</option>
-              <option value="pep_change">PEP status change</option>
-              <option value="ad_hoc">Ad hoc</option>
-            </select>
-          </div>
-          <div>
-            <label for="country">Citizenship / Registered country</label>
-            <input
-              type="text"
-              id="country"
-              placeholder="e.g. UAE, Iran, Russia"
-              autocomplete="off"
-              maxlength="64"
-            />
-          </div>
-        </div>
-
-        <div class="row-2">
-          <div>
-            <label for="idNumber">ID / register no.</label>
-            <input
-              type="text"
-              id="idNumber"
-              placeholder="Passport, EID, Trade Licence"
-              autocomplete="off"
-              maxlength="64"
-            />
-          </div>
-          <div>
-            <label for="passportNumber">Passport number(s)</label>
-            <input
-              type="text"
-              id="passportNumber"
-              placeholder="Comma-separated if multiple"
-              autocomplete="off"
-              maxlength="256"
-            />
-          </div>
-        </div>
-
-        <div class="row-2">
-          <div>
-            <label for="gender">Gender</label>
-            <select id="gender" autocomplete="off">
-              <option value="">Select gender</option>
-              <option value="male">Male</option>
-              <option value="female">Female</option>
-            </select>
-          </div>
-          <div>
-            <label for="position">Position / role</label>
-            <input
-              type="text"
-              id="position"
-              placeholder="e.g. Director, Minister of Interior, UBO > 25%"
-              autocomplete="off"
-              maxlength="128"
-            />
-          </div>
-        </div>
-
-        <div class="row-2">
-          <div>
-            <label for="subjectId">Subject ID (system)</label>
-            <input type="text" id="subjectId" placeholder="auto if blank" autocomplete="off" />
-          </div>
-          <div>
-            <label for="organizationAffiliation">Organization / political party</label>
-            <input
-              type="text"
-              id="organizationAffiliation"
-              placeholder="e.g. Hezbollah, IRGC, Ministry of Defence"
-              autocomplete="off"
-              maxlength="128"
-            />
-          </div>
-        </div>
-
-        <div class="row-2">
-          <div>
-            <label for="riskTier">Risk tier</label>
-            <select id="riskTier">
-              <option value="high">High risk</option>
-              <option value="medium" selected>Medium risk</option>
-              <option value="low">Low risk</option>
-            </select>
-          </div>
-          <div>
-            <label for="jurisdiction">Jurisdiction (ISO-2)</label>
-            <input
-              type="text"
-              id="jurisdiction"
-              placeholder="e.g. AE, UK, IR"
-              autocomplete="off"
-              maxlength="4"
-            />
-          </div>
-        </div>
-
+      <section class="hero">
         <div>
-          <label for="notes">Notes</label>
-          <input type="text" id="notes" placeholder="Context for the MLRO" autocomplete="off" />
-          <p class="help-text" style="margin-top: 4px">
-            Every screened subject is automatically enrolled in daily monitoring (06:00 / 14:00 UTC)
-            and in immediate sanctions / adverse-media / PEP / UBO alerts. No opt-out (FDL
-            Art.20-21, Cabinet Res 134/2025 Art.19).
+          <div class="hero-eyebrow">Screening Command</div>
+          <h1 class="hero-title">
+            <span class="nowrap">Your subjects, <em>screened</em>.</span><br />
+            <span class="nowrap">All <em>audit-logged</em>.</span>
+          </h1>
+          <p class="hero-lede">
+            Sanctions matching, transaction monitoring, STR case files, and active
+            watchlists &mdash; unified under one workspace. Each surface below maps to a
+            distinct UAE AML/CFT obligation and writes to the 10-year audit trail.
           </p>
         </div>
+        <aside class="hero-summary" aria-label="Screening command live status">
+          <div class="hero-summary-cell">
+            <div class="k"><span class="dot"></span>Sanctions Lists</div>
+            <div class="v">6<small>UN &middot; EOCN &middot; +4</small></div>
+          </div>
+          <div class="hero-summary-cell">
+            <div class="k"><span class="dot"></span>Mandatory</div>
+            <div class="v">2<small>UN &middot; EOCN</small></div>
+          </div>
+          <div class="hero-summary-cell">
+            <div class="k"><span class="dot"></span>Match Algorithms</div>
+            <div class="v">5<small>Fuzzy &middot; Phonetic</small></div>
+          </div>
+          <div class="hero-summary-cell" data-state="amber">
+            <div class="k"><span class="dot"></span>Daily Crons (UTC)</div>
+            <div class="v">2<small>06:00 &middot; 14:00</small></div>
+          </div>
+        </aside>
+      </section>
 
-        <p class="help-text" style="margin-top: 6px">
-          <b>Screened by:</b> <span id="mlroActiveBadgeRun" class="tag">—</span>
-        </p>
-        <button id="screenBtn" type="button">Run Screening</button>
-        <div id="screenMsg"></div>
-        <div id="screenResult" style="margin-top: 14px"></div>
+      <div class="section-head">
+        <span class="section-label">Operational Surfaces</span>
+        <span class="section-count">04 / 04</span>
+      </div>
 
-        <!-- Disposition / MLRO attestation ─────────────────────────── -->
-        <div id="disposition" class="disposition">
-          <h3>MLRO Disposition &mdash; Attestation Required</h3>
-          <p class="help-text">
-            Every screening event must be closed out with a documented disposition. This record is
-            written to the screening-events blob store (10-year retention per FDL Art.24) and an
-            Asana task is created regardless of outcome so MoE audit can confirm the reviewer
-            actually looked.
+      <div class="grid">
+        <a class="card" href="/screening-command/subject-screening" data-route="screening" data-slug="subject-screening">
+          <div class="card-icon" aria-hidden="true">🔍</div>
+          <div class="card-meta">
+            <span class="dot"></span>
+            <span>Module 01 &middot; Screening</span>
+          </div>
+          <h2 class="card-title">Subject Screening</h2>
+          <p class="card-desc">
+            Multi-modal fuzzy matching (Jaro-Winkler + Levenshtein + Soundex + Double
+            Metaphone + token-set) against UN, EOCN, OFAC, EU, UK and adverse-media.
+            Four-eyes MLRO disposition on every partial / confirmed match.
           </p>
-
-          <div class="row-2">
-            <div>
-              <label for="screeningDate">Screening date *</label>
-              <input
-                type="text"
-                id="screeningDate"
-                placeholder="dd/mm/yyyy"
-                autocomplete="off"
-                maxlength="10"
-              />
+          <div class="card-stats">
+            <div class="stat">
+              <span class="stat-val">6 +</span>
+              <span class="stat-key">Lists screened</span>
             </div>
-            <div>
-              <label for="reviewedBy">Reviewed by *</label>
-              <input
-                type="text"
-                id="reviewedBy"
-                placeholder="Compliance Officer / MLRO name"
-                autocomplete="off"
-                maxlength="128"
-              />
+            <div class="stat">
+              <span class="stat-val">24 h</span>
+              <span class="stat-key">EOCN freeze</span>
             </div>
           </div>
-
-          <label>Screening outcome *</label>
-          <div class="outcome-grid" role="radiogroup" aria-label="Screening outcome">
-            <button
-              type="button"
-              class="outcome-btn"
-              data-outcome="negative_no_match"
-              role="radio"
-              aria-checked="false"
-            >
-              <span class="outcome-head">
-                <span class="glyph" aria-hidden="true">&#10003;</span>
-                <span class="label">Negative</span>
-              </span>
-              <span class="impact"
-                >No match across any list. Proceed to SDD / CDD path per the subject's risk
-                tier.</span
-              >
-            </button>
-            <button
-              type="button"
-              class="outcome-btn"
-              data-outcome="false_positive"
-              role="radio"
-              aria-checked="false"
-            >
-              <span class="outcome-head">
-                <span class="glyph" aria-hidden="true">&#215;</span>
-                <span class="label">False positive</span>
-              </span>
-              <span class="impact"
-                >Name hit ruled out on DoB / ID / jurisdiction. Document the differentiator in the
-                rationale.</span
-              >
-            </button>
-            <button
-              type="button"
-              class="outcome-btn"
-              data-outcome="partial_match"
-              role="radio"
-              aria-checked="false"
-            >
-              <span class="outcome-head">
-                <span class="glyph" aria-hidden="true">?</span>
-                <span class="label">Partial match</span>
-              </span>
-              <span class="impact"
-                >Escalate to Compliance Officer. Suspend onboarding / transaction until
-                adjudicated.</span
-              >
-            </button>
-            <button
-              type="button"
-              class="outcome-btn"
-              data-outcome="confirmed_match"
-              role="radio"
-              aria-checked="false"
-            >
-              <span class="outcome-head">
-                <span class="glyph" aria-hidden="true">!</span>
-                <span class="label">Confirmed</span>
-              </span>
-              <span class="impact"
-                >FREEZE within 24h (Cabinet Res 74/2020 Art.4). File CNMR with EOCN in 5 business
-                days. No tipping off.</span
-              >
-            </button>
+          <div class="card-cta">
+            <span>Open module</span>
+            <span class="card-cta-arrow" aria-hidden="true">&rarr;</span>
           </div>
+        </a>
 
-          <div id="dispositionPreview" class="disposition-preview" aria-live="polite">
-            <span class="dp-label">Disposition</span>
-            <span class="dp-value muted" id="dpOutcome">Select an outcome above.</span>
-            <span class="dp-label">Next action</span>
-            <span class="dp-value muted" id="dpAction">&mdash;</span>
-            <span class="dp-label">Record</span>
-            <span class="dp-value muted" id="dpRecord"
-              >Outcome, rationale, key findings, reviewer, IP, and timestamp will be written to the
-              append-only audit log + mirrored to the Asana task.</span
-            >
+        <a class="card" href="/screening-command/transaction-monitor" data-route="transaction-monitor" data-slug="transaction-monitor">
+          <div class="card-icon" aria-hidden="true">💸</div>
+          <div class="card-meta">
+            <span class="dot"></span>
+            <span>Module 02 &middot; Monitor</span>
           </div>
-
-          <label for="keyFindings" style="margin-top: 12px">Key findings</label>
-          <textarea
-            id="keyFindings"
-            placeholder="Bullet-point what you actually found: top list hit(s), adverse-media signals, PEP indicators, UBO concerns, jurisdictional red flags, DoB / ID differentiators for false-positive dismissal."
-            maxlength="4000"
-          ></textarea>
-          <span class="help-text"
-            >Optional but strongly recommended. Displayed verbatim in the Asana task and the audit
-            record.</span
-          >
-
-          <label for="rationale" style="margin-top: 12px">Disposition rationale / notes *</label>
-          <textarea
-            id="rationale"
-            placeholder="Document the full basis for your screening decision. For false positives: state exactly how you differentiated. For confirmed/partial matches: describe the match and actions taken."
-            minlength="20"
-          ></textarea>
-          <span class="help-text"
-            >Minimum 20 characters. This text is the audit record seen by MoE / LBMA
-            inspectors.</span
-          >
-
-          <div id="fourEyesBlock" class="four-eyes" aria-hidden="true">
-            <h4>Four-eyes approval required</h4>
-            <p>
-              Partial and confirmed matches cannot be saved by a single reviewer. A second,
-              independent approver must attest to the outcome before the record is written to the
-              audit log (FDL No.10/2025 Art.20-21; Cabinet Res 134/2025 Art.19 — internal review).
-              The first reviewer and the second approver must be different people.
-            </p>
-            <label for="secondApprover">Second approver (full name) *</label>
-            <input
-              type="text"
-              id="secondApprover"
-              placeholder="e.g. Luisa Fernanda"
-              autocomplete="off"
-              maxlength="120"
-            />
-            <label for="secondApproverRole">Second approver role / title *</label>
-            <input
-              type="text"
-              id="secondApproverRole"
-              placeholder="e.g. Compliance Officer / MLRO"
-              autocomplete="off"
-              maxlength="120"
-            />
-            <label class="ack">
-              <input type="checkbox" id="secondApproverAck" />
-              <span
-                >I, the second approver, have independently reviewed the subject candidates, the
-                match evidence, and the rationale above. I attest that the disposition is
-                appropriate under FDL Art.20-21 and Cabinet Res 134/2025 Art.14/19, and that I am
-                not the same person as the first reviewer.</span
-              >
-            </label>
-          </div>
-
-          <div class="action-row">
-            <button id="saveBtn" class="btn-save" type="button">Save Screening Event</button>
-            <button id="rerunBtn" class="btn-rerun" type="button">Run Screening</button>
-            <button id="cancelBtn" class="btn-cancel" type="button">Cancel</button>
-          </div>
-          <div id="saveMsg" style="margin-top: 8px"></div>
-
-          <!-- Compliance-disposition report. Populated after a successful
-               save. Every section adapts to the selected outcome; the
-               "next actions" block switches between clearance / dismissal
-               / escalation / freeze-24h per Cabinet Res 74/2020 Art.4-7
-               and FDL No.10/2025 Art.26-27. -->
-          <div id="complianceReport" class="compliance-report" aria-live="polite" hidden></div>
-        </div>
-      </div>
-
-      <!-- Transaction monitor ────────────────────────────────────────────── -->
-      <div class="card" style="border-color: #22c55e">
-        <h2 style="color: #22c55e">
-          Transaction Monitor <span class="tag">Structuring + Velocity + Cross-Border</span>
-        </h2>
-        <p class="help-text">
-          Runs the weaponized TM engine on a batch of transactions: rule-based (structuring,
-          profile-mismatch, third-party, offshore routing, AED 55K DPMS CTR, round-number,
-          price-gaming) plus velocity, behavioral deviation, cumulative exposure, and cross-border
-          thresholds. Critical alerts auto-create an Asana task. FDL Art.15-16, 26-27; Cabinet Res
-          134/2025 Art.16, 19.
-        </p>
-        <div class="row-2">
-          <div>
-            <label for="tmCustomerId">Customer ID *</label>
-            <input type="text" id="tmCustomerId" placeholder="CUS-12345" autocomplete="off" />
-          </div>
-          <div>
-            <label for="tmCustomerName">Customer name *</label>
-            <input
-              type="text"
-              id="tmCustomerName"
-              placeholder="e.g. Gold Trader LLC"
-              autocomplete="off"
-            />
-          </div>
-        </div>
-        <div class="row-2">
-          <div>
-            <label for="tmAmount">Amount (AED/USD/EUR) *</label>
-            <div style="display: flex; gap: 6px">
-              <input
-                type="number"
-                id="tmAmount"
-                min="0"
-                step="0.01"
-                placeholder="54999"
-                style="flex: 1"
-              />
-              <select id="tmCurrency" style="width: 90px">
-                <option value="AED" selected>AED</option>
-                <option value="USD">USD</option>
-                <option value="EUR">EUR</option>
-              </select>
+          <h2 class="card-title">Transaction Monitor</h2>
+          <p class="card-desc">
+            Rule-based + behavioural engine: structuring near AED 55K, velocity spikes,
+            third-party payers, offshore routing, round-number + price-gaming patterns.
+            Critical alerts auto-open an Asana case.
+          </p>
+          <div class="card-stats">
+            <div class="stat">
+              <span class="stat-val">AED 55K</span>
+              <span class="stat-key">DPMS CTR</span>
+            </div>
+            <div class="stat">
+              <span class="stat-val">AED 60K</span>
+              <span class="stat-key">Cross-border</span>
             </div>
           </div>
-          <div>
-            <label for="tmRiskRating">Customer risk</label>
-            <select id="tmRiskRating">
-              <option value="high">High</option>
-              <option value="medium" selected>Medium</option>
-              <option value="low">Low</option>
-            </select>
+          <div class="card-cta">
+            <span>Open module</span>
+            <span class="card-cta-arrow" aria-hidden="true">&rarr;</span>
           </div>
+        </a>
+
+        <a class="card" href="/screening-command/str-cases" data-route="str" data-slug="str-cases">
+          <div class="card-icon" aria-hidden="true">🚨</div>
+          <div class="card-meta">
+            <span class="dot"></span>
+            <span>Module 03 &middot; Reports</span>
+          </div>
+          <h2 class="card-title">STR Case Management</h2>
+          <p class="card-desc">
+            STR / SAR / AIF / PEPR / HRCR / FTFR case files with red-flag taxonomy,
+            suspicion narrative, goAML reference, and four-eyes approval. File without
+            delay upon suspicion arising. No tipping off.
+          </p>
+          <div class="card-stats">
+            <div class="stat">
+              <span class="stat-val">goAML</span>
+              <span class="stat-key">XML schema</span>
+            </div>
+            <div class="stat">
+              <span class="stat-val">W/out delay</span>
+              <span class="stat-key">Filing SLA</span>
+            </div>
+          </div>
+          <div class="card-cta">
+            <span>Open module</span>
+            <span class="card-cta-arrow" aria-hidden="true">&rarr;</span>
+          </div>
+        </a>
+
+        <a class="card" href="/screening-command/watchlist" data-route="watchlist" data-slug="watchlist">
+          <div class="card-icon" aria-hidden="true">📡</div>
+          <div class="card-meta">
+            <span class="dot"></span>
+            <span>Module 04 &middot; Monitoring</span>
+          </div>
+          <h2 class="card-title">Active Watchlist</h2>
+          <p class="card-desc">
+            Every screened subject auto-enrolled in ongoing monitoring. Two scheduled
+            crons per day (06:00 / 14:00 UTC) re-screen the full watchlist and push
+            delta alerts to Asana. No opt-out under Art.20-21.
+          </p>
+          <div class="card-stats">
+            <div class="stat">
+              <span class="stat-val">2 &times;/day</span>
+              <span class="stat-key">Re-screen</span>
+            </div>
+            <div class="stat">
+              <span class="stat-val">10 yr</span>
+              <span class="stat-key">Retention</span>
+            </div>
+          </div>
+          <div class="card-cta">
+            <span>Open module</span>
+            <span class="card-cta-arrow" aria-hidden="true">&rarr;</span>
+          </div>
+        </a>
+      </div>
+
+      <section
+        class="module-view"
+        id="moduleView"
+        aria-label="Embedded module view"
+        aria-hidden="true"
+      >
+        <div class="module-view-head">
+          <h2 class="module-view-title" id="moduleViewTitle">Module</h2>
+          <button type="button" class="module-view-close" id="moduleViewClose">
+            &larr; Back to surfaces
+          </button>
         </div>
-        <div class="row-2">
-          <div>
-            <label for="tmOriginCountry">Origin country</label>
-            <input
-              type="text"
-              id="tmOriginCountry"
-              placeholder="AE or United Arab Emirates"
-              autocomplete="off"
-              maxlength="64"
-            />
-          </div>
-          <div>
-            <label for="tmDestCountry">Destination country</label>
-            <input
-              type="text"
-              id="tmDestCountry"
-              placeholder="IR or Iran"
-              autocomplete="off"
-              maxlength="64"
-            />
-          </div>
+        <iframe
+          class="module-view-frame"
+          id="moduleViewFrame"
+          title="Screening command module"
+          loading="lazy"
+          src="about:blank"
+        ></iframe>
+      </section>
+
+      <div class="reg-basis">
+        <div class="reg-title">Regulatory Basis</div>
+        <div class="reg-text">
+          Sanctions + PEP screening aligns with <strong>FDL No.(10)/2025 Art.35</strong>
+          and <strong>Cabinet Res 74/2020 Art.4-7</strong> (24h EOCN freeze, 5 bd CNMR).
+          Transaction monitoring enforces <strong>FDL Art.15-16</strong> and
+          <strong>Cabinet Res 134/2025 Art.16</strong> (cross-border cash AED 60,000) +
+          <strong>MoE Circular 08/AML/2021</strong> (AED 55,000 DPMS CTR). STR / SAR
+          workflow files via goAML per <strong>FDL Art.26-27</strong>, protects the
+          subject from tipping off per <strong>Art.29</strong>, and retains 10 years per
+          <strong>Art.24</strong>.
         </div>
-        <div class="row-2">
-          <div>
-            <label for="tmTxLast30">Transactions (30d)</label>
-            <input type="number" id="tmTxLast30" min="0" step="1" placeholder="3" />
-          </div>
-          <div>
-            <label for="tmCumLast30">Cumulative AED (30d)</label>
-            <input type="number" id="tmCumLast30" min="0" step="0.01" placeholder="164000" />
-          </div>
-        </div>
-        <div class="row-2">
-          <div>
-            <label for="tmPaymentMethod">Payment method</label>
-            <select id="tmPaymentMethod">
-              <option value="cash">Cash</option>
-              <option value="wire" selected>Wire</option>
-              <option value="card">Card</option>
-              <option value="crypto">Crypto</option>
-            </select>
-          </div>
-          <div>
-            <label for="tmPayerMatches">Payer = customer?</label>
-            <select id="tmPayerMatches">
-              <option value="true" selected>Yes</option>
-              <option value="false">No (third-party)</option>
-            </select>
-          </div>
-        </div>
-        <div>
-          <label for="tmCommodity">Commodity Type</label>
-          <input
-            type="text"
-            id="tmCommodity"
-            placeholder="e.g. Gold bars, used vehicles, diamonds"
-            autocomplete="off"
-          />
-        </div>
-        <div>
-          <label for="tmNotes">Notes</label>
-          <textarea
-            id="tmNotes"
-            rows="2"
-            placeholder="Free-text context for the MLRO (purpose of transaction, source of funds, anything unusual)"
-          ></textarea>
-        </div>
-        <button id="tmBtn" type="button">Run Transaction Monitor</button>
-        <div id="tmMsg"></div>
-        <div id="tmResult" style="margin-top: 14px"></div>
       </div>
     </div>
 
-    <!-- STR Case Management (centre of page, between RUN SCREENING and ACTIVE WATCHLIST) -->
-    <div class="card str-card" style="margin-top: 14px; border-color: var(--gold)">
-      <div class="str-top">
-        <h2 class="str-title">STR Case Management</h2>
-        <span class="str-cite">
-          UAE FDL No.(10) of 2025 Art.26-27 | goAML | FATF Rec.20 | File WITHOUT DELAY upon suspicion
-        </span>
-        <button
-          type="button"
-          id="strNewCaseBtn"
-          class="str-new-btn"
-          title="Open a new STR case file inline"
-        >
-          + New STR Case
-        </button>
-      </div>
-      <div class="str-conf-notice" role="alert">
-        <span class="str-conf-icon" aria-hidden="true">&#9888;</span>
-        <span>
-          <b>CONFIDENTIALITY NOTICE:</b> STR information is strictly confidential. Tipping off a
-          subject is a criminal offence under UAE FDL No.(10) of 2025 Art.21. Do not disclose to any
-          person that a report has been or will be filed.
-        </span>
-      </div>
-      <div class="str-metrics" id="strMetrics">
-        <div class="str-metric str-m-draft">
-          <div class="str-m-num" id="strCountDraft">0</div>
-          <div class="str-m-lbl">Draft</div>
-        </div>
-        <div class="str-metric str-m-review">
-          <div class="str-m-num" id="strCountReview">0</div>
-          <div class="str-m-lbl">Under Review</div>
-        </div>
-        <div class="str-metric str-m-pending">
-          <div class="str-m-num" id="strCountPending">0</div>
-          <div class="str-m-lbl">Pending Filing</div>
-        </div>
-        <div class="str-metric str-m-filed">
-          <div class="str-m-num" id="strCountFiled">0</div>
-          <div class="str-m-lbl">Filed</div>
-        </div>
-      </div>
-      <p class="str-empty" id="strEmpty">
-        No STR cases. Click &ldquo;+ New STR Case&rdquo; to begin investigation.
-      </p>
-    </div>
-
-    <!-- STR New Case modal ──────────────────────────────────────────────
-         Inline STR Case File form. Saves into localStorage.fgl_str_cases_v2
-         — the same key compliance-suite.js reads/writes. Captures every
-         field UAE FDL No.(10)/2025 Art.26-27 + goAML require (report
-         type, priority, subject name + type, suspicion date, filing
-         deadline, red flags, narrative, transaction amount + dates,
-         investigator, status, goAML reference, internal notes). No
-         tip-off risk (FDL Art.21) — nothing is transmitted until the
-         MLRO files via goAML.
-    -->
-    <div id="strModal" class="str-modal" role="dialog" aria-modal="true" aria-labelledby="strModalTitle" hidden>
-      <div class="str-modal-card str-modal-card-wide">
-        <button type="button" class="str-modal-close" id="strModalClose" aria-label="Close">&times;</button>
-        <h2 id="strModalTitle" class="str-modal-title">STR Case File</h2>
-        <p class="str-modal-cite">UAE FDL No.(10) of 2025 Art.26-27 &middot; File to UAE FIU via goAML WITHOUT DELAY upon suspicion arising</p>
-        <div class="str-modal-row-2">
-          <div>
-            <label for="strCaseReportType">Report type *</label>
-            <select id="strCaseReportType" required>
-              <option value="" selected>Select</option>
-              <option value="STR">STR &mdash; Suspicious Transaction Report</option>
-              <option value="SAR">SAR &mdash; Suspicious Activity Report</option>
-              <option value="AIF">AIF &mdash; Additional Information File</option>
-              <option value="PEPR">PEPR &mdash; Politically Exposed Person Report</option>
-              <option value="HRCR">HRCR &mdash; High-Risk Country Report</option>
-              <option value="FTFR">FTFR &mdash; Funds Transfer Report</option>
-            </select>
-          </div>
-          <div>
-            <label for="strCasePriority">Priority</label>
-            <select id="strCasePriority">
-              <option value="Without Delay" selected>Without Delay (FDL Art.26-27)</option>
-              <option value="High">High</option>
-              <option value="Medium">Medium</option>
-              <option value="Low">Low</option>
-            </select>
-          </div>
-        </div>
-        <div class="str-modal-row-2">
-          <div>
-            <label for="strCaseSubject">Subject name *</label>
-            <input type="text" id="strCaseSubject" maxlength="256" placeholder="Individual or entity name" autocomplete="off" />
-          </div>
-          <div>
-            <label for="strCaseSubjectType">Subject type</label>
-            <select id="strCaseSubjectType">
-              <option value="" selected>Select</option>
-              <option value="Individual">Individual</option>
-              <option value="Legal Entity">Legal Entity</option>
-              <option value="Trust">Trust / Arrangement</option>
-              <option value="Government">Government / PEP</option>
-            </select>
-          </div>
-        </div>
-        <div class="str-modal-row-2">
-          <div>
-            <label for="strCaseSuspicionDate">Date suspicion arose *</label>
-            <input type="text" id="strCaseSuspicionDate" maxlength="10" placeholder="dd/mm/yyyy" autocomplete="off" />
-          </div>
-          <div>
-            <label for="strCaseFilingDeadline">Filing deadline (Without Delay &mdash; file immediately)</label>
-            <input type="text" id="strCaseFilingDeadline" maxlength="10" placeholder="dd/mm/yyyy" autocomplete="off" />
-          </div>
-        </div>
-        <div class="str-modal-row">
-          <label>Red flags identified (select all that apply) *</label>
-          <div class="str-redflags" id="strCaseRedFlags">
-            <label class="str-redflag"><input type="checkbox" value="Customer reluctant to provide identification" /> Customer reluctant to provide identification</label>
-            <label class="str-redflag"><input type="checkbox" value="Customer declines to complete CDD documentation" /> Customer declines to complete CDD documentation</label>
-            <label class="str-redflag"><input type="checkbox" value="Inconsistency between declared source of funds and known business" /> Inconsistency between declared source of funds and known business</label>
-            <label class="str-redflag"><input type="checkbox" value="Customer behaviour changes after CDD request" /> Customer behaviour changes after CDD request</label>
-            <label class="str-redflag"><input type="checkbox" value="Customer requests anonymity or third-party payment" /> Customer requests anonymity or third-party payment</label>
-            <label class="str-redflag"><input type="checkbox" value="Customer cannot be reached at declared address or phone" /> Customer cannot be reached at declared address or phone</label>
-            <label class="str-redflag"><input type="checkbox" value="Transactions structured below AED 55,000 CTR threshold" /> Transactions structured below AED 55,000 CTR threshold</label>
-            <label class="str-redflag"><input type="checkbox" value="Transactions inconsistent with customer profile or history" /> Transactions inconsistent with customer profile or history</label>
-            <label class="str-redflag"><input type="checkbox" value="Unusual high-value cash transactions" /> Unusual high-value cash transactions</label>
-            <label class="str-redflag"><input type="checkbox" value="Cross-border transfers to high-risk jurisdictions" /> Cross-border transfers to high-risk jurisdictions</label>
-            <label class="str-redflag"><input type="checkbox" value="Sanctions list hit (UN/OFAC/EU/UK/UAE EOCN)" /> Sanctions list hit (UN/OFAC/EU/UK/UAE EOCN)</label>
-            <label class="str-redflag"><input type="checkbox" value="Adverse media hit (financial crime, corruption, terror)" /> Adverse media hit (financial crime, corruption, terror)</label>
-            <label class="str-redflag"><input type="checkbox" value="PEP involvement without adequate source of wealth evidence" /> PEP involvement without adequate source of wealth evidence</label>
-            <label class="str-redflag"><input type="checkbox" value="UBO obscured behind shell-company layering" /> UBO obscured behind shell-company layering</label>
-          </div>
-        </div>
-        <div class="str-modal-row">
-          <label for="strCaseSuspicion">Suspicion narrative *</label>
-          <textarea id="strCaseSuspicion" maxlength="8000" rows="5" placeholder="Describe the basis for suspicion in detail. Include: (1) subject profile, (2) transaction chronology, (3) red flags observed, (4) why suspicion arose, (5) any mitigating factors considered and rejected. This narrative will form the basis of the goAML submission."></textarea>
-        </div>
-        <div class="str-modal-row-2">
-          <div>
-            <label for="strCaseTxnAmount">Transaction amount (AED)</label>
-            <input type="text" id="strCaseTxnAmount" maxlength="32" placeholder="0.00" autocomplete="off" inputmode="decimal" />
-          </div>
-          <div>
-            <label for="strCaseTxnDates">Transaction date(s)</label>
-            <input type="text" id="strCaseTxnDates" maxlength="128" placeholder="e.g. 01/04/2026" autocomplete="off" />
-          </div>
-        </div>
-        <div class="str-modal-row-2">
-          <div>
-            <label for="strCaseInvestigator">Investigator / MLRO</label>
-            <input type="text" id="strCaseInvestigator" maxlength="128" placeholder="Name of person handling" autocomplete="off" />
-          </div>
-          <div>
-            <label for="strCaseStatus">Case status *</label>
-            <select id="strCaseStatus">
-              <option value="Draft" selected>Draft</option>
-              <option value="Under Review">Under Review</option>
-              <option value="Approved - Pending Filing">Approved &mdash; Pending Filing</option>
-              <option value="Filed - goAML">Filed &mdash; goAML</option>
-              <option value="Closed - No Filing">Closed &mdash; No Filing</option>
-            </select>
-          </div>
-        </div>
-        <div class="str-modal-row">
-          <label for="strCaseGoamlRef">goAML reference number (after filing)</label>
-          <input type="text" id="strCaseGoamlRef" maxlength="64" placeholder="goAML submission reference" autocomplete="off" />
-        </div>
-        <div class="str-modal-row">
-          <label for="strCaseInternalNotes">Internal notes</label>
-          <textarea id="strCaseInternalNotes" maxlength="4000" rows="3" placeholder="Internal escalation notes, management approvals, supporting documents..."></textarea>
-        </div>
-        <div class="str-modal-actions">
-          <button type="button" class="str-modal-btn str-modal-btn-secondary" id="strModalCancel">Cancel</button>
-          <button type="button" class="str-modal-btn str-modal-btn-primary" id="strModalSave">Save STR Case</button>
-        </div>
-        <p class="str-modal-help">
-          Saved locally under <code>fgl_str_cases_v2</code> (FDL Art.24 &mdash; 10yr audit trail). Do NOT tip off the subject (FDL Art.21). Use the full compliance suite to draft the goAML XML submission.
-        </p>
-      </div>
-    </div>
-
-    <!-- Watchlist snapshot ────────────────────────────────────────────── -->
-    <div class="card" style="margin-top: 14px; border-color: var(--amber)">
-      <h2>Active Watchlist <span class="tag">Daily 06:00 / 14:00 UTC</span></h2>
-      <p class="help-text">
-        Subjects currently enrolled in ongoing monitoring. The scheduled cron screens every entry on
-        this list twice per day; NEW hits versus the last run are routed to Asana as delta alerts.
-        Subjects you screen above auto-enroll here (unless you opt out).
-      </p>
-      <div class="stat">
-        <div class="stat-item" style="--stat-color: #22c55e; border-color: var(--gold)">
-          <div class="stat-value" id="wlCount">—</div>
-          <div class="stat-label">Subjects monitored</div>
-        </div>
-        <div class="stat-item" style="--stat-color: #ef4444; border-color: var(--gold)">
-          <div class="stat-value" id="wlAlerts">—</div>
-          <div class="stat-label">Total alerts lifetime</div>
-        </div>
-        <div class="stat-item" style="--stat-color: #3b82f6; border-color: var(--gold)">
-          <div class="stat-value" id="wlLastRun">—</div>
-          <div class="stat-label">Last screened</div>
-        </div>
-      </div>
-      <button id="refreshBtn" class="btn-secondary" type="button">Refresh watchlist</button>
-      <div id="wlList" style="margin-top: 14px"></div>
-    </div>
-
-    <p class="footer">&copy; 2026 Hawkeye Sterling. All rights reserved.</p>
-
-    <!-- jsPDF for client-side PDF export of the compliance-disposition
-         report. CDN is whitelisted in netlify.toml CSP (cdnjs.cloudflare.com).
-         Same pinned version as index.html. -->
-    <script
-      defer
-      crossorigin="anonymous"
-      src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"
-      onerror="console.warn('jsPDF CDN failed — PDF export unavailable')"
-    ></script>
-    <script src="screening-command.js?v=4"></script>
+    <footer class="footer">
+      <span>© 2026 Hawkeye Sterling</span>
+      <span>Confidential &middot; Audit-ready</span>
+    </footer>
+    <script src="landing-module-viewer.js?v=4"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Re-skin `screening-command.html` to match `compliance-ops.html`'s landing-hub layout (topbar + hero + 2×2 summary aside + 4-card operational-surfaces grid + inline module iframe + regulatory basis strip + footer).
- **Purple / lilac / fuchsia palette preserved** — only the CSS tokens the layout consumes were remapped onto the existing purple variables (`--azure`, `--azure-bright`, `--sky`, `--ice`, `--mist`). No colour values were changed.
- Four operational-surface cards: Subject Screening, Transaction Monitor, STR Case Management, Active Watchlist. Each opens inline via the existing `landing-module-viewer.js` iframe pattern.
- Wire-up: added `screening-command` to `LANDING_SLUGS` in `landing-module-viewer.js`; added `/screening-command/*` splat redirect in `netlify.toml` so deep-link refresh resolves.

## Regulatory citations (preserved verbatim)
- **FDL No.(10)/2025 Art.15-16, 20-21, 24, 26-27, 29, 35**
- **Cabinet Res 74/2020 Art.4-7** (24h EOCN freeze, 5 bd CNMR)
- **Cabinet Res 134/2025 Art.14, 16, 19** (EDD / cross-border AED 60K / internal review)
- **MoE Circular 08/AML/2021** (AED 55K DPMS CTR)
- Tipping-off prohibition (Art.29) and 10-year audit-trail retention (Art.24) both surfaced in the card copy and the reg-basis strip.

## Test plan
- [ ] Load `/screening-command` — hero, 2×2 summary, four cards render with the purple palette.
- [ ] Click each card — iframe opens `index.html?embedded=1#<route>` and URL becomes `/screening-command/<slug>`.
- [ ] Refresh on a deep-linked `/screening-command/subject-screening` — landing page loads and auto-opens the correct module.
- [ ] Browser back / forward traverses module open / close without a full reload.
- [ ] Escape key closes the inline module view.
- [ ] Confirm no hardcoded colour values leaked (all `--azure*` / `--sky` / `--ice` tokens only).
