### PR TITLE
Remove Integrations and Trading tab buttons from SPA nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -2703,7 +2703,7 @@
           <!-- Settings tab removed per MLRO request (previously removed on main) -->
           <!-- Reports tab removed per MLRO request -->
           <!-- Reg Monitor tab removed per MLRO request -->
-          <div class="tab active" data-action="switchTab" data-arg="integrations">🔗 Integrations</div>
+          <!-- Integrations tab removed per MLRO request -->
           <!-- goAML Export removed -->
           <!-- Thresholds tab removed — DPMS AED 55K monitor surfaces automatically on relevant transaction pages -->
           <!-- Supply tab removed per MLRO request -->
@@ -2714,7 +2714,7 @@
           <!-- Export Pipeline tab removed per MLRO request -->
           <!-- Intelligence + Brain Console tabs removed \u2014 internal setup, not disclosed in the tool -->
 
-          <div class="tab" data-action="switchTab" data-arg="metalstrading">◈ Trading</div>
+          <!-- Trading tab removed per MLRO request -->
           <!-- Customer 360 tab removed per MLRO request -->
           <!-- ESG tab removed per MLRO request -->
           <!-- Data Upload removed -->


### PR DESCRIPTION
## Summary

- Removes the two remaining tab nav pill buttons (🔗 Integrations, ◈ Trading) from `index.html` per MLRO request (see screenshot on `hawkeye-sterling-v2.netlify.app`).
- Replaces each with a `<!-- ... removed per MLRO request -->` marker consistent with the existing tab-removal pattern in the same block.
- Surface cards on the landing hub and the `tab-integrations` / `tab-metalstrading` content divs are preserved — only the inline tab navigation entries are removed.

## Regulatory traceability

- **FDL No.10/2025 Art.20** — CO duties over the tool surface (MLRO controls visible navigation).
- **FDL No.10/2025 Art.24** — 10-year record retention; tab-content divs intentionally preserved so historical state stays addressable.

## Test plan

- [ ] Visual check on Netlify preview: nav row no longer shows the Integrations/Trading pills.
- [ ] Confirm the landing-hub surface cards still render (they link via `data-arg` to the preserved tab-content divs).
- [ ] `vitest run` — no tests reference these tab buttons; suite should be green.
- [ ] No CSP regression (pure markup edit, no inline script change → no hash change).

https://claude.ai/code/session_016V9u6yaMJzW48tELE8xKgj