### PR TITLE
Clean bottom-right robot watermarks on 5 landing pages

### DIFF
--- a/assets/watermark-compliance-ops.svg
+++ b/assets/watermark-compliance-ops.svg
@@ -1,45 +1,58 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 520" fill="none" stroke="#000" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" aria-hidden="true">
-  <!-- Neon-ribbon variant for /compliance-ops (rose / pink). Smooth flowing curves. -->
-  <path d="M 176 68 C 120 78 82 138 78 210 C 74 272 92 322 118 360 L 130 406 L 140 458 L 190 478 L 250 470 L 286 446 C 310 424 320 388 324 352 L 334 296 C 346 236 344 172 312 130 C 280 86 232 64 196 68 C 188 68 182 68 176 68 Z" fill="#000" fill-opacity="0.15"/>
-  <path d="M 176 68 C 120 78 82 138 78 210 C 74 272 92 322 118 360 L 130 406 L 140 458" stroke-width="2.8"/>
-  <path d="M 196 68 C 232 64 280 86 312 130 C 344 172 346 236 334 296 L 324 352 C 320 388 310 424 286 446" stroke-width="2.8"/>
-  <!-- Flowing neon traces (ribbon loops) -->
-  <path d="M 80 220 C 160 170 260 200 334 160" stroke-width="2.4" opacity="0.9"/>
-  <path d="M 84 258 C 170 230 260 250 334 224" stroke-width="2.2" opacity="0.85"/>
-  <path d="M 92 294 C 176 286 258 292 326 272" stroke-width="2.2" opacity="0.8"/>
-  <path d="M 108 330 C 180 328 250 336 312 326" stroke-width="2" opacity="0.75"/>
-  <!-- Spiral curls around crown (heart / ribbon feel) -->
-  <path d="M 196 78 C 226 56 262 58 272 90 C 276 108 262 122 246 118" stroke-width="2.2"/>
-  <path d="M 222 88 C 244 74 266 82 268 100" stroke-width="2"/>
-  <!-- Face profile (left) -->
-  <path d="M 78 204 C 72 214 72 226 80 232" stroke-width="2.4"/>
-  <circle cx="104" cy="216" r="3.2" fill="#000"/>
-  <path d="M 88 240 C 78 248 78 260 90 264"/>
-  <path d="M 90 278 C 102 286 120 282 126 274"/>
-  <path d="M 102 296 C 112 306 130 306 142 298"/>
-  <!-- Jaw curve -->
-  <path d="M 142 306 C 150 340 152 380 144 420"/>
-  <!-- Ear loop -->
-  <ellipse cx="252" cy="290" rx="38" ry="44"/>
-  <ellipse cx="252" cy="290" rx="22" ry="28"/>
-  <circle cx="252" cy="290" r="6" fill="#000"/>
-  <!-- Trailing neon ribbons from crown -->
-  <path d="M 232 74 C 290 50 344 80 346 140" stroke-width="2" stroke-dasharray="6 4" opacity="0.75"/>
-  <path d="M 250 86 C 320 92 364 144 358 208" stroke-width="2" stroke-dasharray="6 4" opacity="0.7"/>
-  <path d="M 274 118 C 340 144 372 200 362 260" stroke-width="2" stroke-dasharray="6 4" opacity="0.65"/>
-  <path d="M 290 176 C 348 208 368 260 348 308" stroke-width="2" stroke-dasharray="6 4" opacity="0.6"/>
-  <!-- Heart-shaped node on temple -->
-  <path d="M 160 124 C 156 116 146 116 144 126 C 142 116 132 116 128 124 C 128 136 144 148 144 148 C 144 148 160 136 160 124 Z" stroke-width="1.6"/>
-  <!-- Sparkle accents -->
-  <path d="M 308 160 L 314 154 M 314 160 L 308 154" stroke-width="1.6"/>
-  <path d="M 328 220 L 336 214 M 336 220 L 328 214" stroke-width="1.6"/>
-  <path d="M 340 280 L 348 274 M 348 280 L 340 274" stroke-width="1.6"/>
-  <!-- Neck ribbon -->
-  <path d="M 146 462 C 200 478 262 474 294 452" stroke-width="2.4"/>
-  <path d="M 162 474 C 208 486 260 484 288 468"/>
-  <path d="M 178 488 C 210 496 252 494 274 484"/>
-  <!-- Data nodes -->
-  <circle cx="346" cy="140" r="2.6" fill="#000"/>
-  <circle cx="358" cy="208" r="2.6" fill="#000"/>
-  <circle cx="362" cy="260" r="2.6" fill="#000"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 640" aria-hidden="true">
+  <!-- Female cyborg profile with flowing cable-hair — Compliance Ops -->
+  <g fill="#000">
+    <!-- Flowing cable hair mass behind head -->
+    <path d="M 264 44
+             C 176 48 104 118 90 210
+             C 78 292 98 370 140 436
+             C 168 478 182 528 164 578
+             L 138 626
+             L 282 626
+             L 266 574
+             C 256 532 280 498 318 468
+             C 364 430 396 378 402 314
+             C 410 236 392 156 340 104
+             C 312 76 288 52 264 44 Z"/>
+    <!-- Face profile (strong jaw/cheekbone) -->
+    <path d="M 222 142
+             C 184 162 162 212 164 264
+             C 166 310 182 352 202 384
+             L 210 420
+             L 216 458
+             L 254 472
+             L 294 462
+             L 322 432
+             C 342 400 350 354 344 304
+             L 338 250
+             C 330 206 312 166 278 148
+             C 260 138 238 138 222 142 Z"/>
+    <!-- Neck + shoulder suggestion -->
+    <path d="M 216 472
+             L 212 512
+             L 200 558
+             L 180 600
+             L 348 600
+             L 332 560
+             L 310 524
+             L 288 492 Z"/>
+  </g>
+  <!-- Eye, lip, jaw highlights (cutouts via white fill — subtle on tinted bg) -->
+  <g fill="#ffffff" fill-opacity="0.42">
+    <ellipse cx="250" cy="272" rx="14" ry="6"/>
+    <circle cx="250" cy="272" r="3" fill="#000"/>
+  </g>
+  <g fill="#ffffff" fill-opacity="0.22">
+    <path d="M 224 358 Q 250 364 276 358 L 276 368 Q 250 376 224 368 Z"/>
+    <path d="M 214 306 Q 250 324 282 308 L 282 348 Q 250 364 212 348 Z"/>
+  </g>
+  <!-- Brow line -->
+  <path d="M 218 252 L 282 248" stroke="#ffffff" stroke-opacity="0.35" stroke-width="4" stroke-linecap="round" fill="none"/>
+  <!-- Cable hair flow seams -->
+  <g stroke="#ffffff" stroke-width="2.4" fill="none" stroke-opacity="0.22" stroke-linecap="round">
+    <path d="M 108 216 Q 154 196 200 202"/>
+    <path d="M 100 268 Q 150 260 200 264"/>
+    <path d="M 102 320 Q 152 322 200 324"/>
+    <path d="M 110 372 Q 156 380 198 380"/>
+    <path d="M 128 434 Q 170 444 204 442"/>
+  </g>
 </svg>

