### PR TITLE
Arrange logistics module cards in a single row of four

### DIFF
--- a/logistics.html
+++ b/logistics.html
@@ -437,7 +437,7 @@
       }
 
       .card {
-        grid-column: span 4;
+        grid-column: span 3;
         position: relative;
         padding: 2rem 1.75rem 1.75rem;
         background: linear-gradient(180deg, rgba(14, 56, 36, 0.85) 0%, rgba(10, 40, 24, 0.95) 100%);


### PR DESCRIPTION
## Summary
- Match the Operational Surfaces four-across layout (compliance-ops.html) on the logistics page
- Change `.card { grid-column: span 4 }` to `span 3` on the 12-column logistics grid so all four modules (Inbound Advice, Tracking, Approved Accounts, Local Shipments) sit on one row instead of 3 + 1 wrapped
- Responsive fallbacks unchanged: `span 6` at <=980px (2/row), `span 12` at <=640px (1/row)

## Test plan
- [ ] Visual check at >=1200px width: four cards align in a single row
- [ ] Visual check at ~980px: two cards per row
- [ ] Visual check at <=640px: one card per row
- [ ] Hover / focus styles unaffected