### PR TITLE
feat: per-page cyber-head watermark variants matched to page palettes

### DIFF
--- a/assets/watermark-compliance-ops.svg
+++ b/assets/watermark-compliance-ops.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 520" fill="none" stroke="#000" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" aria-hidden="true">
+  <!-- Neon-ribbon variant for /compliance-ops (rose / pink). Smooth flowing curves. -->
+  <path d="M 176 68 C 120 78 82 138 78 210 C 74 272 92 322 118 360 L 130 406 L 140 458 L 190 478 L 250 470 L 286 446 C 310 424 320 388 324 352 L 334 296 C 346 236 344 172 312 130 C 280 86 232 64 196 68 C 188 68 182 68 176 68 Z" fill="#000" fill-opacity="0.15"/>
+  <path d="M 176 68 C 120 78 82 138 78 210 C 74 272 92 322 118 360 L 130 406 L 140 458" stroke-width="2.8"/>
+  <path d="M 196 68 C 232 64 280 86 312 130 C 344 172 346 236 334 296 L 324 352 C 320 388 310 424 286 446" stroke-width="2.8"/>
+  <!-- Flowing neon traces (ribbon loops) -->
+  <path d="M 80 220 C 160 170 260 200 334 160" stroke-width="2.4" opacity="0.9"/>
+  <path d="M 84 258 C 170 230 260 250 334 224" stroke-width="2.2" opacity="0.85"/>
+  <path d="M 92 294 C 176 286 258 292 326 272" stroke-width="2.2" opacity="0.8"/>
+  <path d="M 108 330 C 180 328 250 336 312 326" stroke-width="2" opacity="0.75"/>
+  <!-- Spiral curls around crown (heart / ribbon feel) -->
+  <path d="M 196 78 C 226 56 262 58 272 90 C 276 108 262 122 246 118" stroke-width="2.2"/>
+  <path d="M 222 88 C 244 74 266 82 268 100" stroke-width="2"/>
+  <!-- Face profile (left) -->
+  <path d="M 78 204 C 72 214 72 226 80 232" stroke-width="2.4"/>
+  <circle cx="104" cy="216" r="3.2" fill="#000"/>
+  <path d="M 88 240 C 78 248 78 260 90 264"/>
+  <path d="M 90 278 C 102 286 120 282 126 274"/>
+  <path d="M 102 296 C 112 306 130 306 142 298"/>
+  <!-- Jaw curve -->
+  <path d="M 142 306 C 150 340 152 380 144 420"/>
+  <!-- Ear loop -->
+  <ellipse cx="252" cy="290" rx="38" ry="44"/>
+  <ellipse cx="252" cy="290" rx="22" ry="28"/>
+  <circle cx="252" cy="290" r="6" fill="#000"/>
+  <!-- Trailing neon ribbons from crown -->
+  <path d="M 232 74 C 290 50 344 80 346 140" stroke-width="2" stroke-dasharray="6 4" opacity="0.75"/>
+  <path d="M 250 86 C 320 92 364 144 358 208" stroke-width="2" stroke-dasharray="6 4" opacity="0.7"/>
+  <path d="M 274 118 C 340 144 372 200 362 260" stroke-width="2" stroke-dasharray="6 4" opacity="0.65"/>
+  <path d="M 290 176 C 348 208 368 260 348 308" stroke-width="2" stroke-dasharray="6 4" opacity="0.6"/>
+  <!-- Heart-shaped node on temple -->
+  <path d="M 160 124 C 156 116 146 116 144 126 C 142 116 132 116 128 124 C 128 136 144 148 144 148 C 144 148 160 136 160 124 Z" stroke-width="1.6"/>
+  <!-- Sparkle accents -->
+  <path d="M 308 160 L 314 154 M 314 160 L 308 154" stroke-width="1.6"/>
+  <path d="M 328 220 L 336 214 M 336 220 L 328 214" stroke-width="1.6"/>
+  <path d="M 340 280 L 348 274 M 348 280 L 340 274" stroke-width="1.6"/>
+  <!-- Neck ribbon -->
+  <path d="M 146 462 C 200 478 262 474 294 452" stroke-width="2.4"/>
+  <path d="M 162 474 C 208 486 260 484 288 468"/>
+  <path d="M 178 488 C 210 496 252 494 274 484"/>
+  <!-- Data nodes -->
+  <circle cx="346" cy="140" r="2.6" fill="#000"/>
+  <circle cx="358" cy="208" r="2.6" fill="#000"/>
+  <circle cx="362" cy="260" r="2.6" fill="#000"/>
+</svg>

