### PR TITLE
Fix mlroOrchestrator advisor call missing stream flag (stream idle timeout)

### DIFF
--- a/src/services/mlroOrchestrator.ts
+++ b/src/services/mlroOrchestrator.ts
@@ -313,6 +313,22 @@ async function review(
       additionalSystemPrompt: COMPLIANCE_ADVISOR_SYSTEM_PROMPT,
       userMessage: prompt,
       maxTokens: 1024,
+      // Stream so `/api/ai-proxy` uses its streaming code path with
+      // `: keepalive\n\n` SSE comment injection. Opus advisor
+      // sub-inferences regularly run 20-40s end-to-end during which
+      // no bytes flow over the socket; the proxy's non-streaming
+      // ceiling is 22s (NONSTREAM_UPSTREAM_TIMEOUT_MS), so leaving
+      // this false fires the upstream timeout mid-Opus-call and
+      // surfaces as "Stream idle timeout - partial response
+      // received" on the MLRO's screen. Same bug shape as the one
+      // fixed for anthropicAdvisor in PR #359 (d176944) — the
+      // orchestrator's reviewer path was the missed caller.
+      //
+      // Regulatory basis:
+      //   FDL No.10/2025 Art.20-21 (CO duty — advisor must reach
+      //     the advisor, not silently fail to a 504 + empty review)
+      //   Cabinet Res 134/2025 Art.19 (internal review before decision)
+      stream: true,
     },
     options.advisorDeps
   );