--- a/assets/watermark-logistics.svg
+++ b/assets/watermark-logistics.svg
@@ -1,51 +1,58 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 520" fill="none" stroke="#000" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" aria-hidden="true">
-  <!-- Bio-mech variant for /logistics (green). Head with organic vine / leaf motifs and circuit tendrils. -->
-  <path d="M 174 70 C 120 80 84 138 80 208 C 76 268 94 320 118 356 L 130 400 L 140 456 L 188 476 L 248 470 L 284 444 C 308 422 318 388 322 352 L 332 298 C 344 240 342 176 312 132 C 284 90 234 66 196 68 C 188 68 180 68 174 70 Z" fill="#000" fill-opacity="0.15"/>
-  <path d="M 174 70 C 120 80 84 138 80 208 C 76 268 94 320 118 356 L 130 400 L 140 456" stroke-width="2.8"/>
-  <path d="M 196 68 C 234 66 284 90 312 132 C 342 176 344 240 332 298 L 322 352 C 318 388 308 422 284 444" stroke-width="2.8"/>
-  <!-- Panel seams -->
-  <path d="M 98 180 C 174 150 256 154 312 186"/>
-  <path d="M 86 226 C 176 206 260 210 324 232"/>
-  <path d="M 88 274 C 180 262 258 264 322 284"/>
-  <!-- Face profile -->
-  <path d="M 78 210 C 72 220 72 232 80 238" stroke-width="2.4"/>
-  <circle cx="104" cy="220" r="3" fill="#000"/>
-  <path d="M 84 248 C 76 258 78 268 90 272"/>
-  <path d="M 92 284 C 102 292 118 290 124 284"/>
-  <path d="M 102 304 C 116 316 134 314 142 306"/>
-  <!-- Jaw -->
-  <path d="M 142 314 C 150 348 152 386 144 424"/>
-  <!-- Ear disc -->
-  <circle cx="250" cy="290" r="38"/>
-  <circle cx="250" cy="290" r="22"/>
-  <circle cx="250" cy="290" r="8" fill="#000"/>
-  <!-- Main vine stem along temple -->
-  <path d="M 204 78 C 240 96 264 130 280 170 C 292 208 288 248 278 282 C 266 320 240 348 212 362" stroke-width="2" opacity="0.85"/>
-  <!-- Vine branches -->
-  <path d="M 224 108 C 244 104 260 114 262 132" stroke-width="1.8" opacity="0.8"/>
-  <path d="M 236 148 C 258 144 276 156 278 176" stroke-width="1.8" opacity="0.8"/>
-  <path d="M 264 204 C 284 208 300 226 298 248" stroke-width="1.8" opacity="0.8"/>
-  <path d="M 270 260 C 292 264 306 282 302 304" stroke-width="1.8" opacity="0.75"/>
-  <!-- Leaves (teardrop shapes) -->
-  <path d="M 262 132 C 276 124 294 130 296 144 C 294 156 278 156 272 150 C 268 144 264 138 262 132 Z" stroke-width="1.6"/>
-  <path d="M 278 176 C 294 168 314 176 314 192 C 310 204 294 202 286 194 C 282 188 280 182 278 176 Z" stroke-width="1.6"/>
-  <path d="M 298 248 C 318 244 336 254 334 268 C 328 280 310 276 302 268 C 298 262 298 254 298 248 Z" stroke-width="1.6"/>
-  <path d="M 302 304 C 322 302 338 314 334 328 C 326 338 308 332 302 324 C 300 316 300 310 302 304 Z" stroke-width="1.6"/>
-  <!-- Vine tendrils from crown (curly) -->
-  <path d="M 220 78 C 260 60 296 68 320 98 C 338 126 338 164 318 192" stroke-width="1.8" stroke-dasharray="5 3" opacity="0.6"/>
-  <path d="M 246 80 C 288 84 326 118 336 158" stroke-width="1.8" stroke-dasharray="5 3" opacity="0.55"/>
-  <path d="M 266 102 C 320 130 354 178 348 232" stroke-width="1.8" stroke-dasharray="5 3" opacity="0.5"/>
-  <!-- Crown leaves -->
-  <path d="M 200 80 C 216 60 238 56 250 72 C 248 86 230 92 218 86 C 210 84 204 82 200 80 Z" stroke-width="1.6"/>
-  <path d="M 240 80 C 258 62 282 60 294 78 C 290 92 272 96 260 90 Z" stroke-width="1.6"/>
-  <!-- Neck roots -->
-  <path d="M 144 462 L 196 482 L 258 478 L 290 456"/>
-  <path d="M 170 470 L 170 504"/>
-  <path d="M 206 478 L 208 510"/>
-  <path d="M 244 474 L 244 506"/>
-  <!-- Seed dots -->
-  <circle cx="284" cy="140" r="2" fill="#000"/>
-  <circle cx="300" cy="186" r="2" fill="#000"/>
-  <circle cx="314" cy="232" r="2" fill="#000"/>
-  <circle cx="320" cy="280" r="2" fill="#000"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 640" aria-hidden="true">
+  <!-- Astronaut-helmet cyborg — Logistics. Rounded helmet, visor, armored shoulder -->
+  <g fill="#000">
+    <!-- Helmet dome -->
+    <path d="M 234 56
+             C 144 60 88 130 86 226
+             C 84 298 110 358 148 400
+             L 160 448
+             L 172 490
+             L 218 504
+             L 282 500
+             L 336 484
+             L 378 452
+             L 398 402
+             C 412 346 410 282 392 224
+             C 370 152 322 92 260 62
+             C 252 58 244 56 234 56 Z"/>
+    <!-- Shoulder pauldron (armored, right side) -->
+    <path d="M 168 494
+             L 156 540
+             L 142 580
+             L 130 620
+             L 420 620
+             L 398 572
+             L 372 530
+             L 342 502
+             L 304 492
+             L 258 498 Z"/>
+    <!-- Antenna nub -->
+    <rect x="206" y="40" width="14" height="24" rx="4"/>
+    <circle cx="213" cy="32" r="7"/>
+  </g>
+  <!-- Visor band (tinted light) -->
+  <g>
+    <path d="M 138 238
+             Q 244 210 366 232
+             L 362 290
+             Q 244 314 138 292 Z" fill="#ffffff" fill-opacity="0.36"/>
+    <path d="M 150 254 Q 242 234 354 256" stroke="#000" stroke-width="3" fill="none" stroke-opacity="0.6"/>
+  </g>
+  <!-- Helmet panel seams -->
+  <g stroke="#ffffff" stroke-width="3" fill="none" stroke-opacity="0.25" stroke-linecap="round">
+    <path d="M 100 170 Q 240 120 380 170"/>
+    <path d="M 110 330 Q 246 360 378 332"/>
+    <path d="M 160 410 Q 246 424 350 408"/>
+  </g>
+  <!-- Helmet vent louvers -->
+  <g fill="#ffffff" fill-opacity="0.2">
+    <rect x="330" y="350" width="38" height="4" rx="2"/>
+    <rect x="330" y="362" width="38" height="4" rx="2"/>
+    <rect x="330" y="374" width="38" height="4" rx="2"/>
+  </g>
+  <!-- Chest circuit detail -->
+  <g stroke="#ffffff" stroke-width="2.5" fill="none" stroke-opacity="0.22" stroke-linecap="round">
+    <path d="M 180 560 L 240 560 L 250 580 L 330 580"/>
+    <circle cx="340" cy="580" r="5" fill="#ffffff" fill-opacity="0.35"/>
+  </g>
 </svg>

