### PR TITLE
Extend hero-robot-planet wallpaper to all five module pages

### DIFF
--- a/compliance-ops.html
+++ b/compliance-ops.html
@@ -26,7 +26,7 @@
       href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="module-enhancements.css?v=1" />
+    <link rel="stylesheet" href="module-enhancements.css?v=2" />
     <style>
       :root {
         /* Red + pink palette, top to bottom: ink → midnight → wine → rose → pink */

--- a/logistics.html
+++ b/logistics.html
@@ -26,7 +26,7 @@
       href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="module-enhancements.css?v=1" />
+    <link rel="stylesheet" href="module-enhancements.css?v=2" />
     <style>
       :root {
         /* Greens, top to bottom: ink → midnight → navy → steel → royal → azure → sky → ice */

--- a/module-enhancements.css
+++ b/module-enhancements.css
@@ -233,3 +233,77 @@ html.module-view-active .activity-pulse { display: none !important; }
   }
   .activity-pulse .activity-stream { transition: none; }
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+   Shared hero-robot-planet wallpaper — matches the landing page.
+   Painted on html::before so each page's own body::before (module-
+   palette glows) keeps working unchanged on top of it.
+
+   Trick: each page sets body { background: var(--midnight) } inline,
+   which would occlude an html-level pseudo-element. We move the solid
+   midnight fill up onto html (using the page's own --midnight token
+   so per-module tints are preserved) and force body transparent with
+   !important so html::before shines through.
+   ═══════════════════════════════════════════════════════════════════ */
+html {
+  background: var(--midnight, #020B18);
+}
+body {
+  background: transparent !important;
+}
+html::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  pointer-events: none;
+  background:
+    radial-gradient(
+      ellipse 55% 70% at 22% 48%,
+      rgba(244, 114, 182, 0.38) 0%,
+      rgba(244, 114, 182, 0.10) 45%,
+      transparent 72%
+    ),
+    radial-gradient(
+      ellipse 55% 70% at 78% 52%,
+      rgba(59, 130, 246, 0.45) 0%,
+      rgba(59, 130, 246, 0.12) 45%,
+      transparent 72%
+    ),
+    url('assets/hero-robot-planet.png?v=2') center center / cover no-repeat;
+  opacity: 0.5;
+  filter: saturate(1.18) contrast(1.04);
+  animation: me-wallpaper-drift 48s ease-in-out infinite alternate;
+  will-change: transform;
+}
+html::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background:
+    radial-gradient(
+      ellipse 90% 80% at 50% 50%,
+      transparent 0%,
+      rgba(2, 11, 24, 0.20) 55%,
+      rgba(2, 11, 24, 0.58) 100%
+    ),
+    linear-gradient(
+      180deg,
+      rgba(2, 11, 24, 0.25) 0%,
+      transparent 30%,
+      transparent 65%,
+      rgba(2, 11, 24, 0.40) 100%
+    );
+}
+@keyframes me-wallpaper-drift {
+  from { transform: scale(1.04) translate3d(-0.4%, -0.4%, 0); }
+  to   { transform: scale(1.08) translate3d(0.4%, 0.4%, 0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  html::before { animation: none !important; }
+}
+@media (max-width: 768px) {
+  html::before { opacity: 0.34; }
+}

--- a/routines.html
+++ b/routines.html
@@ -26,7 +26,7 @@
       href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="module-enhancements.css?v=1" />
+    <link rel="stylesheet" href="module-enhancements.css?v=2" />
     <style>
       :root {
         --ink: #030814;

--- a/screening-command.html
+++ b/screening-command.html
@@ -27,7 +27,7 @@
       href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="module-enhancements.css?v=1" />
+    <link rel="stylesheet" href="module-enhancements.css?v=2" />
     <style>
       :root {
         /* Purple / lilac / fuchsia palette — unchanged from the previous

--- a/workbench.html
+++ b/workbench.html
@@ -26,7 +26,7 @@
       href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="module-enhancements.css?v=1" />
+    <link rel="stylesheet" href="module-enhancements.css?v=2" />
     <style>
       :root {
         --ink: #030814;


### PR DESCRIPTION
## Summary

The landing page got the full-viewport hand-catching-Earth wallpaper with neon pink + blue bleeds in #376. This propagates the same watermark to **all five module pages** via the shared `module-enhancements.css`:

- `workbench.html`
- `compliance-ops.html`
- `logistics.html`
- `screening-command.html`
- `routines.html`

## How it works

Each module page inlines `body { background: var(--midnight); }` with its own palette-specific `--midnight` token (blue, red, green, purple, teal per module). That would normally occlude an html-level pseudo-element.

- Move the solid `--midnight` fill **up onto `html`** (still using each page's own token so the per-module tint is preserved).
- Force `body { background: transparent !important; }`.
- Paint the wallpaper on `html::before` (z-index: -2) and the vignette on `html::after` (z-index: -1) inside `module-enhancements.css`.
- Each page's own `body::before` palette glow and `body::after` grid pattern (both z-index: 0) continue to paint **on top** of the wallpaper, so each module stays on-brand (workbench amber, compliance-ops pink, logistics green, etc.) while the hand-catching-Earth imagery carries through underneath.

## Changes

- `module-enhancements.css` — appended ~74 lines: wallpaper + neon bleeds + vignette + `@keyframes me-wallpaper-drift` + reduced-motion + mobile opacity carve-outs.
- `workbench.html`, `compliance-ops.html`, `logistics.html`, `screening-command.html`, `routines.html` — cache buster `module-enhancements.css?v=1 → ?v=2` so browsers + CDN pick up the new rules.

## Still holds

- Inlined watermark overlays from `1e1b395` (z-index: 1-5, pointer-events: none) paint above the wallpaper — unchanged.
- `prefers-reduced-motion` disables the 48s drift.
- Mobile (<=768px) drops wallpaper opacity 0.50 → 0.34 for legibility.
- No regulatory, compliance, auth, rate-limit, or CSP logic touched.

## Test plan

- [ ] Hard-reload each of the five module URLs after deploy — wallpaper visible behind the hero + cards, with the per-module palette still tinting correctly:
  - [ ] https://hawkeye-sterling-v2.netlify.app/workbench
  - [ ] https://hawkeye-sterling-v2.netlify.app/compliance-ops
  - [ ] https://hawkeye-sterling-v2.netlify.app/logistics
  - [ ] https://hawkeye-sterling-v2.netlify.app/screening-command
  - [ ] https://hawkeye-sterling-v2.netlify.app/routines
- [ ] Card and hero copy remain AA-legible on every page.
- [ ] Reduced-motion: drift animation stops on all five.
- [ ] Mobile (<=768px): opacity drops, no horizontal scroll introduced.
- [ ] Landing page (index.html) unaffected — it has its own wallpaper pipeline.