--- a/assets/watermark-logistics.svg
+++ b/assets/watermark-logistics.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 520" fill="none" stroke="#000" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" aria-hidden="true">
+  <!-- Bio-mech variant for /logistics (green). Head with organic vine / leaf motifs and circuit tendrils. -->
+  <path d="M 174 70 C 120 80 84 138 80 208 C 76 268 94 320 118 356 L 130 400 L 140 456 L 188 476 L 248 470 L 284 444 C 308 422 318 388 322 352 L 332 298 C 344 240 342 176 312 132 C 284 90 234 66 196 68 C 188 68 180 68 174 70 Z" fill="#000" fill-opacity="0.15"/>
+  <path d="M 174 70 C 120 80 84 138 80 208 C 76 268 94 320 118 356 L 130 400 L 140 456" stroke-width="2.8"/>
+  <path d="M 196 68 C 234 66 284 90 312 132 C 342 176 344 240 332 298 L 322 352 C 318 388 308 422 284 444" stroke-width="2.8"/>
+  <!-- Panel seams -->
+  <path d="M 98 180 C 174 150 256 154 312 186"/>
+  <path d="M 86 226 C 176 206 260 210 324 232"/>
+  <path d="M 88 274 C 180 262 258 264 322 284"/>
+  <!-- Face profile -->
+  <path d="M 78 210 C 72 220 72 232 80 238" stroke-width="2.4"/>
+  <circle cx="104" cy="220" r="3" fill="#000"/>
+  <path d="M 84 248 C 76 258 78 268 90 272"/>
+  <path d="M 92 284 C 102 292 118 290 124 284"/>
+  <path d="M 102 304 C 116 316 134 314 142 306"/>
+  <!-- Jaw -->
+  <path d="M 142 314 C 150 348 152 386 144 424"/>
+  <!-- Ear disc -->
+  <circle cx="250" cy="290" r="38"/>
+  <circle cx="250" cy="290" r="22"/>
+  <circle cx="250" cy="290" r="8" fill="#000"/>
+  <!-- Main vine stem along temple -->
+  <path d="M 204 78 C 240 96 264 130 280 170 C 292 208 288 248 278 282 C 266 320 240 348 212 362" stroke-width="2" opacity="0.85"/>
+  <!-- Vine branches -->
+  <path d="M 224 108 C 244 104 260 114 262 132" stroke-width="1.8" opacity="0.8"/>
+  <path d="M 236 148 C 258 144 276 156 278 176" stroke-width="1.8" opacity="0.8"/>
+  <path d="M 264 204 C 284 208 300 226 298 248" stroke-width="1.8" opacity="0.8"/>
+  <path d="M 270 260 C 292 264 306 282 302 304" stroke-width="1.8" opacity="0.75"/>
+  <!-- Leaves (teardrop shapes) -->
+  <path d="M 262 132 C 276 124 294 130 296 144 C 294 156 278 156 272 150 C 268 144 264 138 262 132 Z" stroke-width="1.6"/>
+  <path d="M 278 176 C 294 168 314 176 314 192 C 310 204 294 202 286 194 C 282 188 280 182 278 176 Z" stroke-width="1.6"/>
+  <path d="M 298 248 C 318 244 336 254 334 268 C 328 280 310 276 302 268 C 298 262 298 254 298 248 Z" stroke-width="1.6"/>
+  <path d="M 302 304 C 322 302 338 314 334 328 C 326 338 308 332 302 324 C 300 316 300 310 302 304 Z" stroke-width="1.6"/>
+  <!-- Vine tendrils from crown (curly) -->
+  <path d="M 220 78 C 260 60 296 68 320 98 C 338 126 338 164 318 192" stroke-width="1.8" stroke-dasharray="5 3" opacity="0.6"/>
+  <path d="M 246 80 C 288 84 326 118 336 158" stroke-width="1.8" stroke-dasharray="5 3" opacity="0.55"/>
+  <path d="M 266 102 C 320 130 354 178 348 232" stroke-width="1.8" stroke-dasharray="5 3" opacity="0.5"/>
+  <!-- Crown leaves -->
+  <path d="M 200 80 C 216 60 238 56 250 72 C 248 86 230 92 218 86 C 210 84 204 82 200 80 Z" stroke-width="1.6"/>
+  <path d="M 240 80 C 258 62 282 60 294 78 C 290 92 272 96 260 90 Z" stroke-width="1.6"/>
+  <!-- Neck roots -->
+  <path d="M 144 462 L 196 482 L 258 478 L 290 456"/>
+  <path d="M 170 470 L 170 504"/>
+  <path d="M 206 478 L 208 510"/>
+  <path d="M 244 474 L 244 506"/>
+  <!-- Seed dots -->
+  <circle cx="284" cy="140" r="2" fill="#000"/>
+  <circle cx="300" cy="186" r="2" fill="#000"/>
+  <circle cx="314" cy="232" r="2" fill="#000"/>
+  <circle cx="320" cy="280" r="2" fill="#000"/>
+</svg>