--- a/assets/watermark-routines.svg
+++ b/assets/watermark-routines.svg
@@ -1,73 +1,64 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 520" fill="none" stroke="#000" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" aria-hidden="true">
-  <!-- Glyph variant for /routines (azure). Head engraved with geometric tribal/glyph patterns. -->
-  <path d="M 176 70 C 120 80 84 138 80 208 C 76 268 94 320 118 356 L 130 400 L 140 456 L 188 476 L 248 470 L 284 444 C 308 422 318 388 322 352 L 332 298 C 344 240 342 176 312 132 C 284 90 234 66 196 68 C 188 68 182 68 176 70 Z" fill="#000" fill-opacity="0.15"/>
-  <path d="M 176 70 C 120 80 84 138 80 208 C 76 268 94 320 118 356 L 130 400 L 140 456" stroke-width="2.8"/>
-  <path d="M 196 68 C 234 66 284 90 312 132 C 342 176 344 240 332 298 L 322 352 C 318 388 308 422 284 444" stroke-width="2.8"/>
-  <!-- Horizontal glyph bands -->
-  <path d="M 96 168 L 310 160" stroke-width="1.6"/>
-  <path d="M 96 180 L 310 176" stroke-width="1.6"/>
-  <!-- Glyph strip 1 -->
-  <path d="M 120 186 L 128 194 L 136 186 L 144 194 L 152 186"/>
-  <path d="M 168 186 L 168 198 L 184 198 L 184 186"/>
-  <path d="M 200 198 L 208 186 L 216 198"/>
-  <path d="M 236 186 L 236 198 M 244 186 L 252 198 M 252 186 L 244 198"/>
-  <path d="M 272 186 L 286 186 L 286 198 L 272 198 Z"/>
-  <!-- Band 2 -->
-  <path d="M 88 240 L 320 236" stroke-width="1.6"/>
-  <path d="M 88 252 L 320 250" stroke-width="1.6"/>
-  <!-- Glyph strip 2 -->
-  <circle cx="120" cy="268" r="5"/>
-  <path d="M 140 262 L 148 272 L 140 278 L 148 284"/>
-  <path d="M 170 262 L 186 284 M 186 262 L 170 284"/>
-  <path d="M 206 262 L 206 284 L 222 284"/>
-  <path d="M 240 262 L 256 262 L 256 284 L 240 284 Z"/>
-  <path d="M 274 262 L 290 272 L 274 282"/>
-  <path d="M 302 262 L 302 284 M 294 272 L 310 272"/>
-  <!-- Band 3 -->
-  <path d="M 96 318 L 314 312" stroke-width="1.6"/>
-  <path d="M 96 330 L 314 326" stroke-width="1.6"/>
-  <!-- Glyph strip 3 -->
-  <path d="M 124 338 L 140 358 L 156 338"/>
-  <path d="M 176 338 L 176 358 L 192 358 L 192 338"/>
-  <circle cx="216" cy="348" r="6"/>
-  <path d="M 242 338 L 242 358 M 250 338 L 258 358 M 258 338 L 250 358"/>
-  <path d="M 276 338 L 290 348 L 276 358 Z"/>
-  <!-- Face profile -->
-  <path d="M 78 214 C 72 224 72 234 80 240" stroke-width="2.4"/>
-  <circle cx="104" cy="224" r="3" fill="#000"/>
-  <path d="M 84 250 C 76 258 78 268 90 272"/>
-  <path d="M 92 286 C 102 294 118 292 124 286"/>
-  <path d="M 102 306 C 116 318 134 316 142 308"/>
-  <!-- Central forehead glyph -->
-  <path d="M 168 100 L 180 90 L 192 100 L 202 90 L 216 100 L 228 90 L 242 100"/>
-  <path d="M 184 112 L 196 122 L 208 112 L 220 122 L 232 112"/>
-  <circle cx="200" cy="138" r="5"/>
-  <circle cx="200" cy="138" r="2" fill="#000"/>
-  <!-- Ear disc -->
-  <circle cx="254" cy="290" r="38"/>
-  <circle cx="254" cy="290" r="22"/>
-  <circle cx="254" cy="290" r="8" fill="#000"/>
-  <!-- Ear concentric glyphs -->
-  <path d="M 254 266 L 258 270 L 254 274 L 250 270 Z"/>
-  <path d="M 254 306 L 258 310 L 254 314 L 250 310 Z"/>
-  <path d="M 230 290 L 234 294 L 230 298 L 226 294 Z"/>
-  <path d="M 278 290 L 282 294 L 278 298 L 274 294 Z"/>
-  <!-- Jaw -->
-  <path d="M 142 316 C 150 352 152 390 144 430"/>
-  <!-- Neck glyph stripes -->
-  <path d="M 144 462 L 294 456"/>
-  <path d="M 150 478 L 290 472"/>
-  <path d="M 158 494 L 284 488"/>
-  <path d="M 168 470 L 168 506 M 200 476 L 200 510 M 232 476 L 232 510 M 264 472 L 264 506"/>
-  <!-- Radiating glyph rays from crown -->
-  <path d="M 220 78 L 300 46" stroke-width="1.4" stroke-dasharray="2 4" opacity="0.7"/>
-  <path d="M 248 82 L 340 80" stroke-width="1.4" stroke-dasharray="2 4" opacity="0.7"/>
-  <path d="M 272 100 L 360 140" stroke-width="1.4" stroke-dasharray="2 4" opacity="0.7"/>
-  <path d="M 292 138 L 374 196" stroke-width="1.4" stroke-dasharray="2 4" opacity="0.65"/>
-  <path d="M 306 186 L 374 256" stroke-width="1.4" stroke-dasharray="2 4" opacity="0.6"/>
-  <!-- Glyph tips -->
-  <path d="M 300 46 L 306 40 L 312 46 L 306 52 Z" fill="#000"/>
-  <path d="M 340 80 L 346 74 L 352 80 L 346 86 Z" fill="#000"/>
-  <path d="M 360 140 L 366 134 L 372 140 L 366 146 Z" fill="#000"/>
-  <path d="M 374 196 L 380 190 L 386 196 L 380 202 Z" fill="#000"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 640" aria-hidden="true">
+  <!-- Sleek DJ/headphones cyborg profile — Routines. Smooth curves, prominent ear disc. -->
+  <g fill="#000">
+    <!-- Head + jaw -->
+    <path d="M 238 64
+             C 172 68 124 120 108 188
+             C 92 258 100 326 128 382
+             L 142 428
+             L 152 476
+             L 190 498
+             L 244 504
+             L 296 494
+             L 340 470
+             L 366 430
+             C 382 396 388 356 386 316
+             L 392 258
+             C 394 198 382 142 350 104
+             C 320 76 282 64 250 64 Z"/>
+    <!-- Chin + neck (long, sleek) -->
+    <path d="M 186 496
+             L 178 540
+             L 168 578
+             L 154 618
+             L 366 618
+             L 346 574
+             L 322 536
+             L 296 506 Z"/>
+    <!-- Headphone band arch -->
+    <path d="M 168 108
+             Q 246 40 344 108
+             L 344 130
+             Q 246 66 168 130 Z"/>
+    <!-- Headphone ear cup (right) -->
+    <circle cx="356" cy="306" r="46"/>
+    <!-- Headphone ear cup (left, partial) -->
+    <circle cx="108" cy="306" r="18"/>
+  </g>
+  <!-- Ear cup detail -->
+  <g>
+    <circle cx="356" cy="306" r="30" fill="#ffffff" fill-opacity="0.28"/>
+    <circle cx="356" cy="306" r="14" fill="#000"/>
+    <circle cx="356" cy="306" r="6" fill="#ffffff" fill-opacity="0.8"/>
+  </g>
+  <!-- Eye -->
+  <g>
+    <ellipse cx="232" cy="258" rx="18" ry="7" fill="#ffffff" fill-opacity="0.45"/>
+    <circle cx="232" cy="258" r="4.5" fill="#000"/>
+  </g>
+  <!-- Brow -->
+  <path d="M 198 232 L 276 226" stroke="#ffffff" stroke-opacity="0.35" stroke-width="4" stroke-linecap="round" fill="none"/>
+  <!-- Lip suggestion -->
+  <path d="M 202 348 Q 226 356 252 350" stroke="#ffffff" stroke-opacity="0.3" stroke-width="3" stroke-linecap="round" fill="none"/>
+  <!-- Panel seams -->
+  <g stroke="#ffffff" stroke-width="2.5" fill="none" stroke-opacity="0.2" stroke-linecap="round">
+    <path d="M 120 200 L 200 188"/>
+    <path d="M 114 296 L 196 292"/>
+    <path d="M 132 388 L 220 390"/>
+  </g>
+  <!-- Collar -->
+  <g stroke="#ffffff" stroke-width="2" fill="none" stroke-opacity="0.22">
+    <path d="M 170 570 L 344 570"/>
+    <path d="M 160 592 L 358 592"/>
+  </g>
 </svg>

