### PR TITLE
Fix anthropicAdvisor stream idle timeout — wrong proxy body shape + no SSE

### DIFF
--- a/src/services/anthropicAdvisor.ts
+++ b/src/services/anthropicAdvisor.ts
@@ -30,6 +30,23 @@
  *   clampReasons, narrative). The Art.29 tipping-off linter runs
  *   on the response text before it is returned.
  *
+ * Transport discipline (stream idle timeout fix):
+ *   This module used to hand-roll a non-streaming POST whose body
+ *   shape also did not match what `/api/ai-proxy` destructures
+ *   (`{ body: {...} }` vs the proxy's `{ payload: {...} }`). That
+ *   bug had two consequences in production:
+ *     1. The proxy forwarded `undefined` as the request body, so
+ *        Anthropic rejected every call and the MLRO silently saw
+ *        deterministic-fallback advice on every escalation.
+ *     2. On the paths where it did reach upstream, the non-stream
+ *        proxy timeout (22s) fired mid-Opus-call (Opus advisor
+ *        sub-inferences routinely run 20-40s) and the caller saw
+ *        "Stream idle timeout - partial response received".
+ *   We now route through `callAdvisorAssisted`, which builds the
+ *   correct `payload` shape, uses the official advisor tool type,
+ *   and enables SSE streaming so the proxy's `: keepalive` comment
+ *   frames hold the socket open during quiet thinking windows.
+ *
  * Regulatory basis:
  *   FDL No.10/2025 Art.20-21 (CO duty — advisor escalation)
  *   FDL No.10/2025 Art.29    (no tipping off — linter on response)
@@ -46,8 +63,8 @@ import { deterministicAdvisor } from './brainSuperRunner';
 import {
   EXECUTOR_SONNET,
   ADVISOR_OPUS,
-  ADVISOR_BETA_HEADER,
-  COMPLIANCE_ADVISOR_SYSTEM_PROMPT,
+  callAdvisorAssisted,
+  type FetchLike,
 } from './advisorStrategy';
 import { lintForTippingOff } from './tippingOffLinter';
 
@@ -63,17 +80,16 @@ export interface AnthropicAdvisorOptions {
   /** Advisor model. Default: claude-opus-4-6. */
   advisor?: string;
   /**
-   * Request timeout ms. Default: 60000.
+   * Wall-clock cap on a single advisor call, in ms. Default: 120_000.
    *
-   * Why 60s and not the old 15s: Opus advisor calls under load
-   * regularly run 20-40s end-to-end. A 15s AbortController fires
-   * mid-stream, which the browser surfaces as
-   * "Stream idle timeout - partial response received" — even though
-   * the upstream is still working fine. 60s is short enough to fail
-   * fast on a dead proxy, long enough to wait out a normal Opus call.
-   * Callers that need a tighter bound (e.g. synchronous UI paths)
-   * can still pass a smaller timeoutMs; the fallback to the
-   * deterministic advisor is what keeps the decision path unblocked.
+   * This is deliberately larger than the proxy's own streaming
+   * wall-clock (STREAM_WALL_CLOCK_MS = 24s) and the inter-byte
+   * watchdog (STREAM_IDLE_READ_TIMEOUT_MS = 30s) so that the
+   * tighter server-side limits fire first and surface structured
+   * errors. The client-side timer exists only as a backstop for
+   * a genuinely wedged network. Callers that need a tighter bound
+   * (e.g. synchronous UI paths) can still pass a smaller value;
+   * the deterministic fallback keeps the decision path unblocked.
    */
   timeoutMs?: number;
   /** HAWKEYE bearer token for the proxy. Default: from window or env. */
@@ -127,50 +143,6 @@ interface AnthropicResponseShape {
   usage?: { input_tokens?: number; output_tokens?: number };
 }
 
-async function callProxy(
-  proxyUrl: string,
-  bearer: string | undefined,
-  body: Record<string, unknown>,
-  timeoutMs: number,
-  fetchImpl: typeof fetch
-): Promise<AdvisorEscalationResult> {
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-  };
-  if (bearer) headers['Authorization'] = `Bearer ${bearer}`;
-
-  const controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
-  const timer = controller !== null ? setTimeout(() => controller.abort(), timeoutMs) : null;
-
-  try {
-    const res = await fetchImpl(proxyUrl, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(body),
-      signal: controller?.signal,
-    });
-    if (!res.ok) {
-      throw new Error(`ai-proxy returned ${res.status}`);
-    }
-    const payload = (await res.json()) as AnthropicResponseShape;
-    const text = extractText(payload);
-    const lint = lintForTippingOff(text);
-    if (!lint.clean && (lint.topSeverity === 'critical' || lint.topSeverity === 'high')) {
-      throw new Error(
-        `advisor response blocked by FDL Art.29 linter: ` +
-          lint.findings.map((f) => f.patternId).join(',')
-      );
-    }
-    return {
-      text: text.slice(0, 1000), // hard cap just in case the model ignores <100 words
-      advisorCallCount: 1,
-      modelUsed: payload.model ?? 'claude-opus-4-6',
-    };
-  } finally {
-    if (timer !== null) clearTimeout(timer);
-  }
-}
-
 function extractText(payload: AnthropicResponseShape): string {
   if (!payload || !Array.isArray(payload.content)) return '';
   const parts = payload.content
@@ -189,7 +161,7 @@ export function createAnthropicAdvisor(opts: AnthropicAdvisorOptions = {}): Advi
   const proxyUrl = opts.proxyUrl ?? '/api/ai-proxy';
   const executor = opts.executor ?? EXECUTOR_SONNET;
   const advisor = opts.advisor ?? ADVISOR_OPUS;
-  const timeoutMs = opts.timeoutMs ?? 60_000;
+  const timeoutMs = opts.timeoutMs ?? 120_000;
   const warnOnFallback = opts.warnOnFallback ?? true;
   const fetchImpl =
     opts.fetchImpl ??
@@ -202,31 +174,67 @@ export function createAnthropicAdvisor(opts: AnthropicAdvisorOptions = {}): Advi
   }
 
   return async (input: AdvisorEscalationInput): Promise<AdvisorEscalationResult> => {
-    const body = {
-      provider: 'anthropic',
-      path: '/v1/messages',
-      betas: [ADVISOR_BETA_HEADER],
-      body: {
-        model: executor,
-        max_tokens: 512,
-        system: COMPLIANCE_ADVISOR_SYSTEM_PROMPT,
-        messages: [
-          {
-            role: 'user',
-            content: buildUserMessage(input),
-          },
-        ],
-        metadata: {
-          user_id: input.entityId,
-        },
-        // Advisor pairing declaration — the executor model above
-        // uses this advisor as its back-channel reviewer.
-        advisor: { model: advisor },
-      },
-    };
+    // Wall-clock backstop. The proxy's own stream wall-clock (24s)
+    // and inter-byte watchdog (30s) fire first in normal operation;
+    // this exists only to rescue the fallback path when the network
+    // itself is wedged and the server-side timers can't reach us.
+    const wallClock =
+      typeof AbortController !== 'undefined' ? new AbortController() : null;
+    const wallClockTimer =
+      wallClock !== null ? setTimeout(() => wallClock.abort(), timeoutMs) : null;
+
+    const abortableFetch: FetchLike = (async (url, init) => {
+      const res = await fetchImpl(url, {
+        method: init.method,
+        headers: init.headers,
+        body: init.body,
+        signal: wallClock?.signal,
+      });
+      return {
+        ok: res.ok,
+        status: res.status,
+        json: () => res.json(),
+        body: res.body,
+      };
+    }) as FetchLike;
 
     try {
-      return await callProxy(proxyUrl, opts.bearerToken, body, timeoutMs, fetchImpl);
+      const result = await callAdvisorAssisted(
+        {
+          userMessage: buildUserMessage(input),
+          executor,
+          advisor,
+          maxAdvisorUses: 1,
+          maxTokens: 512,
+          // Stream so `/api/ai-proxy` injects `: keepalive\n\n` SSE
+          // comments during Opus thinking windows. Without this the
+          // caller sees "Stream idle timeout - partial response
+          // received" whenever the advisor pauses mid-flight.
+          stream: true,
+        },
+        {
+          endpoint: proxyUrl,
+          authToken: opts.bearerToken,
+          fetch: abortableFetch,
+        }
+      );
+
+      const text = extractText({
+        content: [{ type: 'text', text: result.text }],
+      });
+      const lint = lintForTippingOff(text);
+      if (!lint.clean && (lint.topSeverity === 'critical' || lint.topSeverity === 'high')) {
+        throw new Error(
+          `advisor response blocked by FDL Art.29 linter: ` +
+            lint.findings.map((f) => f.patternId).join(',')
+        );
+      }
+
+      return {
+        text: text.slice(0, 1000),
+        advisorCallCount: result.advisorCallCount > 0 ? result.advisorCallCount : 1,
+        modelUsed: advisor,
+      };
     } catch (err) {
       if (warnOnFallback) {
         console.warn(
@@ -235,6 +243,8 @@ export function createAnthropicAdvisor(opts: AnthropicAdvisorOptions = {}): Advi
         );
       }
       return deterministicAdvisor(input);
+    } finally {
+      if (wallClockTimer !== null) clearTimeout(wallClockTimer);
     }
   };
 }