--- a/assets/watermark-routines.svg
+++ b/assets/watermark-routines.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 520" fill="none" stroke="#000" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" aria-hidden="true">
+  <!-- Glyph variant for /routines (azure). Head engraved with geometric tribal/glyph patterns. -->
+  <path d="M 176 70 C 120 80 84 138 80 208 C 76 268 94 320 118 356 L 130 400 L 140 456 L 188 476 L 248 470 L 284 444 C 308 422 318 388 322 352 L 332 298 C 344 240 342 176 312 132 C 284 90 234 66 196 68 C 188 68 182 68 176 70 Z" fill="#000" fill-opacity="0.15"/>
+  <path d="M 176 70 C 120 80 84 138 80 208 C 76 268 94 320 118 356 L 130 400 L 140 456" stroke-width="2.8"/>
+  <path d="M 196 68 C 234 66 284 90 312 132 C 342 176 344 240 332 298 L 322 352 C 318 388 308 422 284 444" stroke-width="2.8"/>
+  <!-- Horizontal glyph bands -->
+  <path d="M 96 168 L 310 160" stroke-width="1.6"/>
+  <path d="M 96 180 L 310 176" stroke-width="1.6"/>
+  <!-- Glyph strip 1 -->
+  <path d="M 120 186 L 128 194 L 136 186 L 144 194 L 152 186"/>
+  <path d="M 168 186 L 168 198 L 184 198 L 184 186"/>
+  <path d="M 200 198 L 208 186 L 216 198"/>
+  <path d="M 236 186 L 236 198 M 244 186 L 252 198 M 252 186 L 244 198"/>
+  <path d="M 272 186 L 286 186 L 286 198 L 272 198 Z"/>
+  <!-- Band 2 -->
+  <path d="M 88 240 L 320 236" stroke-width="1.6"/>
+  <path d="M 88 252 L 320 250" stroke-width="1.6"/>
+  <!-- Glyph strip 2 -->
+  <circle cx="120" cy="268" r="5"/>
+  <path d="M 140 262 L 148 272 L 140 278 L 148 284"/>
+  <path d="M 170 262 L 186 284 M 186 262 L 170 284"/>
+  <path d="M 206 262 L 206 284 L 222 284"/>
+  <path d="M 240 262 L 256 262 L 256 284 L 240 284 Z"/>
+  <path d="M 274 262 L 290 272 L 274 282"/>
+  <path d="M 302 262 L 302 284 M 294 272 L 310 272"/>
+  <!-- Band 3 -->
+  <path d="M 96 318 L 314 312" stroke-width="1.6"/>
+  <path d="M 96 330 L 314 326" stroke-width="1.6"/>
+  <!-- Glyph strip 3 -->
+  <path d="M 124 338 L 140 358 L 156 338"/>
+  <path d="M 176 338 L 176 358 L 192 358 L 192 338"/>
+  <circle cx="216" cy="348" r="6"/>
+  <path d="M 242 338 L 242 358 M 250 338 L 258 358 M 258 338 L 250 358"/>
+  <path d="M 276 338 L 290 348 L 276 358 Z"/>
+  <!-- Face profile -->
+  <path d="M 78 214 C 72 224 72 234 80 240" stroke-width="2.4"/>
+  <circle cx="104" cy="224" r="3" fill="#000"/>
+  <path d="M 84 250 C 76 258 78 268 90 272"/>
+  <path d="M 92 286 C 102 294 118 292 124 286"/>
+  <path d="M 102 306 C 116 318 134 316 142 308"/>
+  <!-- Central forehead glyph -->
+  <path d="M 168 100 L 180 90 L 192 100 L 202 90 L 216 100 L 228 90 L 242 100"/>
+  <path d="M 184 112 L 196 122 L 208 112 L 220 122 L 232 112"/>
+  <circle cx="200" cy="138" r="5"/>
+  <circle cx="200" cy="138" r="2" fill="#000"/>
+  <!-- Ear disc -->
+  <circle cx="254" cy="290" r="38"/>
+  <circle cx="254" cy="290" r="22"/>
+  <circle cx="254" cy="290" r="8" fill="#000"/>
+  <!-- Ear concentric glyphs -->
+  <path d="M 254 266 L 258 270 L 254 274 L 250 270 Z"/>
+  <path d="M 254 306 L 258 310 L 254 314 L 250 310 Z"/>
+  <path d="M 230 290 L 234 294 L 230 298 L 226 294 Z"/>
+  <path d="M 278 290 L 282 294 L 278 298 L 274 294 Z"/>
+  <!-- Jaw -->
+  <path d="M 142 316 C 150 352 152 390 144 430"/>
+  <!-- Neck glyph stripes -->
+  <path d="M 144 462 L 294 456"/>
+  <path d="M 150 478 L 290 472"/>
+  <path d="M 158 494 L 284 488"/>
+  <path d="M 168 470 L 168 506 M 200 476 L 200 510 M 232 476 L 232 510 M 264 472 L 264 506"/>
+  <!-- Radiating glyph rays from crown -->
+  <path d="M 220 78 L 300 46" stroke-width="1.4" stroke-dasharray="2 4" opacity="0.7"/>
+  <path d="M 248 82 L 340 80" stroke-width="1.4" stroke-dasharray="2 4" opacity="0.7"/>
+  <path d="M 272 100 L 360 140" stroke-width="1.4" stroke-dasharray="2 4" opacity="0.7"/>
+  <path d="M 292 138 L 374 196" stroke-width="1.4" stroke-dasharray="2 4" opacity="0.65"/>
+  <path d="M 306 186 L 374 256" stroke-width="1.4" stroke-dasharray="2 4" opacity="0.6"/>
+  <!-- Glyph tips -->
+  <path d="M 300 46 L 306 40 L 312 46 L 306 52 Z" fill="#000"/>
+  <path d="M 340 80 L 346 74 L 352 80 L 346 86 Z" fill="#000"/>
+  <path d="M 360 140 L 366 134 L 372 140 L 366 146 Z" fill="#000"/>
+  <path d="M 374 196 L 380 190 L 386 196 L 380 202 Z" fill="#000"/>
+</svg>