--- a/assets/watermark-screening-command.svg
+++ b/assets/watermark-screening-command.svg
@@ -1,53 +1,62 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 520" fill="none" stroke="#000" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" aria-hidden="true">
-  <!-- Crystal / low-poly variant for /screening-command (violet). Faceted polygonal head. -->
-  <!-- Fill silhouette (polygonal) -->
-  <path d="M 180 70 L 128 116 L 96 176 L 86 236 L 104 294 L 128 342 L 134 398 L 148 454 L 196 472 L 252 470 L 286 440 L 308 394 L 322 342 L 334 286 L 338 222 L 320 158 L 286 108 L 232 74 Z" fill="#000" fill-opacity="0.15"/>
-  <!-- Head outline -->
-  <path d="M 180 70 L 128 116 L 96 176 L 86 236 L 104 294 L 128 342 L 134 398 L 148 454" stroke-width="2.8"/>
-  <path d="M 232 74 L 286 108 L 320 158 L 338 222 L 334 286 L 322 342 L 308 394 L 286 440" stroke-width="2.8"/>
-  <!-- Internal crystal facets -->
-  <path d="M 128 116 L 176 150 L 232 74"/>
-  <path d="M 96 176 L 176 150 L 220 198 L 176 240 L 96 176"/>
-  <path d="M 176 150 L 232 74 L 286 108 L 250 168 L 220 198 L 176 150"/>
-  <path d="M 286 108 L 320 158 L 270 196 L 250 168 Z"/>
-  <path d="M 320 158 L 338 222 L 292 252 L 270 196 Z"/>
-  <path d="M 220 198 L 270 196 L 292 252 L 240 276 Z"/>
-  <path d="M 176 240 L 220 198 L 240 276 L 188 294 Z"/>
-  <path d="M 86 236 L 176 240 L 188 294 L 104 294 Z"/>
-  <path d="M 104 294 L 188 294 L 226 338 L 128 342 Z"/>
-  <path d="M 188 294 L 240 276 L 292 252 L 310 314 L 262 344 L 226 338 Z"/>
-  <path d="M 292 252 L 338 222 L 334 286 L 310 314 Z"/>
-  <path d="M 310 314 L 334 286 L 322 342 L 286 360 Z"/>
-  <path d="M 262 344 L 310 314 L 286 360 L 250 382 Z"/>
-  <path d="M 226 338 L 262 344 L 250 382 L 196 388 Z"/>
-  <path d="M 128 342 L 226 338 L 196 388 L 134 398 Z"/>
-  <path d="M 134 398 L 196 388 L 218 440 L 168 448 Z"/>
-  <path d="M 196 388 L 250 382 L 268 430 L 218 440 Z"/>
-  <path d="M 250 382 L 286 360 L 308 394 L 268 430 Z"/>
-  <!-- Eye (facet gem) -->
-  <path d="M 98 218 L 116 210 L 128 224 L 116 236 Z" fill="#000"/>
-  <!-- Brow slash -->
-  <path d="M 88 206 L 136 198"/>
-  <!-- Mouth slash -->
-  <path d="M 110 280 L 138 286"/>
-  <!-- Crown crystal spikes -->
-  <path d="M 180 70 L 190 40 L 210 60 L 232 74"/>
-  <path d="M 206 62 L 220 36 L 248 50"/>
-  <path d="M 226 50 L 258 28 L 274 66"/>
-  <!-- Radiating crystal shards from crown -->
-  <path d="M 232 74 L 290 40" stroke-width="1.6" opacity="0.7"/>
-  <path d="M 250 80 L 320 62" stroke-width="1.6" opacity="0.7"/>
-  <path d="M 270 94 L 350 94" stroke-width="1.6" opacity="0.7"/>
-  <path d="M 286 108 L 360 130" stroke-width="1.6" opacity="0.65"/>
-  <path d="M 308 136 L 376 166" stroke-width="1.6" opacity="0.6"/>
-  <path d="M 320 158 L 378 210" stroke-width="1.6" opacity="0.55"/>
-  <!-- Small facet gems floating around head -->
-  <path d="M 350 94 L 360 86 L 368 96 L 358 104 Z" fill="#000"/>
-  <path d="M 376 166 L 386 158 L 394 170 L 384 178 Z" fill="#000"/>
-  <path d="M 290 40 L 300 32 L 308 42 L 298 50 Z" fill="#000"/>
-  <!-- Neck polygon -->
-  <path d="M 148 454 L 172 506 L 230 514 L 278 498 L 286 440"/>
-  <path d="M 172 506 L 216 480 L 260 506"/>
-  <path d="M 216 480 L 210 454"/>
-  <path d="M 216 480 L 240 462"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 640" aria-hidden="true">
+  <!-- Faceted crystal / low-poly cyborg — Screening Command. Sharp polygonal planes. -->
+  <g fill="#000">
+    <!-- Polygonal head silhouette -->
+    <path d="M 244 54
+             L 184 82
+             L 128 138
+             L 102 214
+             L 96 290
+             L 110 360
+             L 130 410
+             L 140 462
+             L 160 494
+             L 208 510
+             L 272 502
+             L 328 482
+             L 366 448
+             L 388 398
+             L 400 336
+             L 404 266
+             L 392 198
+             L 362 134
+             L 314 86
+             L 262 56 Z"/>
+    <!-- Neck polygon -->
+    <path d="M 182 502
+             L 170 544
+             L 156 586
+             L 142 622
+             L 378 622
+             L 360 582
+             L 338 546
+             L 320 516
+             L 290 506 Z"/>
+  </g>
+  <!-- Facet highlight planes -->
+  <g fill="#ffffff" fill-opacity="0.14">
+    <path d="M 244 54 L 184 82 L 196 160 L 252 130 Z"/>
+    <path d="M 262 56 L 314 86 L 302 160 L 252 130 Z"/>
+    <path d="M 128 138 L 102 214 L 170 220 L 196 160 L 184 82 Z"/>
+    <path d="M 110 360 L 130 410 L 186 396 L 170 330 L 102 290 L 96 290 Z"/>
+    <path d="M 302 160 L 362 134 L 392 198 L 322 244 Z"/>
+    <path d="M 252 130 L 302 160 L 322 244 L 252 256 L 196 244 L 196 160 Z"/>
+    <path d="M 322 244 L 400 266 L 404 266 L 392 336 L 330 330 Z"/>
+  </g>
+  <g fill="#ffffff" fill-opacity="0.25">
+    <path d="M 252 256 L 322 244 L 330 330 L 252 340 L 170 330 L 196 244 Z"/>
+  </g>
+  <!-- Eye slot -->
+  <path d="M 212 288 L 292 282 L 286 308 L 216 312 Z" fill="#ffffff" fill-opacity="0.45"/>
+  <circle cx="236" cy="298" r="5" fill="#000"/>
+  <circle cx="272" cy="296" r="3" fill="#000"/>
+  <!-- Jaw facet -->
+  <path d="M 186 396 L 252 400 L 330 394 L 300 462 L 220 468 Z" fill="#ffffff" fill-opacity="0.1"/>
+  <!-- Facet edge lines -->
+  <g stroke="#ffffff" stroke-width="2.2" fill="none" stroke-opacity="0.22" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M 196 160 L 252 130 L 302 160"/>
+    <path d="M 170 220 L 252 256 L 322 244"/>
+    <path d="M 170 330 L 252 340 L 330 330"/>
+    <path d="M 186 396 L 252 400 L 330 394"/>
+  </g>
 </svg>

--- a/assets/watermark-workbench.svg
+++ b/assets/watermark-workbench.svg
@@ -1,47 +1,51 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 520" fill="none" stroke="#000" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" aria-hidden="true">
-  <!-- Chrome / industrial variant for /workbench (azure navy). Sharp paneled head. -->
-  <path d="M 174 68 C 120 78 84 134 80 206 C 76 266 94 318 118 356 L 130 400 L 138 452 L 186 470 L 248 464 L 284 440 C 306 418 316 384 320 348 L 332 296 C 344 238 342 176 312 132 C 284 90 234 66 198 68 C 188 68 180 68 174 68 Z" fill="#000" fill-opacity="0.16"/>
-  <path d="M 174 68 C 120 78 84 134 80 206 C 76 266 94 318 118 356 L 130 400 L 138 452" stroke-width="2.8"/>
-  <path d="M 198 68 C 234 66 284 90 312 132 C 342 176 344 238 332 296 L 320 348 C 316 384 306 418 284 440" stroke-width="2.8"/>
-  <!-- Angular plate seams -->
-  <path d="M 96 170 L 180 130 L 256 138 L 312 168"/>
-  <path d="M 86 210 L 178 190 L 262 194 L 324 222"/>
-  <path d="M 84 252 L 176 238 L 268 240 L 330 260"/>
-  <path d="M 92 294 L 180 286 L 262 288 L 322 304"/>
-  <path d="M 108 336 L 186 332 L 256 336 L 308 346"/>
-  <!-- Visor / HUD line across brow -->
-  <path d="M 78 200 L 150 196 L 226 200 L 304 208" stroke-width="2.4"/>
-  <circle cx="104" cy="212" r="3.2" fill="#000"/>
-  <!-- Nose + lip hints -->
-  <path d="M 78 226 L 72 244 L 82 258"/>
-  <path d="M 88 272 L 118 274"/>
-  <path d="M 96 294 L 128 292"/>
-  <!-- Jaw seam -->
-  <path d="M 130 314 L 142 350 L 146 390 L 140 440"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 640" aria-hidden="true">
+  <!-- Chrome cyborg profile — Workbench. Solid silhouette facing right. -->
+  <g fill="#000">
+    <!-- Head + jaw -->
+    <path d="M 232 70
+             C 168 74 118 120 102 184
+             C 88 242 94 304 118 358
+             L 136 406
+             L 146 464
+             L 170 488
+             L 216 500
+             L 270 494
+             L 322 470
+             L 360 430
+             C 378 400 388 360 388 320
+             L 396 258
+             C 402 198 388 138 350 104
+             C 320 80 278 68 244 70 Z"/>
+    <!-- Neck + collar -->
+    <path d="M 178 498
+             L 174 540
+             L 168 578
+             L 152 612
+             L 378 612
+             L 360 578
+             L 338 548
+             L 320 520
+             L 298 510 Z"/>
+    <!-- Crown accent panel -->
+    <path d="M 244 72 L 308 94 L 336 80 L 306 70 L 272 64 Z"/>
+  </g>
+  <!-- Visor / cutout detail painted in white (same alpha, so subtle outline on tinted bg) -->
+  <g fill="#ffffff" fill-opacity="0.28">
+    <rect x="160" y="232" width="210" height="22" rx="6"/>
+    <circle cx="208" cy="244" r="5" fill="#000"/>
+    <circle cx="276" cy="244" r="3" fill="#000"/>
+  </g>
+  <!-- Panel seams -->
+  <g stroke="#ffffff" stroke-width="3" fill="none" stroke-opacity="0.22" stroke-linecap="round">
+    <path d="M 148 190 L 370 182"/>
+    <path d="M 142 290 L 382 284"/>
+    <path d="M 152 356 L 372 350"/>
+    <path d="M 186 410 L 348 406"/>
+  </g>
   <!-- Ear disc -->