@@ -373,3 +389,13 @@ const VERDICT_ORDER: Record<EngineVerdict, number> = {
 function maxVerdict(a: EngineVerdict, b: EngineVerdict): EngineVerdict {
   return VERDICT_ORDER[a] >= VERDICT_ORDER[b] ? a : b;
 }
+
+// ---------------------------------------------------------------------------
+// Test hooks — the review() function is the only path that makes an
+// advisor tool call, and a regression test must be able to pin the
+// stream flag directly without dragging runComplianceDecision into
+// the fixture. Exported under `__test__` so production callers aren't
+// tempted to reach past runOrchestration.
+// ---------------------------------------------------------------------------
+
+export const __test__ = { review };

--- a/tests/mlroOrchestrator.test.ts
+++ b/tests/mlroOrchestrator.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { plan, evaluate } from '@/services/mlroOrchestrator';
+import { describe, expect, it, vi } from 'vitest';
+import { plan, evaluate, __test__ } from '@/services/mlroOrchestrator';
 import type { ComplianceCaseInput, ComplianceDecision } from '@/services/complianceDecisionEngine';
 import type { StrFeatures } from '@/services/predictiveStr';
 
@@ -159,5 +159,116 @@ describe('evaluate()', () => {
     const evl = evaluate(decision, minimalCase());
     expect(evl.shouldConsultAdvisor).toBe(true);
     expect(evl.concerns.some((c) => c.includes('vaspWalletScoring'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// review() — advisor-tool call path.
+//
+// Regression coverage for the "Stream idle timeout - partial response
+// received" failure mode: the orchestrator's reviewer must route the
+// Opus advisor sub-inference through the SSE streaming code path of
+// `/api/ai-proxy`, otherwise the proxy's 22s non-streaming ceiling
+// fires mid-Opus-call (Opus advisor sub-inferences routinely run
+// 20-40s) and the MLRO sees a truncated-socket error instead of an
+// advisor rationale. Same bug shape as the one fixed for
+// anthropicAdvisor in PR #359 (d176944); this pins the matching
+// contract for the orchestrator reviewer.
+//
+// Regulatory basis: FDL No.10/2025 Art.20-21 (CO duty — advisor
+// escalation must actually reach the advisor), Cabinet Res 134/2025
+// Art.19 (internal review before decision).
+// ---------------------------------------------------------------------------
+
+function sseResponseBody(): ReadableStream<Uint8Array> {
+  // Minimum SSE transcript the advisor parser will accept: a proxy
+  // ready frame, message_start (with input token usage), one text
+  // block, message_delta (with output tokens), message_stop.
+  const enc = new TextEncoder();
+  const frames = [
+    `event: proxy_ready\ndata: ${JSON.stringify({ serverTime: new Date().toISOString() })}\n\n`,
+    `event: message_start\ndata: ${JSON.stringify({
+      type: 'message_start',
+      message: { usage: { input_tokens: 10, output_tokens: 0 } },
+    })}\n\n`,
+    `event: content_block_start\ndata: ${JSON.stringify({
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'text', text: '' },
+    })}\n\n`,
+    `event: content_block_delta\ndata: ${JSON.stringify({
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text: '1. Cite Art.20. 2. File STR. 3. Apply four-eyes.' },
+    })}\n\n`,
+    `event: content_block_stop\ndata: ${JSON.stringify({
+      type: 'content_block_stop',
+      index: 0,
+    })}\n\n`,
+    `event: message_delta\ndata: ${JSON.stringify({
+      type: 'message_delta',
+      usage: { input_tokens: 10, output_tokens: 20 },
+    })}\n\n`,
+    `event: message_stop\ndata: ${JSON.stringify({ type: 'message_stop' })}\n\n`,
+  ];
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const f of frames) controller.enqueue(enc.encode(f));
+      controller.close();
+    },
+  });
+}
+
+describe('review() — advisor streaming contract', () => {
+  it('posts stream:true at both the proxy envelope and the Anthropic payload when consulted', async () => {
+    let capturedBody: string | null = null;
+    const fakeFetch = vi.fn(async (_url: string, init: { body: string }) => {
+      capturedBody = init.body;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+        body: sseResponseBody(),
+      };
+    });
+
+    const decision = minimalDecision({ verdict: 'freeze' }); // triggers advisor
+    const evaluation = evaluate(decision, minimalCase());
+    expect(evaluation.shouldConsultAdvisor).toBe(true);
+
+    const report = await __test__.review(decision, evaluation, {
+      advisorDeps: { fetch: fakeFetch, authToken: 'test-token' },
+    });
+
+    expect(report.consulted).toBe(true);
+    expect(capturedBody).not.toBeNull();
+    const parsed = JSON.parse(capturedBody!);
+
+    // Proxy envelope — the /api/ai-proxy streaming code path only
+    // activates when it sees this flag at the top level.
+    expect(parsed.stream).toBe(true);
+    // Anthropic payload — /v1/messages only emits SSE when its own
+    // payload requests streaming. Both must match; one without the
+    // other leaves the proxy holding a silent socket.
+    expect(parsed.payload.stream).toBe(true);
+
+    // Sanity: it's the advisor tool, not some other call.
+    expect(parsed.provider).toBe('anthropic');
+    expect(parsed.path).toBe('/v1/messages');
+    expect(parsed.betas).toContain('advisor-tool-2026-03-01');
+    expect(
+      parsed.payload.tools.some(
+        (t: { type?: string; name?: string }) =>
+          t.type === 'advisor_20260301' && t.name === 'advisor'
+      )
+    ).toBe(true);
+  });
+
+  it('skips the advisor call without error when advisorDeps is omitted', async () => {
+    const decision = minimalDecision({ verdict: 'freeze' });
+    const evaluation = evaluate(decision, minimalCase());
+    const report = await __test__.review(decision, evaluation, {});
+    expect(report.consulted).toBe(false);
+    expect(report.skipReason).toMatch(/advisorDeps not provided/);
   });
 });


### PR DESCRIPTION
## Summary

`mlroOrchestrator.review()` built its `callAdvisorAssisted` payload without `stream: true`, so `/api/ai-proxy` took its non-streaming code path with the 22s upstream timeout (`NONSTREAM_UPSTREAM_TIMEOUT_MS`). Opus advisor sub-inferences routinely run 20-40s end-to-end, so every orchestration review that actually consulted the advisor tripped the upstream timeout mid-Opus-call and surfaced as **"Stream idle timeout - partial response received"** on the MLRO's screen.

Same bug shape as the one fixed for `anthropicAdvisor` in PR #359 (`d176944`) — the orchestrator's reviewer path was the missed caller.

## Fix

- `src/services/mlroOrchestrator.ts` — add `stream: true` to the `callAdvisorAssisted` payload in `review()`. That flips `/api/ai-proxy` into its SSE streaming path: upstream ceiling extends to `STREAM_UPSTREAM_TIMEOUT_MS` (300s), `: keepalive\n\n` SSE comments are injected every 10s during Opus thinking windows, and `proxy_ready` / `proxy_wall_clock` typed events flow to `accumulateAdvisorStream` for diagnosable error surfaces.
- Export `review()` via a `__test__` hook (same pattern as `anthropicAdvisor`) so the fix can be pinned without dragging `runComplianceDecision` into the test fixture.

## Test plan

- [x] `npx vitest run tests/mlroOrchestrator.test.ts tests/advisorStrategy.test.ts tests/anthropicAdvisor.test.ts` — 69 tests passing (11 + 46 + 12)
- [x] `npx tsc --noEmit` — clean
- [x] New regression test: advisor call posts `stream: true` at BOTH the proxy envelope AND the Anthropic payload level
- [x] New regression test: `review()` still skips cleanly (`consulted=false` with `skipReason`) when `advisorDeps` is omitted

## Regulatory basis

- **FDL No.10/2025 Art.20-21** — CO duty of care; advisor escalation must actually reach the advisor, not silently fail to an empty review after a 504.
- **Cabinet Res 134/2025 Art.19** — internal review before decision. The review pass is the one place the orchestrator can contradict the executor's verdict; it must not silently short-circuit to an empty report on timeout.
- **FATF Rec 18** — internal controls proportionate to risk.

https://claude.ai/code/session_01VXyVrFUKfEWA8ALNAHJRzS