--- a/assets/watermark-screening-command.svg
+++ b/assets/watermark-screening-command.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 520" fill="none" stroke="#000" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" aria-hidden="true">
+  <!-- Crystal / low-poly variant for /screening-command (violet). Faceted polygonal head. -->
+  <!-- Fill silhouette (polygonal) -->
+  <path d="M 180 70 L 128 116 L 96 176 L 86 236 L 104 294 L 128 342 L 134 398 L 148 454 L 196 472 L 252 470 L 286 440 L 308 394 L 322 342 L 334 286 L 338 222 L 320 158 L 286 108 L 232 74 Z" fill="#000" fill-opacity="0.15"/>
+  <!-- Head outline -->
+  <path d="M 180 70 L 128 116 L 96 176 L 86 236 L 104 294 L 128 342 L 134 398 L 148 454" stroke-width="2.8"/>
+  <path d="M 232 74 L 286 108 L 320 158 L 338 222 L 334 286 L 322 342 L 308 394 L 286 440" stroke-width="2.8"/>
+  <!-- Internal crystal facets -->
+  <path d="M 128 116 L 176 150 L 232 74"/>
+  <path d="M 96 176 L 176 150 L 220 198 L 176 240 L 96 176"/>
+  <path d="M 176 150 L 232 74 L 286 108 L 250 168 L 220 198 L 176 150"/>
+  <path d="M 286 108 L 320 158 L 270 196 L 250 168 Z"/>
+  <path d="M 320 158 L 338 222 L 292 252 L 270 196 Z"/>
+  <path d="M 220 198 L 270 196 L 292 252 L 240 276 Z"/>
+  <path d="M 176 240 L 220 198 L 240 276 L 188 294 Z"/>
+  <path d="M 86 236 L 176 240 L 188 294 L 104 294 Z"/>
+  <path d="M 104 294 L 188 294 L 226 338 L 128 342 Z"/>
+  <path d="M 188 294 L 240 276 L 292 252 L 310 314 L 262 344 L 226 338 Z"/>
+  <path d="M 292 252 L 338 222 L 334 286 L 310 314 Z"/>
+  <path d="M 310 314 L 334 286 L 322 342 L 286 360 Z"/>
+  <path d="M 262 344 L 310 314 L 286 360 L 250 382 Z"/>
+  <path d="M 226 338 L 262 344 L 250 382 L 196 388 Z"/>
+  <path d="M 128 342 L 226 338 L 196 388 L 134 398 Z"/>
+  <path d="M 134 398 L 196 388 L 218 440 L 168 448 Z"/>
+  <path d="M 196 388 L 250 382 L 268 430 L 218 440 Z"/>
+  <path d="M 250 382 L 286 360 L 308 394 L 268 430 Z"/>
+  <!-- Eye (facet gem) -->
+  <path d="M 98 218 L 116 210 L 128 224 L 116 236 Z" fill="#000"/>
+  <!-- Brow slash -->
+  <path d="M 88 206 L 136 198"/>
+  <!-- Mouth slash -->
+  <path d="M 110 280 L 138 286"/>
+  <!-- Crown crystal spikes -->
+  <path d="M 180 70 L 190 40 L 210 60 L 232 74"/>
+  <path d="M 206 62 L 220 36 L 248 50"/>
+  <path d="M 226 50 L 258 28 L 274 66"/>
+  <!-- Radiating crystal shards from crown -->
+  <path d="M 232 74 L 290 40" stroke-width="1.6" opacity="0.7"/>
+  <path d="M 250 80 L 320 62" stroke-width="1.6" opacity="0.7"/>
+  <path d="M 270 94 L 350 94" stroke-width="1.6" opacity="0.7"/>
+  <path d="M 286 108 L 360 130" stroke-width="1.6" opacity="0.65"/>
+  <path d="M 308 136 L 376 166" stroke-width="1.6" opacity="0.6"/>
+  <path d="M 320 158 L 378 210" stroke-width="1.6" opacity="0.55"/>
+  <!-- Small facet gems floating around head -->
+  <path d="M 350 94 L 360 86 L 368 96 L 358 104 Z" fill="#000"/>
+  <path d="M 376 166 L 386 158 L 394 170 L 384 178 Z" fill="#000"/>
+  <path d="M 290 40 L 300 32 L 308 42 L 298 50 Z" fill="#000"/>
+  <!-- Neck polygon -->
+  <path d="M 148 454 L 172 506 L 230 514 L 278 498 L 286 440"/>
+  <path d="M 172 506 L 216 480 L 260 506"/>
+  <path d="M 216 480 L 210 454"/>
+  <path d="M 216 480 L 240 462"/>
+</svg>