-  <circle cx="252" cy="290" r="40"/>
-  <circle cx="252" cy="290" r="24"/>
-  <circle cx="252" cy="290" r="8" fill="#000"/>
-  <path d="M 252 250 L 284 260 L 286 292 L 270 316" stroke-width="2.6"/>
-  <!-- Crown triangles -->
-  <path d="M 172 72 L 200 98 L 232 88 L 256 72"/>
-  <path d="M 152 82 L 172 64 L 206 60 L 232 70"/>
-  <!-- Circuit bus lines on neck -->
-  <path d="M 146 456 L 200 474 L 258 472 L 290 452"/>
-  <path d="M 166 470 L 170 500"/>
-  <path d="M 208 478 L 208 506"/>
-  <path d="M 248 472 L 246 500"/>
-  <!-- LED dots -->
-  <circle cx="200" cy="138" r="2" fill="#000"/>
-  <circle cx="256" cy="142" r="2" fill="#000"/>
-  <circle cx="236" cy="196" r="2" fill="#000"/>
-  <circle cx="220" cy="240" r="2" fill="#000"/>
-  <circle cx="290" cy="272" r="2" fill="#000"/>
-  <!-- Straight filament strands (rigid, no curls) -->
-  <path d="M 230 72 L 298 46 L 346 66" stroke-width="1.6" stroke-dasharray="3 5" opacity="0.7"/>
-  <path d="M 252 82 L 320 82 L 360 114" stroke-width="1.6" stroke-dasharray="3 5" opacity="0.7"/>
-  <path d="M 272 106 L 346 132 L 372 180" stroke-width="1.6" stroke-dasharray="3 5" opacity="0.65"/>
-  <circle cx="346" cy="66" r="2.6" fill="#000"/>
-  <circle cx="360" cy="114" r="2.6" fill="#000"/>
-  <circle cx="372" cy="180" r="2.6" fill="#000"/>
+  <g fill="#000">
+    <circle cx="338" cy="310" r="34"/>
+  </g>
+  <circle cx="338" cy="310" r="18" fill="#ffffff" fill-opacity="0.35"/>
+  <circle cx="338" cy="310" r="7" fill="#000"/>
 </svg>

--- a/compliance-ops.html
+++ b/compliance-ops.html
@@ -698,96 +698,31 @@
         color: var(--muted);
       }
 
-      /* === DECORATIVE PALETTE WATERMARK === */
-      .wm {
-        position: fixed;
-        right: -4vw;
-        bottom: -2vh;
-        width: min(460px, 36vw);
-        aspect-ratio: 5 / 7;
-        pointer-events: none;
-        z-index: 0;
-        opacity: 0.18;
-        mix-blend-mode: screen;
-        filter: drop-shadow(0 0 40px rgba(236, 72, 153, 0.28));
-        animation: wmFloat 14s ease-in-out infinite alternate;
-      }
-      .wm svg { width: 100%; height: 100%; display: block; }
-      html.module-view-active .wm { display: none; }
-      @media (max-width: 960px) { .wm { display: none; } }
-      @keyframes wmFloat {
-        from { transform: translateY(0) rotate(0deg); }
-        to   { transform: translateY(-14px) rotate(-0.5deg); }
-      }
-      @media (prefers-reduced-motion: reduce) { .wm { animation: none !important; } }
-
-      /* Cyber-head watermark — pink accent on the compliance-ops palette.
-         Large, centred on the left gutter, clearly visible. */
+      /* === ROBOT WATERMARK === Subtle bottom-right professional silhouette. */
       .wm-robot {
         position: fixed;
-        left: 0;
-        top: 50%;
-        width: min(640px, 44vw);
-        aspect-ratio: 420 / 520;
+        right: -2vw;
+        bottom: 0;
+        width: min(520px, 34vw);
+        height: min(680px, 70vh);
         pointer-events: none;
         z-index: 0;
-        opacity: 0.78;
+        opacity: 0.14;
         background-color: #f9a8d4;
-        -webkit-mask: url("assets/watermark-compliance-ops.svg") center / contain no-repeat;
-                mask: url("assets/watermark-compliance-ops.svg") center / contain no-repeat;
-        filter: drop-shadow(0 0 60px rgba(236, 72, 153, 0.55));
-        transform: translateY(-50%);
-        animation: wmRobotFloat 12s ease-in-out infinite alternate;
+        background-image: url("assets/robot-compliance-ops.png");
+        background-repeat: no-repeat;
+        background-position: right bottom;
+        background-size: contain;
+        -webkit-mask: url("assets/watermark-compliance-ops.svg") right bottom / contain no-repeat;
+                mask: url("assets/watermark-compliance-ops.svg") right bottom / contain no-repeat;
+        filter: drop-shadow(0 0 40px rgba(236, 72, 153, 0.35));
       }
       html.module-view-active .wm-robot { display: none; }
       @media (max-width: 960px) { .wm-robot { display: none; } }
-      @keyframes wmRobotFloat {
-        from { transform: translateY(calc(-50% - 10px)); }
-        to   { transform: translateY(calc(-50% + 10px)); }
-      }
-      @media (prefers-reduced-motion: reduce) { .wm-robot { animation: none !important; } }
     </style>
   </head>
   <body>
     <aside class="wm-robot" aria-hidden="true"></aside>
-    <aside class="wm" aria-hidden="true">
-      <svg viewBox="0 0 500 700" xmlns="http://www.w3.org/2000/svg">
-        <defs>
-          <linearGradient id="wmGradCo" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" stop-color="#f472b6" />
-            <stop offset="50%" stop-color="#ec4899" />
-            <stop offset="100%" stop-color="#ef4444" />
-          </linearGradient>
-          <radialGradient id="wmGlowCo" cx="45%" cy="38%" r="55%">
-            <stop offset="0%" stop-color="#fb7185" stop-opacity="0.6" />
-            <stop offset="60%" stop-color="#ec4899" stop-opacity="0.18" />
-            <stop offset="100%" stop-color="transparent" />
-          </radialGradient>
-          <linearGradient id="wmSpineCo" x1="0%" y1="0%" x2="0%" y2="100%">
-            <stop offset="0%" stop-color="#f9a8d4" stop-opacity="0.9" />
-            <stop offset="100%" stop-color="#ef4444" stop-opacity="0.3" />
-          </linearGradient>
-        </defs>
-        <circle cx="245" cy="290" r="270" fill="url(#wmGlowCo)" />
-        <path d="M 220 70 Q 340 50 390 170 Q 420 250 395 340 Q 380 380 395 420 Q 420 470 400 520 Q 380 560 335 570 L 335 650 L 170 650 L 170 520 Q 140 510 125 480 Q 105 430 120 390 Q 135 355 150 330 Q 130 270 140 210 Q 160 120 220 70 Z"
-              fill="url(#wmGradCo)" opacity="0.62" />
-        <path d="M 285 160 Q 340 180 355 240 Q 365 300 340 340 Q 315 370 275 365 Q 245 355 240 310 Q 238 260 255 210 Q 270 175 285 160 Z"
-              fill="#fff" opacity="0.12" />
-        <ellipse cx="235" cy="270" rx="16" ry="7" fill="#fbcfe8" opacity="0.85" />
-        <g stroke="#fbcfe8" stroke-width="1.6" fill="none" opacity="0.55" stroke-linecap="round">
-          <path d="M 210 220 L 290 220" />
-          <path d="M 205 300 L 300 300" />
-          <path d="M 225 345 L 310 345" />
-          <circle cx="300" cy="220" r="3.5" fill="#fbcfe8" opacity="0.95" />
-          <circle cx="310" cy="300" r="2.5" fill="#fbcfe8" opacity="0.9" />
-        </g>
-        <g stroke="url(#wmSpineCo)" stroke-width="1.2" fill="none" opacity="0.7">
-          <path d="M 230 580 L 310 580" />
-          <path d="M 225 605 L 315 605" />
-          <path d="M 220 630 L 320 630" />
-        </g>
-      </svg>
-    </aside>
     <div class="shell">
       <header class="topbar">
         <div class="title-group">

