### PR TITLE
fix: make cyber-head watermarks clearly visible on module pages + landing

### DIFF
--- a/compliance-ops.html
+++ b/compliance-ops.html
@@ -721,28 +721,29 @@
       }
       @media (prefers-reduced-motion: reduce) { .wm { animation: none !important; } }
 
-      /* Cyber-head watermark (pink accent to match compliance-ops palette) */
+      /* Cyber-head watermark — pink accent on the compliance-ops palette.
+         Large, centred on the left gutter, clearly visible. */
       .wm-robot {
         position: fixed;
-        left: -4vw;
-        bottom: -3vh;
-        width: min(420px, 32vw);
+        left: 0;
+        top: 50%;
+        width: min(640px, 44vw);
         aspect-ratio: 420 / 520;
         pointer-events: none;
         z-index: 0;
-        opacity: 0.16;
-        mix-blend-mode: screen;
-        background-color: #f472b6;
+        opacity: 0.78;
+        background-color: #f9a8d4;
         -webkit-mask: url("assets/watermark-compliance-ops.svg") center / contain no-repeat;
                 mask: url("assets/watermark-compliance-ops.svg") center / contain no-repeat;
-        filter: drop-shadow(0 0 40px rgba(244, 114, 182, 0.28));
-        animation: wmRobotFloat 9s ease-in-out infinite alternate;
+        filter: drop-shadow(0 0 60px rgba(236, 72, 153, 0.55));
+        transform: translateY(-50%);
+        animation: wmRobotFloat 12s ease-in-out infinite alternate;
       }
       html.module-view-active .wm-robot { display: none; }
       @media (max-width: 960px) { .wm-robot { display: none; } }
       @keyframes wmRobotFloat {
-        from { transform: translateY(0) rotate(0deg); }
-        to   { transform: translateY(-10px) rotate(0.4deg); }
+        from { transform: translateY(calc(-50% - 10px)); }
+        to   { transform: translateY(calc(-50% + 10px)); }
       }
       @media (prefers-reduced-motion: reduce) { .wm-robot { animation: none !important; } }
     </style>

--- a/index.html
+++ b/index.html
@@ -2853,12 +2853,11 @@
             position: fixed;
             top: 50%;
             transform: translateY(-50%);
-            width: min(360px, 22vw);
+            width: min(520px, 32vw);
             aspect-ratio: 420 / 520;
             pointer-events: none;
             z-index: 0;
-            opacity: 0.22;
-            mix-blend-mode: screen;
+            opacity: 0.78;
             -webkit-mask-size: contain;
                     mask-size: contain;
             -webkit-mask-position: center;