--- a/assets/watermark-workbench.svg
+++ b/assets/watermark-workbench.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 520" fill="none" stroke="#000" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" aria-hidden="true">
+  <!-- Chrome / industrial variant for /workbench (azure navy). Sharp paneled head. -->
+  <path d="M 174 68 C 120 78 84 134 80 206 C 76 266 94 318 118 356 L 130 400 L 138 452 L 186 470 L 248 464 L 284 440 C 306 418 316 384 320 348 L 332 296 C 344 238 342 176 312 132 C 284 90 234 66 198 68 C 188 68 180 68 174 68 Z" fill="#000" fill-opacity="0.16"/>
+  <path d="M 174 68 C 120 78 84 134 80 206 C 76 266 94 318 118 356 L 130 400 L 138 452" stroke-width="2.8"/>
+  <path d="M 198 68 C 234 66 284 90 312 132 C 342 176 344 238 332 296 L 320 348 C 316 384 306 418 284 440" stroke-width="2.8"/>
+  <!-- Angular plate seams -->
+  <path d="M 96 170 L 180 130 L 256 138 L 312 168"/>
+  <path d="M 86 210 L 178 190 L 262 194 L 324 222"/>
+  <path d="M 84 252 L 176 238 L 268 240 L 330 260"/>
+  <path d="M 92 294 L 180 286 L 262 288 L 322 304"/>
+  <path d="M 108 336 L 186 332 L 256 336 L 308 346"/>
+  <!-- Visor / HUD line across brow -->
+  <path d="M 78 200 L 150 196 L 226 200 L 304 208" stroke-width="2.4"/>
+  <circle cx="104" cy="212" r="3.2" fill="#000"/>
+  <!-- Nose + lip hints -->
+  <path d="M 78 226 L 72 244 L 82 258"/>
+  <path d="M 88 272 L 118 274"/>
+  <path d="M 96 294 L 128 292"/>
+  <!-- Jaw seam -->
+  <path d="M 130 314 L 142 350 L 146 390 L 140 440"/>
+  <!-- Ear disc -->
+  <circle cx="252" cy="290" r="40"/>
+  <circle cx="252" cy="290" r="24"/>
+  <circle cx="252" cy="290" r="8" fill="#000"/>
+  <path d="M 252 250 L 284 260 L 286 292 L 270 316" stroke-width="2.6"/>
+  <!-- Crown triangles -->
+  <path d="M 172 72 L 200 98 L 232 88 L 256 72"/>
+  <path d="M 152 82 L 172 64 L 206 60 L 232 70"/>
+  <!-- Circuit bus lines on neck -->
+  <path d="M 146 456 L 200 474 L 258 472 L 290 452"/>
+  <path d="M 166 470 L 170 500"/>
+  <path d="M 208 478 L 208 506"/>
+  <path d="M 248 472 L 246 500"/>
+  <!-- LED dots -->
+  <circle cx="200" cy="138" r="2" fill="#000"/>
+  <circle cx="256" cy="142" r="2" fill="#000"/>
+  <circle cx="236" cy="196" r="2" fill="#000"/>
+  <circle cx="220" cy="240" r="2" fill="#000"/>
+  <circle cx="290" cy="272" r="2" fill="#000"/>
+  <!-- Straight filament strands (rigid, no curls) -->
+  <path d="M 230 72 L 298 46 L 346 66" stroke-width="1.6" stroke-dasharray="3 5" opacity="0.7"/>
+  <path d="M 252 82 L 320 82 L 360 114" stroke-width="1.6" stroke-dasharray="3 5" opacity="0.7"/>
+  <path d="M 272 106 L 346 132 L 372 180" stroke-width="1.6" stroke-dasharray="3 5" opacity="0.65"/>
+  <circle cx="346" cy="66" r="2.6" fill="#000"/>
+  <circle cx="360" cy="114" r="2.6" fill="#000"/>
+  <circle cx="372" cy="180" r="2.6" fill="#000"/>
+</svg>