--- a/logistics.html
+++ b/logistics.html
@@ -937,96 +937,31 @@
         }
       }
 
-      /* === DECORATIVE PALETTE WATERMARK === */
-      .wm {
-        position: fixed;
-        right: -4vw;
-        bottom: -2vh;
-        width: min(460px, 36vw);
-        aspect-ratio: 5 / 7;
-        pointer-events: none;
-        z-index: 0;
-        opacity: 0.18;
-        mix-blend-mode: screen;
-        filter: drop-shadow(0 0 40px rgba(34, 197, 94, 0.28));
-        animation: wmFloat 14s ease-in-out infinite alternate;
-      }
-      .wm svg { width: 100%; height: 100%; display: block; }
-      html.module-view-active .wm { display: none; }
-      @media (max-width: 960px) { .wm { display: none; } }
-      @keyframes wmFloat {
-        from { transform: translateY(0) rotate(0deg); }
-        to   { transform: translateY(-14px) rotate(-0.5deg); }
-      }
-      @media (prefers-reduced-motion: reduce) { .wm { animation: none !important; } }
-
-      /* Cyber-head watermark — green accent on the logistics palette.
-         Large, centred on the left gutter, clearly visible. */
+      /* === ROBOT WATERMARK === Subtle bottom-right professional silhouette. */
       .wm-robot {
         position: fixed;
-        left: 0;
-        top: 50%;
-        width: min(640px, 44vw);
-        aspect-ratio: 420 / 520;
+        right: -2vw;
+        bottom: 0;
+        width: min(520px, 34vw);
+        height: min(680px, 70vh);
         pointer-events: none;
         z-index: 0;
-        opacity: 0.78;
+        opacity: 0.14;
         background-color: #86efac;
-        -webkit-mask: url("assets/watermark-logistics.svg") center / contain no-repeat;
-                mask: url("assets/watermark-logistics.svg") center / contain no-repeat;
-        filter: drop-shadow(0 0 60px rgba(34, 197, 94, 0.55));
-        transform: translateY(-50%);
-        animation: wmRobotFloat 12s ease-in-out infinite alternate;
+        background-image: url("assets/robot-logistics.png");
+        background-repeat: no-repeat;
+        background-position: right bottom;
+        background-size: contain;
+        -webkit-mask: url("assets/watermark-logistics.svg") right bottom / contain no-repeat;
+                mask: url("assets/watermark-logistics.svg") right bottom / contain no-repeat;
+        filter: drop-shadow(0 0 40px rgba(34, 197, 94, 0.35));
       }
       html.module-view-active .wm-robot { display: none; }
       @media (max-width: 960px) { .wm-robot { display: none; } }
-      @keyframes wmRobotFloat {
-        from { transform: translateY(calc(-50% - 10px)); }
-        to   { transform: translateY(calc(-50% + 10px)); }
-      }
-      @media (prefers-reduced-motion: reduce) { .wm-robot { animation: none !important; } }
     </style>
   </head>
   <body>
     <aside class="wm-robot" aria-hidden="true"></aside>
-    <aside class="wm" aria-hidden="true">
-      <svg viewBox="0 0 500 700" xmlns="http://www.w3.org/2000/svg">
-        <defs>
-          <linearGradient id="wmGradLg" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" stop-color="#86efac" />
-            <stop offset="50%" stop-color="#22c55e" />
-            <stop offset="100%" stop-color="#14532d" />
-          </linearGradient>
-          <radialGradient id="wmGlowLg" cx="45%" cy="38%" r="55%">
-            <stop offset="0%" stop-color="#bbf7d0" stop-opacity="0.6" />
-            <stop offset="60%" stop-color="#22c55e" stop-opacity="0.18" />
-            <stop offset="100%" stop-color="transparent" />
-          </radialGradient>
-          <linearGradient id="wmSpineLg" x1="0%" y1="0%" x2="0%" y2="100%">
-            <stop offset="0%" stop-color="#86efac" stop-opacity="0.9" />
-            <stop offset="100%" stop-color="#14532d" stop-opacity="0.3" />
-          </linearGradient>
-        </defs>
-        <circle cx="245" cy="290" r="270" fill="url(#wmGlowLg)" />
-        <path d="M 220 70 Q 340 50 390 170 Q 420 250 395 340 Q 380 380 395 420 Q 420 470 400 520 Q 380 560 335 570 L 335 650 L 170 650 L 170 520 Q 140 510 125 480 Q 105 430 120 390 Q 135 355 150 330 Q 130 270 140 210 Q 160 120 220 70 Z"
-              fill="url(#wmGradLg)" opacity="0.62" />
-        <path d="M 285 160 Q 340 180 355 240 Q 365 300 340 340 Q 315 370 275 365 Q 245 355 240 310 Q 238 260 255 210 Q 270 175 285 160 Z"
-              fill="#fff" opacity="0.12" />
-        <ellipse cx="235" cy="270" rx="16" ry="7" fill="#bbf7d0" opacity="0.85" />
-        <g stroke="#bbf7d0" stroke-width="1.6" fill="none" opacity="0.55" stroke-linecap="round">
-          <path d="M 210 220 L 290 220" />
-          <path d="M 205 300 L 300 300" />
-          <path d="M 225 345 L 310 345" />
-          <circle cx="300" cy="220" r="3.5" fill="#bbf7d0" opacity="0.95" />
-          <circle cx="310" cy="300" r="2.5" fill="#bbf7d0" opacity="0.9" />
-        </g>
-        <g stroke="url(#wmSpineLg)" stroke-width="1.2" fill="none" opacity="0.7">
-          <path d="M 230 580 L 310 580" />
-          <path d="M 225 605 L 315 605" />
-          <path d="M 220 630 L 320 630" />
-        </g>
-      </svg>
-    </aside>
     <main class="shell">
       <header class="topbar">
         <div class="title-group">

--- a/routines.html
+++ b/routines.html
@@ -505,95 +505,31 @@
         *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; }
       }
 
-      /* === DECORATIVE PALETTE WATERMARK === */
-      .wm {
-        position: fixed;
-        right: -4vw;
-        bottom: -2vh;
-        width: min(460px, 36vw);
-        aspect-ratio: 5 / 7;
-        pointer-events: none;
-        z-index: 0;
-        opacity: 0.18;
-        mix-blend-mode: screen;
-        filter: drop-shadow(0 0 40px rgba(47, 125, 255, 0.28));
-        animation: wmFloat 14s ease-in-out infinite alternate;
-      }
-      .wm svg { width: 100%; height: 100%; display: block; }
-      @media (max-width: 960px) { .wm { display: none; } }
-      @keyframes wmFloat {
-        from { transform: translateY(0) rotate(0deg); }
-        to   { transform: translateY(-14px) rotate(-0.5deg); }
-      }
-      @media (prefers-reduced-motion: reduce) { .wm { animation: none !important; } }
-
-      /* Cyber-head watermark — azure accent on the routines palette.
-         Large, centred on the left gutter, clearly visible. */
+      /* === ROBOT WATERMARK === Subtle bottom-right professional silhouette. */
       .wm-robot {
         position: fixed;
-        left: 0;
-        top: 50%;
-        width: min(640px, 44vw);
-        aspect-ratio: 420 / 520;
+        right: -2vw;
+        bottom: 0;
+        width: min(520px, 34vw);
+        height: min(680px, 70vh);
         pointer-events: none;
         z-index: 0;
-        opacity: 0.78;
+        opacity: 0.14;
         background-color: #7fc1ff;
-        -webkit-mask: url("assets/watermark-routines.svg") center / contain no-repeat;
-                mask: url("assets/watermark-routines.svg") center / contain no-repeat;
-        filter: drop-shadow(0 0 60px rgba(47, 125, 255, 0.55));
-        transform: translateY(-50%);
-        animation: wmRobotFloat 12s ease-in-out infinite alternate;
+        background-image: url("assets/robot-routines.png");
+        background-repeat: no-repeat;
+        background-position: right bottom;
+        background-size: contain;
+        -webkit-mask: url("assets/watermark-routines.svg") right bottom / contain no-repeat;
+                mask: url("assets/watermark-routines.svg") right bottom / contain no-repeat;
+        filter: drop-shadow(0 0 40px rgba(47, 125, 255, 0.35));
       }
       html.module-view-active .wm-robot { display: none; }
       @media (max-width: 960px) { .wm-robot { display: none; } }