@@ -2868,19 +2867,19 @@
             animation: hiSideWmFloat 12s ease-in-out infinite alternate;
           }
           .hi-side-wm.left {
-            left: 0.5vw;
-            background-color: #F472B6;
+            left: 0;
+            background-color: #FB7FCA;
             -webkit-mask-image: url("assets/watermark-compliance-ops.svg");
                     mask-image: url("assets/watermark-compliance-ops.svg");
-            filter: drop-shadow(0 0 40px rgba(244, 114, 182, 0.30));
+            filter: drop-shadow(0 0 60px rgba(244, 114, 182, 0.55));
           }
           .hi-side-wm.right {
-            right: 0.5vw;
+            right: 0;
             background-color: #E8C96A;
             transform: translateY(-50%) scaleX(-1);
             -webkit-mask-image: url("assets/watermark-screening-command.svg");
                     mask-image: url("assets/watermark-screening-command.svg");
-            filter: drop-shadow(0 0 40px rgba(232, 201, 106, 0.28));
+            filter: drop-shadow(0 0 60px rgba(232, 201, 106, 0.55));
             animation-delay: -4s;
           }
           @keyframes hiSideWmFloat {

--- a/index.html
+++ b/index.html
@@ -2583,22 +2583,25 @@
             position: relative;
             margin: 24px 0 32px;
             padding: 0;
-            /* Hero background: robot hand holding glowing planet */
-            background: #020B18;
+            /* Transparent so the fixed lateral cyber-head watermarks
+               (.hi-side-wm) that sit below on the z-stack remain
+               visible through the landing. */
+            background: transparent;
             border-radius: 20px;
-            overflow: hidden;
+            overflow: visible;
             min-height: 520px;
-            position: relative;
           }
           .hi-landing::before {
             content: '';
             position: absolute;
             inset: 0;
             background:
-              linear-gradient(100deg, #020B18 0%, #020B18 28%, rgba(2,11,24,0.75) 48%, rgba(2,11,24,0.15) 68%, transparent 85%),
+              linear-gradient(100deg, rgba(2,11,24,0.35) 0%, rgba(2,11,24,0.18) 40%, transparent 70%),
               url('assets/hero-robot-planet.png') right -40px center / 58% auto no-repeat;
             z-index: 1;
             pointer-events: none;
+            border-radius: 20px;
+            opacity: 0.55;
           }
           .hi-landing > * { position: relative; z-index: 2; }
           .hi-hero {
@@ -2645,13 +2648,13 @@
             max-width: 560px; margin: 0; opacity: 0.82;
           }
           .hi-summary {
-            background: linear-gradient(160deg, rgba(59, 130, 246, 0.06) 0%, rgba(2, 11, 24, 0.55) 100%);
+            background: linear-gradient(160deg, rgba(59, 130, 246, 0.04) 0%, rgba(2, 11, 24, 0.30) 100%);
             border: 1px solid var(--hi-border); border-radius: 18px;
             padding: 1.5rem;
             display: grid; grid-template-columns: 1fr 1fr;
             gap: 14px; position: relative;
-            backdrop-filter: blur(6px);
-            -webkit-backdrop-filter: blur(6px);
+            backdrop-filter: blur(5px);
+            -webkit-backdrop-filter: blur(5px);
           }
           .hi-summary::before {
             content: ''; position: absolute; top: -1px; left: 10%; right: 10%;
@@ -2663,9 +2666,9 @@
             padding: 12px 14px;
             border: 1px solid var(--hi-border);
             border-radius: 12px;
-            background: rgba(2, 11, 24, 0.42);
-            backdrop-filter: blur(8px);
-            -webkit-backdrop-filter: blur(8px);
+            background: rgba(2, 11, 24, 0.22);
+            backdrop-filter: blur(6px);
+            -webkit-backdrop-filter: blur(6px);
           }
           .hi-cell .k {
             font-family: 'DM Mono', monospace; font-size: 9px;
@@ -2707,9 +2710,9 @@
             position: relative;
             display: flex; flex-direction: column; gap: 14px;
             padding: 1.75rem 1.75rem 1.5rem;
-            background: linear-gradient(180deg, rgba(7, 24, 48, 0.55) 0%, rgba(2, 11, 24, 0.68) 100%);
-            backdrop-filter: blur(10px);
-            -webkit-backdrop-filter: blur(10px);
+            background: linear-gradient(180deg, rgba(7, 24, 48, 0.28) 0%, rgba(2, 11, 24, 0.38) 100%);
+            backdrop-filter: blur(8px);
+            -webkit-backdrop-filter: blur(8px);
             border: 1px solid var(--hi-border);
             border-radius: 18px;
             text-decoration: none; color: inherit;
@@ -2853,7 +2856,7 @@
             position: fixed;
             top: 50%;
             transform: translateY(-50%);
-            width: min(520px, 32vw);
+            width: min(780px, 44vw);
             aspect-ratio: 420 / 520;
             pointer-events: none;
             z-index: 0;

--- a/logistics.html
+++ b/logistics.html
@@ -960,28 +960,29 @@
       }
       @media (prefers-reduced-motion: reduce) { .wm { animation: none !important; } }
 
-      /* Cyber-head watermark (green accent to match logistics palette) */
+      /* Cyber-head watermark — green accent on the logistics palette.
+         Large, centred on the left gutter, clearly visible. */
       .wm-robot {
         position: fixed;
-        left: -4vw;
-        bottom: -3vh;
-        width: min(420px, 32vw);
+        left: 0;
+        top: 50%;
+        width: min(640px, 44vw);
         aspect-ratio: 420 / 520;
         pointer-events: none;
         z-index: 0;
-        opacity: 0.16;
-        mix-blend-mode: screen;
-        background-color: #4ade80;
+        opacity: 0.78;
+        background-color: #86efac;
         -webkit-mask: url("assets/watermark-logistics.svg") center / contain no-repeat;
                 mask: url("assets/watermark-logistics.svg") center / contain no-repeat;
-        filter: drop-shadow(0 0 40px rgba(74, 222, 128, 0.26));
-        animation: wmRobotFloat 9s ease-in-out infinite alternate;
+        filter: drop-shadow(0 0 60px rgba(34, 197, 94, 0.55));
+        transform: translateY(-50%);
+        animation: wmRobotFloat 12s ease-in-out infinite alternate;
       }
       html.module-view-active .wm-robot { display: none; }
       @media (max-width: 960px) { .wm-robot { display: none; } }
       @keyframes wmRobotFloat {
-        from { transform: translateY(0) rotate(0deg); }
-        to   { transform: translateY(-10px) rotate(0.4deg); }
+        from { transform: translateY(calc(-50% - 10px)); }
+        to   { transform: translateY(calc(-50% + 10px)); }
       }
       @media (prefers-reduced-motion: reduce) { .wm-robot { animation: none !important; } }
     </style>

--- a/routines.html
+++ b/routines.html
@@ -527,28 +527,29 @@
       }
       @media (prefers-reduced-motion: reduce) { .wm { animation: none !important; } }
 
