### PR TITLE
Surface /routines as main-page nav card (FDL No.10/2025 Art.20 & Art.24)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2564,6 +2564,10 @@
             --hi-blue-bright: #5ea3ff;
             --hi-blue-dim: rgba(47, 125, 255, 0.14);
             --hi-blue-border: rgba(47, 125, 255, 0.4);
+            --hi-purple: #a855f7;
+            --hi-purple-bright: #c084fc;
+            --hi-purple-dim: rgba(168, 85, 247, 0.14);
+            --hi-purple-border: rgba(168, 85, 247, 0.4);
             --hi-ink: #fef3c7;
             --hi-muted: rgba(254, 243, 199, 0.58);
             --hi-border: rgba(250, 204, 21, 0.18);
@@ -2708,6 +2712,8 @@
           .hi-card[data-tone="orange"]:hover { box-shadow: 0 20px 50px -22px rgba(251, 146, 60, 0.55); }
           .hi-card[data-tone="blue"] { color: var(--hi-blue); border-color: var(--hi-blue-border); }
           .hi-card[data-tone="blue"]:hover { box-shadow: 0 20px 50px -22px rgba(47, 125, 255, 0.55); }
+          .hi-card[data-tone="purple"] { color: var(--hi-purple); border-color: var(--hi-purple-border); }
+          .hi-card[data-tone="purple"]:hover { box-shadow: 0 20px 50px -22px rgba(168, 85, 247, 0.55); }
 
           .hi-card-icon {
             width: 52px; height: 52px; border-radius: 14px;
@@ -2848,7 +2854,7 @@
 
           <div class="hi-section-head">
             <span class="hi-section-label">Operations Surfaces</span>
-            <span class="hi-section-count">05 / 05</span>
+            <span class="hi-section-count">06 / 06</span>
           </div>
 
           <div class="hi-cards">
@@ -3009,6 +3015,39 @@
                 <div class="hi-stat">
                   <span class="hi-stat-val">24h</span>
                   <span class="hi-stat-key">EOCN freeze</span>
+                </div>
+              </div>
+              <div class="hi-card-cta">
+                <span>Open surface</span>
+                <span class="hi-card-cta-arrow" aria-hidden="true">&rarr;</span>
+              </div>
+            </a>
+
+            <a
+              class="hi-card"
+              data-tone="purple"
+              href="/routines"
+              aria-label="Open the Routines registry surface"
+            >
+              <div class="hi-card-icon" aria-hidden="true">&#9696;</div>
+              <div class="hi-card-meta">
+                <span class="dot"></span>
+                <span>Surface 06 &middot; Routines</span>
+              </div>
+              <h2 class="hi-card-title">Routines Registry</h2>
+              <p class="hi-card-desc">
+                Every scheduled compliance workflow in one place &mdash;
+                sanctions ingestion, CDD rollups, regulatory drift, KPI
+                digests. See what runs, when, and under which article.
+              </p>
+              <div class="hi-card-stats">
+                <div class="hi-stat">
+                  <span class="hi-stat-val">20</span>
+                  <span class="hi-stat-key">Routines</span>
+                </div>
+                <div class="hi-stat">
+                  <span class="hi-stat-val">10yr</span>
+                  <span class="hi-stat-key">Audit trail</span>
                 </div>
               </div>
               <div class="hi-card-cta">


### PR DESCRIPTION
## Summary

- Adds a 6th surface card on `index.html` linking to `/routines` so the MLRO can click through from the main page to the Routines registry.
- `routines.html` already existed (20 scheduled compliance workflows: sanctions ingest, CDD rollups, regulatory drift, KPI digests, etc.) and is routed via `netlify.toml`, but there was no entry point from the main page — a user landing on the index could not reach it.
- Adds a `purple` tone (`--hi-purple*` variables + `.hi-card[data-tone="purple"]`) matching the Weaponized Brain accent already used in `routines.html`'s brain-strip.
- Bumps the "Operations Surfaces" count from `05 / 05` to `06 / 06`.

## Regulatory Basis

Keeps the 10-year audit trail visibility requirement under **FDL No.10/2025 Art.24** reachable from the entry page, and aligns with **FDL No.10/2025 Art.20** (CO duties — the MLRO must be able to see what scheduled routines are running).

## Test plan

- [ ] Load `/` in the browser — the landing grid shows 6 cards ending with "Routines Registry".
- [ ] Click the Routines card — navigates to `/routines` and renders the existing routines registry with 20 scheduled workflows.
- [ ] Cadence chips (All / Continuous / Daily / Weekly) filter the grid correctly.
- [ ] `/routines/continuous`, `/routines/daily`, `/routines/weekly` deep-links pre-select the matching chip.
- [ ] Mobile viewport: the 6-card grid reflows cleanly without breaking the existing 5-card layout.
- [ ] Dark/light theme: purple tone remains legible in both.

https://claude.ai/code/session_01SbGnFb82KHiyNye6B7sQ1d