-      @keyframes wmRobotFloat {
-        from { transform: translateY(calc(-50% - 10px)); }
-        to   { transform: translateY(calc(-50% + 10px)); }
-      }
-      @media (prefers-reduced-motion: reduce) { .wm-robot { animation: none !important; } }
     </style>
   </head>
   <body>
     <aside class="wm-robot" aria-hidden="true"></aside>
-    <aside class="wm" aria-hidden="true">
-      <svg viewBox="0 0 500 700" xmlns="http://www.w3.org/2000/svg">
-        <defs>
-          <linearGradient id="wmGradRt" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" stop-color="#5ea3ff" />
-            <stop offset="50%" stop-color="#2f7dff" />
-            <stop offset="100%" stop-color="#1d4ed8" />
-          </linearGradient>
-          <radialGradient id="wmGlowRt" cx="45%" cy="38%" r="55%">
-            <stop offset="0%" stop-color="#bcd8f5" stop-opacity="0.6" />
-            <stop offset="60%" stop-color="#2f7dff" stop-opacity="0.2" />
-            <stop offset="100%" stop-color="transparent" />
-          </radialGradient>
-          <linearGradient id="wmSpineRt" x1="0%" y1="0%" x2="0%" y2="100%">
-            <stop offset="0%" stop-color="#7fc1ff" stop-opacity="0.9" />
-            <stop offset="100%" stop-color="#1d4ed8" stop-opacity="0.3" />
-          </linearGradient>
-        </defs>
-        <circle cx="245" cy="290" r="270" fill="url(#wmGlowRt)" />
-        <path d="M 220 70 Q 340 50 390 170 Q 420 250 395 340 Q 380 380 395 420 Q 420 470 400 520 Q 380 560 335 570 L 335 650 L 170 650 L 170 520 Q 140 510 125 480 Q 105 430 120 390 Q 135 355 150 330 Q 130 270 140 210 Q 160 120 220 70 Z"
-              fill="url(#wmGradRt)" opacity="0.62" />
-        <path d="M 285 160 Q 340 180 355 240 Q 365 300 340 340 Q 315 370 275 365 Q 245 355 240 310 Q 238 260 255 210 Q 270 175 285 160 Z"
-              fill="#fff" opacity="0.12" />
-        <ellipse cx="235" cy="270" rx="16" ry="7" fill="#bcd8f5" opacity="0.9" />
-        <g stroke="#bcd8f5" stroke-width="1.6" fill="none" opacity="0.55" stroke-linecap="round">
-          <path d="M 210 220 L 290 220" />
-          <path d="M 205 300 L 300 300" />
-          <path d="M 225 345 L 310 345" />
-          <circle cx="300" cy="220" r="3.5" fill="#bcd8f5" opacity="0.95" />
-          <circle cx="310" cy="300" r="2.5" fill="#bcd8f5" opacity="0.9" />
-        </g>
-        <g stroke="url(#wmSpineRt)" stroke-width="1.2" fill="none" opacity="0.7">
-          <path d="M 230 580 L 310 580" />
-          <path d="M 225 605 L 315 605" />
-          <path d="M 220 630 L 320 630" />
-        </g>
-      </svg>
-    </aside>
     <main class="shell">
       <header class="topbar">
         <div class="brand">

--- a/screening-command.html
+++ b/screening-command.html
@@ -690,96 +690,31 @@
         color: var(--muted);
       }
 
-      /* === DECORATIVE PALETTE WATERMARK === */
-      .wm {
-        position: fixed;
-        right: -4vw;
-        bottom: -2vh;
-        width: min(460px, 36vw);
-        aspect-ratio: 5 / 7;
-        pointer-events: none;
-        z-index: 0;
-        opacity: 0.2;
-        mix-blend-mode: screen;
-        filter: drop-shadow(0 0 40px rgba(168, 85, 247, 0.3));
-        animation: wmFloat 14s ease-in-out infinite alternate;
-      }
-      .wm svg { width: 100%; height: 100%; display: block; }
-      html.module-view-active .wm { display: none; }
-      @media (max-width: 960px) { .wm { display: none; } }
-      @keyframes wmFloat {
-        from { transform: translateY(0) rotate(0deg); }
-        to   { transform: translateY(-14px) rotate(-0.5deg); }
-      }
-      @media (prefers-reduced-motion: reduce) { .wm { animation: none !important; } }
-
-      /* Cyber-head watermark — violet accent on the screening-command palette.
-         Large, centred on the left gutter, clearly visible. */
+      /* === ROBOT WATERMARK === Subtle bottom-right professional silhouette. */
       .wm-robot {
         position: fixed;
-        left: 0;
-        top: 50%;
-        width: min(640px, 44vw);
-        aspect-ratio: 420 / 520;
+        right: -2vw;
+        bottom: 0;
+        width: min(520px, 34vw);
+        height: min(680px, 70vh);
         pointer-events: none;
         z-index: 0;
-        opacity: 0.78;
+        opacity: 0.14;
         background-color: #e879f9;
-        -webkit-mask: url("assets/watermark-screening-command.svg") center / contain no-repeat;
-                mask: url("assets/watermark-screening-command.svg") center / contain no-repeat;
-        filter: drop-shadow(0 0 60px rgba(168, 85, 247, 0.55));
-        transform: translateY(-50%);
-        animation: wmRobotFloat 12s ease-in-out infinite alternate;
+        background-image: url("assets/robot-screening-command.png");
+        background-repeat: no-repeat;
+        background-position: right bottom;
+        background-size: contain;
+        -webkit-mask: url("assets/watermark-screening-command.svg") right bottom / contain no-repeat;
+                mask: url("assets/watermark-screening-command.svg") right bottom / contain no-repeat;
+        filter: drop-shadow(0 0 40px rgba(168, 85, 247, 0.35));
       }
       html.module-view-active .wm-robot { display: none; }
       @media (max-width: 960px) { .wm-robot { display: none; } }
-      @keyframes wmRobotFloat {
-        from { transform: translateY(calc(-50% - 10px)); }
-        to   { transform: translateY(calc(-50% + 10px)); }
-      }
-      @media (prefers-reduced-motion: reduce) { .wm-robot { animation: none !important; } }
     </style>
   </head>
   <body>
     <aside class="wm-robot" aria-hidden="true"></aside>
-    <aside class="wm" aria-hidden="true">
-      <svg viewBox="0 0 500 700" xmlns="http://www.w3.org/2000/svg">
-        <defs>
-          <linearGradient id="wmGradSc" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" stop-color="#c084fc" />
-            <stop offset="50%" stop-color="#a855f7" />
-            <stop offset="100%" stop-color="#e879f9" />
-          </linearGradient>
-          <radialGradient id="wmGlowSc" cx="45%" cy="38%" r="55%">
-            <stop offset="0%" stop-color="#f0abfc" stop-opacity="0.65" />
-            <stop offset="60%" stop-color="#a855f7" stop-opacity="0.2" />
-            <stop offset="100%" stop-color="transparent" />
-          </radialGradient>
-          <linearGradient id="wmSpineSc" x1="0%" y1="0%" x2="0%" y2="100%">
-            <stop offset="0%" stop-color="#f0abfc" stop-opacity="0.9" />
-            <stop offset="100%" stop-color="#6b21a8" stop-opacity="0.3" />
-          </linearGradient>
-        </defs>
-        <circle cx="245" cy="290" r="270" fill="url(#wmGlowSc)" />
-        <path d="M 220 70 Q 340 50 390 170 Q 420 250 395 340 Q 380 380 395 420 Q 420 470 400 520 Q 380 560 335 570 L 335 650 L 170 650 L 170 520 Q 140 510 125 480 Q 105 430 120 390 Q 135 355 150 330 Q 130 270 140 210 Q 160 120 220 70 Z"
-              fill="url(#wmGradSc)" opacity="0.62" />
-        <path d="M 285 160 Q 340 180 355 240 Q 365 300 340 340 Q 315 370 275 365 Q 245 355 240 310 Q 238 260 255 210 Q 270 175 285 160 Z"
-              fill="#fff" opacity="0.12" />
-        <ellipse cx="235" cy="270" rx="16" ry="7" fill="#f0abfc" opacity="0.9" />
-        <g stroke="#f0abfc" stroke-width="1.6" fill="none" opacity="0.55" stroke-linecap="round">
-          <path d="M 210 220 L 290 220" />
-          <path d="M 205 300 L 300 300" />
-          <path d="M 225 345 L 310 345" />
-          <circle cx="300" cy="220" r="3.5" fill="#f0abfc" opacity="0.95" />
-          <circle cx="310" cy="300" r="2.5" fill="#f0abfc" opacity="0.9" />
-        </g>
-        <g stroke="url(#wmSpineSc)" stroke-width="1.2" fill="none" opacity="0.7">
-          <path d="M 230 580 L 310 580" />
-          <path d="M 225 605 L 315 605" />
-          <path d="M 220 630 L 320 630" />
-        </g>
-      </svg>
-    </aside>
     <div class="shell">
       <header class="topbar">
         <div class="title-group">

