### PR TITLE
Force fresh HTML on bfcache restore + imperative topbar/page-nav hide

### DIFF
--- a/compliance-ops.html
+++ b/compliance-ops.html
@@ -763,6 +763,6 @@
       <span>Confidential &middot; Audit-ready</span>
     </footer>
     <script src="page-nav.js?v=1"></script>
-    <script src="landing-module-viewer.js?v=8"></script>
+    <script src="landing-module-viewer.js?v=9"></script>
   </body>
 </html>

--- a/landing-module-viewer.js
+++ b/landing-module-viewer.js
@@ -1,9 +1,32 @@
 (function () {
+  // iOS Safari / Firefox bfcache: when the landing page is restored
+  // from the back/forward cache (e.g. after merging a fix + returning
+  // via Safari's back button), the page state is revived WITHOUT
+  // re-requesting the HTML — so a stale-build topbar/page-nav can
+  // keep rendering even after a deploy. Force a hard reload on bfcache
+  // restore so every post-deploy visit sees the current HTML.
+  window.addEventListener('pageshow', function (e) {
+    if (e && e.persisted) window.location.reload();
+  });
+
   var view = document.getElementById('moduleView');
   var frame = document.getElementById('moduleViewFrame');
   var titleEl = document.getElementById('moduleViewTitle');
   var closeBtn = document.getElementById('moduleViewClose');
   if (!view || !frame || !titleEl || !closeBtn) return;
+
+  // Imperative DOM hide — defense-in-depth for stale-HTML clients
+  // whose cached inline <style> does not yet include .topbar + .page-nav
+  // in the module-view-active hide list. Sets `hidden` attribute directly
+  // on the elements, which is harder for any cached CSS to un-hide.
+  function applyImperativeHide() {
+    var onSubRoute = document.documentElement.classList.contains('module-view-active');
+    var els = document.querySelectorAll('.topbar, .page-nav, #pageNav');
+    for (var i = 0; i < els.length; i++) {
+      if (onSubRoute) els[i].setAttribute('hidden', '');
+      else els[i].removeAttribute('hidden');
+    }
+  }
 
   // Landing chrome (hero, summary, card grid, regulatory strip) must be
   // MUTUALLY EXCLUSIVE with module content: sub-routes like
@@ -95,6 +118,7 @@
     view.classList.add('is-open');
     view.setAttribute('aria-hidden', 'false');
     document.documentElement.classList.add('module-view-active');
+    applyImperativeHide();
     if (pushHistory !== false && slug) {
       var target = getBasePath() + '/' + slug;
       if (location.pathname !== target) {
@@ -111,6 +135,7 @@
     view.classList.remove('is-open');
     view.setAttribute('aria-hidden', 'true');
     document.documentElement.classList.remove('module-view-active');
+    applyImperativeHide();
     frame.src = 'about:blank';
     if (pushHistory !== false) {
       var base = getBasePath();
@@ -184,6 +209,13 @@
     if (LANDING_SLUGS.indexOf(first) === -1) return;
     openSlug(segs[1], false);
   })();
+
+  // Run the imperative hide once at script-load in case the inline head
+  // script already set `module-view-active` (the sub-route auto-detect)
+  // but no card/pill click has fired yet. Belt-and-suspenders: even a
+  // stale cached inline <style> block without .topbar/.page-nav in the
+  // hide list gets covered by the `hidden` attribute set here.
+  applyImperativeHide();
 
   // When the embedded app navigates internally (user clicks a nav-bar
   // item inside index.html), mirror the new route into the parent URL

--- a/logistics.html
+++ b/logistics.html
@@ -1038,6 +1038,6 @@
       })();
     </script>
     <script src="page-nav.js?v=1"></script>
-    <script src="landing-module-viewer.js?v=8"></script>
+    <script src="landing-module-viewer.js?v=9"></script>
   </body>
 </html>

--- a/screening-command.html
+++ b/screening-command.html
@@ -762,6 +762,6 @@
       <span>Confidential &middot; Audit-ready</span>
     </footer>
     <script src="page-nav.js?v=1"></script>
-    <script src="landing-module-viewer.js?v=8"></script>
+    <script src="landing-module-viewer.js?v=9"></script>
   </body>
 </html>

--- a/workbench.html
+++ b/workbench.html
@@ -657,6 +657,6 @@
       <span class="footer-text">Confidential · Audit-ready</span>
     </footer>
     <script src="page-nav.js?v=1"></script>
-    <script src="landing-module-viewer.js?v=8"></script>
+    <script src="landing-module-viewer.js?v=9"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Fixes the "empty landing pages" regression observed after #349 on iOS Safari and Windows Edge — landing roots `/compliance-ops`, `/workbench`, `/screening-command`, `/logistics` rendered with title + footer only, everything else hidden.

## Root cause

Browser **bfcache** (back-forward cache) restored the previous sub-route page state — including the `html.module-view-active` class set by the inline head script — **without** re-running the inline head script against the new pathname. Result: #349's CSS rule (which hides every landing element when `module-view-active` is set) kept hiding everything while the class stayed set from the cached state.

## Changes (3 defenses)

1. **bfcache force-reload** — `landing-module-viewer.js` registers a `pageshow` handler that calls `window.location.reload()` when `event.persisted === true`. Forces a fresh network fetch of the HTML (Netlify's `no-cache` headers apply normally), so the inline head script re-runs against the new pathname.

2. **Imperative DOM hide** — belt-and-suspenders fallback that sets the `hidden` attribute directly on `.topbar, .page-nav, #pageNav` whenever `module-view-active` is present (or clears it when absent). Defends stale-HTML clients whose cached inline `<style>` block pre-dates #349.

3. **Cache-bust** `landing-module-viewer.js?v=8 → v=9` on the four embedding landing pages.

## Not changed

- No CSP hash churn. `landing-module-viewer.js` is an external file (not hashed).
- No backend / src/ changes.
- routines.html doesn't load `landing-module-viewer.js` (filter chips handled inline) so no edit needed there.

## Regulatory basis

- **FDL No.10/2025 Art.20** — operational continuity; an empty stale-bfcache page is as broken as a chrome-leak page.
- **FDL No.10/2025 Art.24** — URLs must resolve to the visible content the auditor expects.

## Test plan

- [ ] Hard-refresh `hawkeye-sterling-v2.netlify.app/compliance-ops` — landing renders normally (title + nav pills + cards + footer).
- [ ] Navigate to `/compliance-ops/training` — only module content + back button visible.
- [ ] Press browser back → `/compliance-ops` — landing re-renders normally (no stale hidden state).
- [ ] Repeat on workbench/screening-command/logistics.
- [ ] DevTools: no "Refused to execute" CSP warnings, no 404s for `landing-module-viewer.js?v=9`.

## Separate issue noted (not fixed here)

Netlify observability shows `499 POST /.netlify/functions/...` at 08:10 — client-aborted by the 12s `AbortController` in `screening-command.js` (from #348). If screening runs routinely take >12s, the client budget needs raising to ~25s (server hard-cap is ~26s). Will investigate + fix separately once this PR is merged and the landing renders correctly.

https://claude.ai/code/session_01S35WwMWPqNrXcDi4saU9D6