-      /* Cyber-head watermark (azure accent to match routines palette) */
+      /* Cyber-head watermark — azure accent on the routines palette.
+         Large, centred on the left gutter, clearly visible. */
       .wm-robot {
         position: fixed;
-        left: -4vw;
-        bottom: -3vh;
-        width: min(420px, 32vw);
+        left: 0;
+        top: 50%;
+        width: min(640px, 44vw);
         aspect-ratio: 420 / 520;
         pointer-events: none;
         z-index: 0;
-        opacity: 0.16;
-        mix-blend-mode: screen;
-        background-color: #5ea3ff;
+        opacity: 0.78;
+        background-color: #7fc1ff;
         -webkit-mask: url("assets/watermark-routines.svg") center / contain no-repeat;
                 mask: url("assets/watermark-routines.svg") center / contain no-repeat;
-        filter: drop-shadow(0 0 40px rgba(94, 163, 255, 0.25));
-        animation: wmRobotFloat 9s ease-in-out infinite alternate;
+        filter: drop-shadow(0 0 60px rgba(47, 125, 255, 0.55));
+        transform: translateY(-50%);
+        animation: wmRobotFloat 12s ease-in-out infinite alternate;
       }
       html.module-view-active .wm-robot { display: none; }
       @media (max-width: 960px) { .wm-robot { display: none; } }
       @keyframes wmRobotFloat {
-        from { transform: translateY(0) rotate(0deg); }
-        to   { transform: translateY(-10px) rotate(0.4deg); }
+        from { transform: translateY(calc(-50% - 10px)); }
+        to   { transform: translateY(calc(-50% + 10px)); }
       }
       @media (prefers-reduced-motion: reduce) { .wm-robot { animation: none !important; } }
     </style>

--- a/screening-command.html
+++ b/screening-command.html
@@ -713,28 +713,29 @@
       }
       @media (prefers-reduced-motion: reduce) { .wm { animation: none !important; } }
 
-      /* Cyber-head watermark (violet accent to match screening-command palette) */
+      /* Cyber-head watermark — violet accent on the screening-command palette.
+         Large, centred on the left gutter, clearly visible. */
       .wm-robot {
         position: fixed;
-        left: -4vw;
-        bottom: -3vh;
-        width: min(420px, 32vw);
+        left: 0;
+        top: 50%;
+        width: min(640px, 44vw);
         aspect-ratio: 420 / 520;
         pointer-events: none;
         z-index: 0;
-        opacity: 0.17;
-        mix-blend-mode: screen;
-        background-color: #c084fc;
+        opacity: 0.78;
+        background-color: #e879f9;
         -webkit-mask: url("assets/watermark-screening-command.svg") center / contain no-repeat;
                 mask: url("assets/watermark-screening-command.svg") center / contain no-repeat;
-        filter: drop-shadow(0 0 42px rgba(192, 132, 252, 0.30));
-        animation: wmRobotFloat 9s ease-in-out infinite alternate;
+        filter: drop-shadow(0 0 60px rgba(168, 85, 247, 0.55));
+        transform: translateY(-50%);
+        animation: wmRobotFloat 12s ease-in-out infinite alternate;
       }
       html.module-view-active .wm-robot { display: none; }
       @media (max-width: 960px) { .wm-robot { display: none; } }
       @keyframes wmRobotFloat {
-        from { transform: translateY(0) rotate(0deg); }
-        to   { transform: translateY(-10px) rotate(0.4deg); }
+        from { transform: translateY(calc(-50% - 10px)); }
+        to   { transform: translateY(calc(-50% + 10px)); }
       }
       @media (prefers-reduced-motion: reduce) { .wm-robot { animation: none !important; } }
     </style>