--- a/workbench.html
+++ b/workbench.html
@@ -718,106 +718,36 @@
         *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; }
       }
 
-      /* === DECORATIVE PALETTE WATERMARK ===
-         AI-humanoid silhouette painted in the landing's palette. Fixed
-         bottom-right, low opacity, soft-light blend so it reads as a
-         watermark behind the content without distracting from it.
-         Hidden on mobile (viewport budget) and while a module is open
-         (module content owns the screen). */
-      .wm {
-        position: fixed;
-        right: -4vw;
-        bottom: -2vh;
-        width: min(460px, 36vw);
-        aspect-ratio: 5 / 7;
-        pointer-events: none;
-        z-index: 0;
-        opacity: 0.18;
-        mix-blend-mode: screen;
-        filter: drop-shadow(0 0 40px rgba(251, 146, 60, 0.25));
-        animation: wmFloat 14s ease-in-out infinite alternate;
-      }
-      .wm svg { width: 100%; height: 100%; display: block; }
-      html.module-view-active .wm { display: none; }
-      @media (max-width: 960px) { .wm { display: none; } }
-      @keyframes wmFloat {
-        from { transform: translateY(0) rotate(0deg); }
-        to   { transform: translateY(-14px) rotate(-0.5deg); }
-      }
-      @media (prefers-reduced-motion: reduce) {
-        .wm { animation: none !important; }
-      }
-
-      /* Cyber-head watermark — azure accent on the workbench palette.
-         Large, centred on the left gutter, clearly visible (no screen
-         blend-mode so it reads on dark navy). */
+      /* === ROBOT WATERMARK ===
+         Single professional robot-profile silhouette anchored to the
+         bottom-right corner. Low opacity, no animation, sits behind
+         content (z-index: 0). Drop assets/robot-workbench.png into the
+         assets folder to override the SVG — the layered background
+         will show the PNG on top of the SVG fallback. */
       .wm-robot {
         position: fixed;
-        left: 0;
-        top: 50%;
-        width: min(640px, 44vw);
-        aspect-ratio: 420 / 520;
+        right: -2vw;
+        bottom: 0;
+        width: min(520px, 34vw);
+        height: min(680px, 70vh);
         pointer-events: none;
         z-index: 0;
-        opacity: 0.78;
+        opacity: 0.14;
         background-color: #7fc1ff;
-        -webkit-mask: url("assets/watermark-workbench.svg") center / contain no-repeat;
-                mask: url("assets/watermark-workbench.svg") center / contain no-repeat;
-        filter: drop-shadow(0 0 60px rgba(47, 125, 255, 0.55));
-        transform: translateY(-50%);
-        animation: wmRobotFloat 12s ease-in-out infinite alternate;
+        background-image: url("assets/robot-workbench.png");
+        background-repeat: no-repeat;
+        background-position: right bottom;
+        background-size: contain;
+        -webkit-mask: url("assets/watermark-workbench.svg") right bottom / contain no-repeat;
+                mask: url("assets/watermark-workbench.svg") right bottom / contain no-repeat;
+        filter: drop-shadow(0 0 40px rgba(47, 125, 255, 0.35));
       }
       html.module-view-active .wm-robot { display: none; }
       @media (max-width: 960px) { .wm-robot { display: none; } }
-      @keyframes wmRobotFloat {
-        from { transform: translateY(calc(-50% - 10px)); }
-        to   { transform: translateY(calc(-50% + 10px)); }
-      }
-      @media (prefers-reduced-motion: reduce) {
-        .wm-robot { animation: none !important; }
-      }
     </style>
   </head>
   <body>
     <aside class="wm-robot" aria-hidden="true"></aside>
-    <aside class="wm" aria-hidden="true">
-      <svg viewBox="0 0 500 700" xmlns="http://www.w3.org/2000/svg">
-        <defs>
-          <linearGradient id="wmGradWb" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" stop-color="#fb923c" />
-            <stop offset="50%" stop-color="#facc15" />
-            <stop offset="100%" stop-color="#22c55e" />
-          </linearGradient>
-          <radialGradient id="wmGlowWb" cx="45%" cy="38%" r="55%">
-            <stop offset="0%" stop-color="#fde047" stop-opacity="0.65" />
-            <stop offset="60%" stop-color="#fb923c" stop-opacity="0.18" />
-            <stop offset="100%" stop-color="transparent" />
-          </radialGradient>
-          <linearGradient id="wmSpineWb" x1="0%" y1="0%" x2="0%" y2="100%">
-            <stop offset="0%" stop-color="#fdba74" stop-opacity="0.9" />
-            <stop offset="100%" stop-color="#22c55e" stop-opacity="0.3" />
-          </linearGradient>
-        </defs>
-        <circle cx="245" cy="290" r="270" fill="url(#wmGlowWb)" />
-        <path d="M 220 70 Q 340 50 390 170 Q 420 250 395 340 Q 380 380 395 420 Q 420 470 400 520 Q 380 560 335 570 L 335 650 L 170 650 L 170 520 Q 140 510 125 480 Q 105 430 120 390 Q 135 355 150 330 Q 130 270 140 210 Q 160 120 220 70 Z"
-              fill="url(#wmGradWb)" opacity="0.62" />
-        <path d="M 285 160 Q 340 180 355 240 Q 365 300 340 340 Q 315 370 275 365 Q 245 355 240 310 Q 238 260 255 210 Q 270 175 285 160 Z"
-              fill="#fff" opacity="0.12" />
-        <ellipse cx="235" cy="270" rx="16" ry="7" fill="#fde047" opacity="0.85" />
-        <g stroke="#fde047" stroke-width="1.6" fill="none" opacity="0.55" stroke-linecap="round">
-          <path d="M 210 220 L 290 220" />
-          <path d="M 205 300 L 300 300" />
-          <path d="M 225 345 L 310 345" />
-          <circle cx="300" cy="220" r="3.5" fill="#fde047" opacity="0.95" />
-          <circle cx="310" cy="300" r="2.5" fill="#fde047" opacity="0.9" />
-        </g>
-        <g stroke="url(#wmSpineWb)" stroke-width="1.2" fill="none" opacity="0.7">
-          <path d="M 230 580 L 310 580" />
-          <path d="M 225 605 L 315 605" />
-          <path d="M 220 630 L 320 630" />
-        </g>
-      </svg>
-    </aside>
     <main class="shell">
       <header class="topbar">
         <div class="brand">


### PR DESCRIPTION
## Summary

- Replaced the messy inline SVG watermarks (wireframe humanoid + gradient halo) that were overlapping the hero headline on /workbench, /compliance-ops, /logistics, /routines, /screening-command.
- Each page now shows a single, clean robot profile silhouette anchored to the bottom-right corner at opacity 0.14 — reads as a proper watermark, does not clash with the title, does not force horizontal scrolling at 100% zoom.
- 5 distinct silhouette styles, one per page:
  - `/workbench` — chrome cyborg with ear disc + visor
  - `/compliance-ops` — female cyborg with cable-hair flow
  - `/logistics` — astronaut helmet with visor band + pauldron
  - `/routines` — DJ/headphone profile with prominent ear cup
  - `/screening-command` — faceted crystal / low-poly profile
- PNG hook: each page's CSS has `background-image: url("assets/robot-<page>.png")`. If a photographic PNG is dropped into `assets/` with that name, it will be rendered (tinted + clipped to the silhouette shape) without any further code change.

## Test plan

- [ ] Visit `/workbench`, `/compliance-ops`, `/logistics`, `/routines`, `/screening-command` at 100% browser zoom — hero headline is fully readable, no horizontal scrollbar.
- [ ] Confirm the watermark sits behind content in the bottom-right and does not intercept clicks.
- [ ] Confirm watermark disappears when a module iframe opens (the `html.module-view-active .wm-robot { display: none }` rule) and on viewports narrower than 960px.
- [ ] Optional: drop `assets/robot-workbench.png` and reload /workbench to verify the PNG hook renders through the silhouette mask.