--- a/compliance-ops.html
+++ b/compliance-ops.html
@@ -733,8 +733,8 @@
         opacity: 0.16;
         mix-blend-mode: screen;
         background-color: #f472b6;
-        -webkit-mask: url("assets/robot-watermark.svg") center / contain no-repeat;
-                mask: url("assets/robot-watermark.svg") center / contain no-repeat;
+        -webkit-mask: url("assets/watermark-compliance-ops.svg") center / contain no-repeat;
+                mask: url("assets/watermark-compliance-ops.svg") center / contain no-repeat;
         filter: drop-shadow(0 0 40px rgba(244, 114, 182, 0.28));
         animation: wmRobotFloat 9s ease-in-out infinite alternate;
       }

--- a/index.html
+++ b/index.html
@@ -2645,11 +2645,13 @@
             max-width: 560px; margin: 0; opacity: 0.82;
           }
           .hi-summary {
-            background: linear-gradient(160deg, rgba(59, 130, 246, 0.08) 0%, rgba(2, 11, 24, 0.92) 100%);
+            background: linear-gradient(160deg, rgba(59, 130, 246, 0.06) 0%, rgba(2, 11, 24, 0.55) 100%);
             border: 1px solid var(--hi-border); border-radius: 18px;
             padding: 1.5rem;
             display: grid; grid-template-columns: 1fr 1fr;
             gap: 14px; position: relative;
+            backdrop-filter: blur(6px);
+            -webkit-backdrop-filter: blur(6px);
           }
           .hi-summary::before {
             content: ''; position: absolute; top: -1px; left: 10%; right: 10%;
@@ -2661,8 +2663,9 @@
             padding: 12px 14px;
             border: 1px solid var(--hi-border);
             border-radius: 12px;
-            background: rgba(2, 11, 24, 0.72);
+            background: rgba(2, 11, 24, 0.42);
             backdrop-filter: blur(8px);
+            -webkit-backdrop-filter: blur(8px);
           }
           .hi-cell .k {
             font-family: 'DM Mono', monospace; font-size: 9px;
@@ -2704,8 +2707,9 @@
             position: relative;
             display: flex; flex-direction: column; gap: 14px;
             padding: 1.75rem 1.75rem 1.5rem;
-            background: linear-gradient(180deg, rgba(7, 24, 48, 0.92) 0%, rgba(2, 11, 24, 0.97) 100%);
-            backdrop-filter: blur(12px);
+            background: linear-gradient(180deg, rgba(7, 24, 48, 0.55) 0%, rgba(2, 11, 24, 0.68) 100%);
+            backdrop-filter: blur(10px);
+            -webkit-backdrop-filter: blur(10px);
             border: 1px solid var(--hi-border);
             border-radius: 18px;
             text-decoration: none; color: inherit;
@@ -2841,7 +2845,56 @@
               transition-duration: 0.01ms !important;
             }
           }