--- a/workbench.html
+++ b/workbench.html
@@ -748,28 +748,30 @@
         .wm { animation: none !important; }
       }
 
-      /* Cyber-head watermark (azure accent to match workbench palette) */
+      /* Cyber-head watermark — azure accent on the workbench palette.
+         Large, centred on the left gutter, clearly visible (no screen
+         blend-mode so it reads on dark navy). */
       .wm-robot {
         position: fixed;
-        left: -4vw;
-        bottom: -3vh;
-        width: min(420px, 32vw);
+        left: 0;
+        top: 50%;
+        width: min(640px, 44vw);
         aspect-ratio: 420 / 520;
         pointer-events: none;
         z-index: 0;
-        opacity: 0.16;
-        mix-blend-mode: screen;
-        background-color: #5ea3ff;
+        opacity: 0.78;
+        background-color: #7fc1ff;
         -webkit-mask: url("assets/watermark-workbench.svg") center / contain no-repeat;
                 mask: url("assets/watermark-workbench.svg") center / contain no-repeat;
-        filter: drop-shadow(0 0 40px rgba(94, 163, 255, 0.25));
-        animation: wmRobotFloat 9s ease-in-out infinite alternate;
+        filter: drop-shadow(0 0 60px rgba(47, 125, 255, 0.55));
+        transform: translateY(-50%);
+        animation: wmRobotFloat 12s ease-in-out infinite alternate;
       }
       html.module-view-active .wm-robot { display: none; }
       @media (max-width: 960px) { .wm-robot { display: none; } }
       @keyframes wmRobotFloat {
-        from { transform: translateY(0) rotate(0deg); }
-        to   { transform: translateY(-10px) rotate(0.4deg); }
+        from { transform: translateY(calc(-50% - 10px)); }
+        to   { transform: translateY(calc(-50% + 10px)); }
       }
       @media (prefers-reduced-motion: reduce) {
         .wm-robot { animation: none !important; }


### PR DESCRIPTION
The watermarks shipped in #362 / #363 were present in the DOM but effectively invisible on the deployed site. This PR fixes the visibility so they read as a clear robot silhouette, not a ghost.

## What was wrong

| Symptom | Cause |
|---|---|
| Robot invisible on dark navy / wine / green / purple / pink pages | `mix-blend-mode: screen` with a mid-tone mask colour on an already-dark backdrop had nothing to lift |
| Barely-there even where visible | `opacity: 0.16` |
| Only a sliver shown | Positioned at `left: -4vw; bottom: -3vh` — mostly pushed off-screen |
| Silhouette detail lost | Width capped at `min(420px, 32vw)` |

## What changed

For all five module landings (`workbench`, `compliance-ops`, `logistics`, `screening-command`, `routines`) and the index landing:

- Dropped `mix-blend-mode: screen`
- Opacity `0.16`/`0.22` → `0.78`
- Position `left: -4vw; bottom: -3vh` → `left: 0; top: 50%` with `translateY(-50%)`, vertically centred against the left gutter (landing keeps its existing left + right pair)
- Size `min(420px, 32vw)` → `min(640px, 44vw)` on module pages, `min(520px, 32vw)` on landing
- Tint switched to the palette's *bright* tone (`--sky #7fc1ff`, `--ice` pinks, `--sky #86efac`, `--sky #e879f9`) so the silhouette lifts off the dark `--midnight`
- Drop-shadow glow strengthened to 0.55 alpha
- `wmRobotFloat` keyframes rewritten around `translateY(-50%)` so the centring survives the animation

Hidden states unchanged: `module-view-active`, `<=960px`, `html.embedded`, `prefers-reduced-motion`.

## Test plan

- [ ] `/workbench` — bright azure robot, centred left, clearly legible on navy
- [ ] `/compliance-ops` — bright pink robot, centred left, legible on wine
- [ ] `/logistics` — bright green robot, centred left, legible on deep green
- [ ] `/screening-command` — bright violet robot, centred left, legible on purple
- [ ] `/routines` — bright azure robot, centred left, legible on navy
- [ ] `/` (landing) — pink robot on left, gold robot on right, both clearly visible in the viewport gutters
- [ ] Sub-route (`/workbench/foo`) still hides the watermark
- [ ] `<960px` viewport still hides
- [ ] `prefers-reduced-motion` still disables the float