### PR TITLE
Raise screening client AbortController 12s → 25s

### DIFF
--- a/screening-command.js
+++ b/screening-command.js
@@ -374,14 +374,25 @@
 
   // ─── Shared fetch helper ─────────────────────────────────────────
   //
-  // The server enforces an internal 6.5s deadline on the screening
-  // pipeline (netlify/functions/screening-run.mts). Client-side we cap
-  // at 12s so that a Netlify edge hang never leaves the MLRO staring
-  // at a spinner — a clear "timed out, re-screen" message is better
-  // than an indefinite wait under FDL No.10/2025 Art.20 (no delay in
-  // screening action). If the server responds earlier (normal case),
-  // the AbortController is a no-op.
-  const API_TIMEOUT_MS = 12_000;
+  // Server-side budget for /api/screening-run (worst case):
+  //   SANCTIONS_FETCH_TIMEOUT_MS = 6_500ms (5 lists, race + blob fallback)
+  //   ADVERSE_MEDIA_TIMEOUT_MS   = 3_000ms
+  //   WATCHLIST_TIMEOUT_MS       = 1_200ms
+  //   ASANA_TIMEOUT_MS           = 1_500ms
+  //   + 5 subsystems × ~1s each for anomaly / scoring / corroboration
+  //   ≈ 18–22s upper bound under load.
+  //
+  // Netlify sync functions hard-cap at 26s. The client cap must sit
+  // safely above the server's realistic upper bound AND below Netlify's
+  // death limit. 25s covers the full worst-case pipeline while still
+  // firing on genuinely stuck connections — the 12s cap used in #348
+  // was too tight and was triggering 499 client-aborts on normal slow-
+  // path screenings (see Netlify observability 08:10 cluster).
+  //
+  // Regulatory: FDL Art.20-21 — no delay in screening action. A clear
+  // "timed out, re-screen" after 25s is still actionable; a premature
+  // 12s abort on an in-progress screen is not.
+  const API_TIMEOUT_MS = 25_000;
 
   async function apiPost(endpoint, body) {
     saveToken();


### PR DESCRIPTION
## Summary

Netlify observability at 08:10 showed a cluster of `499` "client closed request" POSTs on `/.netlify/functions/screening-run`. Root cause: the client-side `AbortController` cap added in #348 was 12,000ms, which is tighter than the server's realistic upper bound for a full screening run under load. Real screenings were being aborted by the browser before the server could respond, leaving the MLRO with a "re-screen" message on an otherwise-working pipeline — a regulatory gap under FDL Art.20-21 (no delay in screening action).

## Budget analysis

| Server-side subsystem | Cap |
|---|---|
| `SANCTIONS_FETCH_TIMEOUT_MS` | 6,500 ms |
| `ADVERSE_MEDIA_TIMEOUT_MS` | 3,000 ms |
| `WATCHLIST_TIMEOUT_MS` | 1,200 ms |
| `ASANA_TIMEOUT_MS` | 1,500 ms |
| 5 brain subsystems (cold-start worst) | ~5,000 ms |
| **Upper bound** | **~18–22 s** |

Netlify sync functions hard-cap at 26 s. The client cap must sit **above** the server's worst case and **below** Netlify's death limit. `25,000 ms` satisfies both — covers the full slow path, still fires on genuinely stuck connections.

## Changes

- `screening-command.js` — `API_TIMEOUT_MS` raised from 12,000 to 25,000. Comment expanded with the budget breakdown so the next reader doesn't re-relitigate the choice.
- Error-message template unchanged; reads `Math.round(API_TIMEOUT_MS / 1000) + 's'`, so the diagnostic auto-reads "25s" instead of "12s".

## Not changed

- No server/`src`/`.mts` changes. Server timeouts already balanced.
- No CSP hash churn (JS-only edit, not inline).

## Regulatory basis

**FDL No.10/2025 Art.20-21** — no delay in screening action. A premature 12s client abort on an in-progress screen forces the MLRO to re-run from scratch; a 25s cap still protects against indefinite hangs while letting the server complete its normal worst-case path.

## Test plan

- [ ] Deploy preview: `/screening-command/subject-screening` submit succeeds end-to-end on slow-path screenings (previously triggering 499) without client-side abort.
- [ ] Observability post-deploy: `499` cluster on `screening-run` drops to near-zero during normal load.
- [ ] A deliberately stuck network (e.g. offline mid-request) still surfaces "Request timed out after 25s" within 25s — no indefinite spinner.

https://claude.ai/code/session_01S35WwMWPqNrXcDi4saU9D6