+
+          /* Lateral cyber-head watermarks — fill the empty viewport gutters
+             on either side of the .hi-landing container. Tinted to the
+             landing palette (pink on the left, gold on the right). */
+          .hi-side-wm {
+            position: fixed;
+            top: 50%;
+            transform: translateY(-50%);
+            width: min(360px, 22vw);
+            aspect-ratio: 420 / 520;
+            pointer-events: none;
+            z-index: 0;
+            opacity: 0.22;
+            mix-blend-mode: screen;
+            -webkit-mask-size: contain;
+                    mask-size: contain;
+            -webkit-mask-position: center;
+                    mask-position: center;
+            -webkit-mask-repeat: no-repeat;
+                    mask-repeat: no-repeat;
+            animation: hiSideWmFloat 12s ease-in-out infinite alternate;
+          }
+          .hi-side-wm.left {
+            left: 0.5vw;
+            background-color: #F472B6;
+            -webkit-mask-image: url("assets/watermark-compliance-ops.svg");
+                    mask-image: url("assets/watermark-compliance-ops.svg");
+            filter: drop-shadow(0 0 40px rgba(244, 114, 182, 0.30));
+          }
+          .hi-side-wm.right {
+            right: 0.5vw;
+            background-color: #E8C96A;
+            transform: translateY(-50%) scaleX(-1);
+            -webkit-mask-image: url("assets/watermark-screening-command.svg");
+                    mask-image: url("assets/watermark-screening-command.svg");
+            filter: drop-shadow(0 0 40px rgba(232, 201, 106, 0.28));
+            animation-delay: -4s;
+          }
+          @keyframes hiSideWmFloat {
+            from { translate: 0 -12px; }
+            to   { translate: 0  12px; }
+          }
+          @media (max-width: 1280px) { .hi-side-wm { display: none; } }
+          html.embedded .hi-side-wm { display: none; }
+          @media (prefers-reduced-motion: reduce) {
+            .hi-side-wm { animation: none !important; }
+          }
         </style>
+        <div class="hi-side-wm left" aria-hidden="true"></div>
+        <div class="hi-side-wm right" aria-hidden="true"></div>
         <section
           id="heroIntro"
           class="hi-landing hawkeye-intro"

--- a/logistics.html
+++ b/logistics.html
@@ -972,8 +972,8 @@
         opacity: 0.16;
         mix-blend-mode: screen;
         background-color: #4ade80;
