### PR TITLE
Hide landing page chrome when module view is active

### DIFF
--- a/compliance-ops.html
+++ b/compliance-ops.html
@@ -748,6 +748,6 @@
       <span>Confidential &middot; Audit-ready</span>
     </footer>
     <script src="page-nav.js?v=1"></script>
-    <script src="landing-module-viewer.js?v=5"></script>
+    <script src="landing-module-viewer.js?v=6"></script>
   </body>
 </html>

--- a/landing-module-viewer.js
+++ b/landing-module-viewer.js
@@ -5,6 +5,31 @@
   var closeBtn = document.getElementById('moduleViewClose');
   if (!view || !frame || !titleEl || !closeBtn) return;
 
+  // Inject styles that collapse the landing-page chrome (hero, summary,
+  // card grid, regulatory strip) when a module is active. Sub-routes
+  // like /workbench/compliance-tasks must show ONLY the module content,
+  // never the landing-page module cards (URL → content must be
+  // deterministic). Topbar + page-nav + module-view stay visible so the
+  // user can still navigate or close.
+  (function injectModuleViewStyles() {
+    if (document.getElementById('moduleViewActiveStyles')) return;
+    var style = document.createElement('style');
+    style.id = 'moduleViewActiveStyles';
+    style.textContent =
+      'body.module-view-active .hero,' +
+      'body.module-view-active .summary,' +
+      'body.module-view-active .hero-summary,' +
+      'body.module-view-active .section-head,' +
+      'body.module-view-active .cards,' +
+      'body.module-view-active .grid,' +
+      'body.module-view-active .reg-strip,' +
+      'body.module-view-active .reg-basis' +
+      '{display:none !important;}' +
+      'body.module-view-active .module-view{margin-top:0;}' +
+      'body.module-view-active .module-view-frame{height:calc(100vh - 180px);min-height:640px;}';
+    document.head.appendChild(style);
+  })();
+
   // Landing slugs that resolve to a root-level .html via netlify.toml
   // redirects. Any first URL segment outside this list is treated as a
   // raw .html file (defensive: local file:// / preview deploys).
@@ -60,6 +85,7 @@
     titleEl.textContent = label || 'Module';
     view.classList.add('is-open');
     view.setAttribute('aria-hidden', 'false');
+    document.body.classList.add('module-view-active');
     if (pushHistory !== false && slug) {
       var target = getBasePath() + '/' + slug;
       if (location.pathname !== target) {
@@ -75,6 +101,7 @@
   function closeModule(pushHistory) {
     view.classList.remove('is-open');
     view.setAttribute('aria-hidden', 'true');
+    document.body.classList.remove('module-view-active');
     frame.src = 'about:blank';
     if (pushHistory !== false) {
       var base = getBasePath();

--- a/logistics.html
+++ b/logistics.html
@@ -1024,6 +1024,6 @@
       })();
     </script>
     <script src="page-nav.js?v=1"></script>
-    <script src="landing-module-viewer.js?v=5"></script>
+    <script src="landing-module-viewer.js?v=6"></script>
   </body>
 </html>

--- a/screening-command.html
+++ b/screening-command.html
@@ -704,6 +704,6 @@
       <span>© 2026 Hawkeye Sterling</span>
       <span>Confidential &middot; Audit-ready</span>
     </footer>
-    <script src="landing-module-viewer.js?v=4"></script>
+    <script src="landing-module-viewer.js?v=6"></script>
   </body>
 </html>

--- a/workbench.html
+++ b/workbench.html
@@ -643,6 +643,6 @@
       <span class="footer-text">Confidential · Audit-ready</span>
     </footer>
     <script src="page-nav.js?v=1"></script>
-    <script src="landing-module-viewer.js?v=5"></script>
+    <script src="landing-module-viewer.js?v=6"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
This PR ensures that when a module is opened in the module viewer, the landing page chrome (hero section, summary, card grid, regulatory strip) is hidden. This guarantees deterministic URL-to-content mapping for sub-routes like `/workbench/compliance-tasks`, which must display only module content without landing page elements.

## Key Changes
- **Dynamic style injection**: Added `injectModuleViewStyles()` function that creates and injects CSS rules to hide landing page elements (`.hero`, `.summary`, `.section-head`, `.cards`, `.grid`, `.reg-strip`, `.reg-basis`) when `body.module-view-active` class is present
- **Module view layout adjustments**: Applied `margin-top: 0` to `.module-view` and set `.module-view-frame` height to `calc(100vh - 180px)` with minimum height of `640px` for proper spacing when chrome is hidden
- **State management**: Added `document.body.classList.add('module-view-active')` when opening a module and `document.body.classList.remove('module-view-active')` when closing
- **Script version bumps**: Updated `landing-module-viewer.js` script references from v4/v5 to v6 across all affected HTML files (compliance-ops.html, logistics.html, screening-command.html, workbench.html)

## Implementation Details
- The style injection uses an IIFE pattern with an idempotency check (`getElementById('moduleViewActiveStyles')`) to prevent duplicate style tags
- Uses `!important` flags to ensure landing page chrome remains hidden regardless of other CSS specificity
- Topbar, page navigation, and module view container remain visible to maintain navigation capability and allow users to close the module

https://claude.ai/code/session_011DJfznM31gaoaF1huo5uoj