### PR TITLE
Remove § badge icon from Regulatory Basis strips

### DIFF
--- a/index.html
+++ b/index.html
@@ -2666,7 +2666,6 @@
           </div>
 
           <div class="hi-reg-strip" role="note">
-            <div class="hi-reg-badge" aria-hidden="true">&sect;</div>
             <div>
               <div class="hi-reg-title">Regulatory Basis</div>
               <div class="hi-reg-text">

--- a/logistics.html
+++ b/logistics.html
@@ -986,7 +986,6 @@
       </section>
 
       <div class="reg-strip" role="note">
-        <div class="reg-badge" aria-hidden="true">§</div>
         <div class="reg-body">
           <div class="reg-title">Regulatory Basis</div>
           <div class="reg-text">

--- a/routines.html
+++ b/routines.html
@@ -571,7 +571,6 @@
       <div class="routines" id="routinesGrid"></div>
 
       <div class="reg-strip" role="note">
-        <div class="reg-badge" aria-hidden="true">§</div>
         <div>
           <div class="reg-title">Regulatory Basis</div>
           <div class="reg-text">

--- a/workbench.html
+++ b/workbench.html
@@ -636,7 +636,6 @@
       </section>
 
       <div class="reg-strip" role="note">
-        <div class="reg-badge" aria-hidden="true">§</div>
         <div>
           <div class="reg-title">Regulatory Basis</div>
           <div class="reg-text">


### PR DESCRIPTION
## Summary

- Drops the decorative `§` badge (`.reg-badge` / `.hi-reg-badge`) from the Regulatory Basis strips in `workbench.html`, `logistics.html`, `routines.html`, and `index.html`.
- Badge was `aria-hidden="true"` — pure visual decoration, no semantic value.
- No regulatory logic changed. Citations (FDL No.10/2025 Art.20 & Art.24, Cabinet Res 134/2025 Art.7-10 & Art.14 & Art.19, FDL No.10/2025 Art.21, MoE Circular 08/AML/2021, LBMA RGG v9, Cabinet Decision 109/2023, Cabinet Res 74/2020 Art.4, FATF Rec 6) render unchanged on every page.
- CSS rules for `.reg-badge` / `.hi-reg-badge` left in place as dead styling — no runtime impact.

## Test plan

- [ ] `workbench.html` — Regulatory Basis strip renders without icon, text flows full-width
- [ ] `logistics.html` — Regulatory Basis strip renders without icon, text flows full-width
- [ ] `routines.html` — Regulatory Basis strip renders without icon, text flows full-width
- [ ] `index.html` — Hawkeye Sterling integrations section's Regulatory Basis strip renders without icon
- [ ] No console errors, no broken layout on mobile breakpoints

https://claude.ai/code/session_01VGc4jxcBr6xaeESPj1L1RW