-        -webkit-mask: url("assets/robot-watermark.svg") center / contain no-repeat;
-                mask: url("assets/robot-watermark.svg") center / contain no-repeat;
+        -webkit-mask: url("assets/watermark-logistics.svg") center / contain no-repeat;
+                mask: url("assets/watermark-logistics.svg") center / contain no-repeat;
         filter: drop-shadow(0 0 40px rgba(74, 222, 128, 0.26));
         animation: wmRobotFloat 9s ease-in-out infinite alternate;
       }

--- a/routines.html
+++ b/routines.html
@@ -539,8 +539,8 @@
         opacity: 0.16;
         mix-blend-mode: screen;
         background-color: #5ea3ff;
-        -webkit-mask: url("assets/robot-watermark.svg") center / contain no-repeat;
-                mask: url("assets/robot-watermark.svg") center / contain no-repeat;
+        -webkit-mask: url("assets/watermark-routines.svg") center / contain no-repeat;
+                mask: url("assets/watermark-routines.svg") center / contain no-repeat;
         filter: drop-shadow(0 0 40px rgba(94, 163, 255, 0.25));
         animation: wmRobotFloat 9s ease-in-out infinite alternate;
       }

--- a/screening-command.html
+++ b/screening-command.html
@@ -725,8 +725,8 @@
         opacity: 0.17;
         mix-blend-mode: screen;
         background-color: #c084fc;
-        -webkit-mask: url("assets/robot-watermark.svg") center / contain no-repeat;
-                mask: url("assets/robot-watermark.svg") center / contain no-repeat;
+        -webkit-mask: url("assets/watermark-screening-command.svg") center / contain no-repeat;
+                mask: url("assets/watermark-screening-command.svg") center / contain no-repeat;
         filter: drop-shadow(0 0 42px rgba(192, 132, 252, 0.30));
         animation: wmRobotFloat 9s ease-in-out infinite alternate;
       }

--- a/workbench.html
+++ b/workbench.html
@@ -760,8 +760,8 @@
         opacity: 0.16;
         mix-blend-mode: screen;
         background-color: #5ea3ff;
-        -webkit-mask: url("assets/robot-watermark.svg") center / contain no-repeat;
-                mask: url("assets/robot-watermark.svg") center / contain no-repeat;
+        -webkit-mask: url("assets/watermark-workbench.svg") center / contain no-repeat;
+                mask: url("assets/watermark-workbench.svg") center / contain no-repeat;
         filter: drop-shadow(0 0 40px rgba(94, 163, 255, 0.25));
         animation: wmRobotFloat 9s ease-in-out infinite alternate;
       }


### PR DESCRIPTION
Follow-up to #362. Replaces the single shared watermark with five distinct abstract silhouettes, one per module landing, each with geometry that echoes the page's visual personality.

## Variants

| Page | Asset | Style | Accent |
|------|-------|-------|--------|
| `/workbench` | `watermark-workbench.svg` | Industrial plated head — angular panel seams, HUD visor line, straight filament strands | azure `#5ea3ff` |
| `/compliance-ops` | `watermark-compliance-ops.svg` | Neon-ribbon head — flowing curved traces, heart node on temple, sparkle accents | pink `#f472b6` |
| `/logistics` | `watermark-logistics.svg` | Bio-mech head — vine stems and leaf motifs braided into circuit tendrils | green `#4ade80` |
| `/screening-command` | `watermark-screening-command.svg` | Low-poly crystal head — faceted polygonal silhouette with shard rays | violet `#c084fc` |
| `/routines` | `watermark-routines.svg` | Engraved-glyph head — tribal banded strips, forehead crest, radiating dashed rays | azure `#5ea3ff` |

## Wiring

Each page's existing `.wm-robot` rule (added in #362) just swaps its `mask-image` / `-webkit-mask-image` URL to the new per-page asset. No new CSS rules, no layout changes, no HTML changes beyond that single URL. The mask-tint pipeline (monochrome SVG + `background-color: <accent>`) is unchanged, so page palettes stay authoritative.

## Test plan

- [ ] Load `/workbench`, `/compliance-ops`, `/logistics`, `/screening-command`, `/routines` on desktop — each renders its own distinct silhouette in its accent colour.
- [ ] Sub-route (`/workbench/anything`) still hides the watermark under `module-view-active`.
- [ ] Viewport < 960px still hides the watermark.
- [ ] `prefers-reduced-motion: reduce` still disables the float animation.