--- a/tests/anthropicAdvisor.test.ts
+++ b/tests/anthropicAdvisor.test.ts
@@ -2,11 +2,13 @@
  * Anthropic-backed advisor tests.
  *
  * Covers:
- *   - Successful proxy call returns the advisor text
- *   - Proxy error → deterministic fallback
- *   - Proxy timeout → deterministic fallback
- *   - Proxy returning a tipping-off-flagged reply → deterministic fallback
- *   - buildUserMessage never contains the executor system prompt
+ *   - Request shape matches `/api/ai-proxy` (payload, stream, betas)
+ *   - Successful SSE proxy response returns the advisor text
+ *   - Proxy non-2xx → deterministic fallback
+ *   - Network error → deterministic fallback
+ *   - Tipping-off-flagged advisor reply → deterministic fallback
+ *   - 1000-char response cap
+ *   - buildUserMessage carries every input field
  *   - extractText concatenates multi-part text arrays
  */
 import { describe, it, expect, vi } from "vitest";
@@ -31,6 +33,103 @@ function input(
     narrative: "Multi-subsystem narrative text without any subject name.",
     ...overrides,
   };
+}
+
+/**
+ * Build a mock SSE Response whose body streams a minimal Anthropic
+ * transcript: message_start, one text block, message_delta, message_stop.
+ * The advisor SSE parser consumes these exact event shapes.
+ */
+function sseResponse(
+  text: string,
+  init: {
+    status?: number;
+    advisorCalls?: number;
+    inputTokens?: number;
+    outputTokens?: number;
+  } = {}
+): Response {
+  const status = init.status ?? 200;
+  const inputTokens = init.inputTokens ?? 10;
+  const outputTokens = init.outputTokens ?? 20;
+  const advisorCalls = init.advisorCalls ?? 0;
+
+  const frames: string[] = [];
+  // Proxy advisory frame — emitted first by /api/ai-proxy.
+  frames.push(
+    `event: proxy_ready\ndata: ${JSON.stringify({
+      serverTime: new Date().toISOString(),
+    })}\n\n`
+  );
+  // Anthropic stream events.
+  frames.push(
+    `event: message_start\ndata: ${JSON.stringify({
+      type: "message_start",
+      message: { usage: { input_tokens: inputTokens, output_tokens: 0 } },
+    })}\n\n`
+  );
+  // Emit `advisorCalls` server_tool_use blocks named "advisor" so the
+  // parser counts them correctly.
+  let blockIdx = 0;
+  for (let i = 0; i < advisorCalls; i++) {
+    frames.push(
+      `event: content_block_start\ndata: ${JSON.stringify({
+        type: "content_block_start",
+        index: blockIdx,
+        content_block: { type: "server_tool_use", name: "advisor" },
+      })}\n\n`
+    );
+    frames.push(
+      `event: content_block_stop\ndata: ${JSON.stringify({
+        type: "content_block_stop",
+        index: blockIdx,
+      })}\n\n`
+    );
+    blockIdx++;
+  }
+  // One text block with the advisor's visible reply.
+  frames.push(
+    `event: content_block_start\ndata: ${JSON.stringify({
+      type: "content_block_start",
+      index: blockIdx,
+      content_block: { type: "text", text: "" },
+    })}\n\n`
+  );
+  frames.push(
+    `event: content_block_delta\ndata: ${JSON.stringify({
+      type: "content_block_delta",
+      index: blockIdx,
+      delta: { type: "text_delta", text },
+    })}\n\n`
+  );
+  frames.push(
+    `event: content_block_stop\ndata: ${JSON.stringify({
+      type: "content_block_stop",
+      index: blockIdx,
+    })}\n\n`
+  );
+  frames.push(
+    `event: message_delta\ndata: ${JSON.stringify({
+      type: "message_delta",
+      usage: { input_tokens: inputTokens, output_tokens: outputTokens },
+    })}\n\n`
+  );
+  frames.push(
+    `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`
+  );
+
+  const enc = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const f of frames) controller.enqueue(enc.encode(f));
+      controller.close();
+    },
+  });
+
+  return new Response(body, {
+    status,
+    headers: { "Content-Type": "text/event-stream" },
+  });
 }
 
 describe("buildUserMessage", () => {
@@ -75,29 +174,22 @@ describe("extractText", () => {
 });
 
 // ---------------------------------------------------------------------------
-// createAnthropicAdvisor — happy path
+// createAnthropicAdvisor — request shape + happy path
 // ---------------------------------------------------------------------------
 
 describe("createAnthropicAdvisor — proxy success", () => {
-  it("returns the text from a successful proxy response", async () => {
-    const fakeFetch = vi.fn(async () => {
-      return new Response(
-        JSON.stringify({
-          model: "claude-opus-4-6",
-          content: [
-            {
-              type: "text",
-              text: "1. Escalate to CO. 2. Apply four-eyes. 3. Document reasoning.",
-            },
-          ],
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } }
-      );
-    }) as unknown as typeof fetch;
+  it("returns the text from a successful SSE proxy response", async () => {
+    const fakeFetch = vi.fn(async () =>
+      sseResponse(
+        "1. Escalate to CO. 2. Apply four-eyes. 3. Document reasoning.",
+        { advisorCalls: 1 }
+      )
+    ) as unknown as typeof fetch;
 
     const advisor = createAnthropicAdvisor({
       proxyUrl: "http://fake/api/ai-proxy",
       fetchImpl: fakeFetch,
+      bearerToken: "test-token",
       warnOnFallback: false,
     });
     const result = await advisor(input());
@@ -109,29 +201,69 @@ describe("createAnthropicAdvisor — proxy success", () => {
     expect(fakeFetch).toHaveBeenCalledTimes(1);
   });
 
-  it("forwards the advisor-tool beta flag in the request body", async () => {
+  it("posts the correct ai-proxy request shape (payload, stream, advisor tool)", async () => {
     let capturedBody: string | null = null;
     const fakeFetch = vi.fn(async (_url: unknown, init: RequestInit) => {
       capturedBody = init.body as string;
-      return new Response(
-        JSON.stringify({ content: [{ type: "text", text: "ok" }] }),
-        { status: 200, headers: { "Content-Type": "application/json" } }
-      );
+      return sseResponse("ok");
     }) as unknown as typeof fetch;
 
     const advisor = createAnthropicAdvisor({
       proxyUrl: "http://fake/api/ai-proxy",
       fetchImpl: fakeFetch,
+      bearerToken: "test-token",
       warnOnFallback: false,
     });
     await advisor(input());
     expect(capturedBody).not.toBeNull();
     const parsed = JSON.parse(capturedBody!);
-    expect(parsed.betas).toContain("advisor-tool-2026-03-01");
+
+    // Proxy envelope.
     expect(parsed.provider).toBe("anthropic");
     expect(parsed.path).toBe("/v1/messages");
-    expect(parsed.body.model).toBe("claude-sonnet-4-6");
-    expect(parsed.body.advisor?.model).toBe("claude-opus-4-6");
+    expect(parsed.betas).toContain("advisor-tool-2026-03-01");
+    // Stream flag must be set at BOTH the proxy envelope level and
+    // the Anthropic payload level — the proxy reads its own flag to
+    // enable keepalive injection, and Anthropic reads its payload
+    // flag to actually emit SSE.
+    expect(parsed.stream).toBe(true);
+    expect(parsed.payload.stream).toBe(true);
+
+    // Payload — note the field name is `payload`, NOT `body`. The old
+    // code sent `body` which the proxy silently dropped, producing
+    // "Stream idle timeout - partial response received" on every call.
+    expect(parsed.payload.model).toBe("claude-sonnet-4-6");
+    expect(parsed.payload.max_tokens).toBe(512);
+    expect(typeof parsed.payload.system).toBe("string");
+    expect(Array.isArray(parsed.payload.tools)).toBe(true);
+
+    const advisorTool = parsed.payload.tools.find(
+      (t: { type?: string; name?: string }) =>
+        t.type === "advisor_20260301" && t.name === "advisor"
+    );
+    expect(advisorTool).toBeDefined();
+    expect(advisorTool.model).toBe("claude-opus-4-6");
+    expect(advisorTool.max_uses).toBe(1);
+  });
+
+  it("sends an Authorization: Bearer header derived from bearerToken", async () => {
+    let capturedHeaders: Record<string, string> | null = null;
+    const fakeFetch = vi.fn(async (_url: unknown, init: RequestInit) => {
+      capturedHeaders = init.headers as Record<string, string>;
+      return sseResponse("ok");
+    }) as unknown as typeof fetch;
+
+    const advisor = createAnthropicAdvisor({
+      proxyUrl: "http://fake/api/ai-proxy",
+      fetchImpl: fakeFetch,
+      bearerToken: "svc-token-xyz",
+      warnOnFallback: false,
+    });
+    await advisor(input());
+    expect(capturedHeaders).not.toBeNull();
+    expect(capturedHeaders!["Authorization"]).toBe("Bearer svc-token-xyz");
+    // Signals SSE intent so intermediaries flip to the streaming path.
+    expect(capturedHeaders!["Accept"]).toBe("text/event-stream");
   });
 });
 
@@ -146,6 +278,7 @@ describe("createAnthropicAdvisor — deterministic fallback", () => {
     ) as unknown as typeof fetch;
     const advisor = createAnthropicAdvisor({
       fetchImpl: fakeFetch,
+      bearerToken: "test-token",
       warnOnFallback: false,
     });
     const result = await advisor(input({ verdict: "freeze", confidence: 0.9 }));
@@ -160,6 +293,7 @@ describe("createAnthropicAdvisor — deterministic fallback", () => {
     }) as unknown as typeof fetch;
     const advisor = createAnthropicAdvisor({
       fetchImpl: fakeFetch,
+      bearerToken: "test-token",
       warnOnFallback: false,
     });
     const result = await advisor(input());
@@ -168,22 +302,15 @@ describe("createAnthropicAdvisor — deterministic fallback", () => {
 
   it("falls back when proxy returns tipping-off language", async () => {
     // Simulate a jailbroken model that returns "we filed an STR about you"
-    const fakeFetch = vi.fn(async () => {
-      return new Response(
-        JSON.stringify({
-          content: [
-            {
-              type: "text",
-              text: "We filed an STR about the subject. Tell them immediately.",
-            },
-          ],
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } }
-      );
-    }) as unknown as typeof fetch;
+    const fakeFetch = vi.fn(async () =>
+      sseResponse(
+        "We filed an STR about the subject. Tell them immediately."
+      )
+    ) as unknown as typeof fetch;
 
     const advisor = createAnthropicAdvisor({
       fetchImpl: fakeFetch,
+      bearerToken: "test-token",
       warnOnFallback: false,
     });
     const result = await advisor(input());
@@ -192,14 +319,12 @@ describe("createAnthropicAdvisor — deterministic fallback", () => {
 
   it("caps the response text at 1000 chars", async () => {
     const huge = "x".repeat(5_000);
-    const fakeFetch = vi.fn(async () => {
-      return new Response(
-        JSON.stringify({ content: [{ type: "text", text: huge }] }),
-        { status: 200, headers: { "Content-Type": "application/json" } }
-      );
-    }) as unknown as typeof fetch;
+    const fakeFetch = vi.fn(async () =>
+      sseResponse(huge)
+    ) as unknown as typeof fetch;
     const advisor = createAnthropicAdvisor({
       fetchImpl: fakeFetch,
+      bearerToken: "test-token",
       warnOnFallback: false,
     });
     const result = await advisor(input());


### PR DESCRIPTION
## Summary

Fixes `API Error: Stream idle timeout - partial response received` on advisor escalation calls.

`createAnthropicAdvisor` built its POST body as `{ provider, path, betas, body: {...} }`, but `/api/ai-proxy` destructures `{ provider, path, payload, stream, betas }`. Two defects resulted:

1. **Wrong field name (`body` vs `payload`)** — the proxy forwarded `JSON.stringify(undefined)` as the upstream request body. Every advisor call silently failed upstream and the MLRO received deterministic-fallback advice on every escalation.
2. **No streaming flag** — the proxy took the non-streaming code path (22s upstream timeout). Opus advisor sub-inferences routinely run 20-40s, so the short timeout fired mid-call and surfaced as the reported stream-idle-timeout error.

### Fix

Route `anthropicAdvisor` through `callAdvisorAssisted` from `advisorStrategy.ts`:

- Builds the correct `payload` shape.
- Declares the official advisor tool (`type: 'advisor_20260301'`, `anthropic-beta: advisor-tool-2026-03-01`).
- Enables SSE streaming so `/api/ai-proxy` injects `: keepalive\n\n` comment frames during Opus thinking windows (lines 82-104 of `ai-proxy.mts`), plus first-byte + inter-byte watchdogs via `accumulateAdvisorStream`.
- Client-side wall-clock backstop raised 60s → 120s so the proxy's own 24s wall-clock + 30s inter-byte watchdog surface structured errors first.

Tests updated with an `sseResponse` helper that builds a minimal Anthropic SSE transcript; new assertions prove the posted body uses `payload` (not `body`), `stream: true` is set at both proxy and Anthropic levels, and the `tools` array contains the official advisor tool type.

## Regulatory basis

- **FDL No.10/2025 Art.20-21** — CO duty of care; advisor escalation must actually reach the advisor, not silently fail to deterministic fallback on every call.
- **FDL No.10/2025 Art.29** — tipping-off linter still runs on the advisor text before it's returned.
- **Cabinet Res 134/2025 Art.19** — internal review before decision.
- **FATF Rec 18** — internal controls proportionate to risk.

## Test plan

- [x] `npx vitest run tests/anthropicAdvisor.test.ts` — 12/12 pass
- [x] `npx vitest run tests/advisorStrategy.test.ts` — 46/46 pass (shared code regression check)
- [x] `npx tsc --noEmit` — no errors in `anthropicAdvisor.ts` / `advisorStrategy.ts`
- [ ] Manual: trigger an advisor escalation in staging, confirm `payload.tools[0].type === 'advisor_20260301'` in the `/api/ai-proxy` request log, and confirm the SSE response includes `proxy_ready` + `: keepalive` frames during Opus thinking.

https://claude.ai/code/session_0133y3K2vBt4CwimLp67APDg