### PR TITLE
Add warm & metallic accents to logistics and screening-command

### DIFF
--- a/logistics.html
+++ b/logistics.html
@@ -51,7 +51,6 @@
         /* Warm accents — subtle yellow & orange highlights over the green base */
         --amber: #fbbf24;
         --amber-soft: #fde68a;
-        --marigold: #f97316;
         --sunset: #fb923c;
       }
 

--- a/logistics.html
+++ b/logistics.html
@@ -48,6 +48,11 @@
         --border-strong: rgba(134, 239, 172, 0.38);
         --glow: rgba(34, 197, 94, 0.55);
         --muted: #6ea88a;
+        /* Warm accents — subtle yellow & orange highlights over the green base */
+        --amber: #fbbf24;
+        --amber-soft: #fde68a;
+        --marigold: #f97316;
+        --sunset: #fb923c;
       }
 
       * {
@@ -81,7 +86,9 @@
         z-index: 0;
         background:
           radial-gradient(ellipse 80% 60% at 15% 0%, rgba(34, 197, 94, 0.22), transparent 60%),
-          radial-gradient(ellipse 60% 50% at 85% 10%, rgba(21, 128, 61, 0.18), transparent 55%),
+          radial-gradient(ellipse 55% 45% at 90% 8%, rgba(251, 191, 36, 0.16), transparent 60%),
+          radial-gradient(ellipse 60% 50% at 85% 40%, rgba(21, 128, 61, 0.18), transparent 55%),
+          radial-gradient(ellipse 50% 40% at 12% 92%, rgba(249, 115, 22, 0.14), transparent 60%),
           radial-gradient(ellipse 70% 40% at 50% 100%, rgba(23, 87, 56, 0.55), transparent 60%);
       }
 
@@ -134,6 +141,7 @@
         box-shadow:
           0 0 0 1px rgba(134, 239, 172, 0.4),
           0 8px 24px rgba(34, 197, 94, 0.35),
+          0 4px 18px rgba(251, 191, 36, 0.18),
           inset 0 1px 0 rgba(255, 255, 255, 0.18);
       }
 
@@ -143,7 +151,7 @@
         font-weight: 700;
         letter-spacing: -0.01em;
         text-transform: none;
-        background: linear-gradient(180deg, #ffffff 0%, var(--ice) 45%, var(--sky) 100%);
+        background: linear-gradient(180deg, #ffffff 0%, var(--ice) 40%, var(--sky) 75%, var(--amber-soft) 100%);
         -webkit-background-clip: text;
         background-clip: text;
         color: transparent;
@@ -268,8 +276,8 @@
         width: 7px;
         height: 7px;
         border-radius: 50%;
-        background: var(--azure-bright);
-        box-shadow: 0 0 12px var(--azure-bright);
+        background: var(--amber);
+        box-shadow: 0 0 12px var(--amber);
         animation: pulse 2.2s ease-in-out infinite;
       }
 
@@ -287,7 +295,7 @@
         color: var(--mist);
         margin: 0 0 1.25rem;
         padding-bottom: 0.12em;
-        background: linear-gradient(180deg, #ffffff 0%, var(--ice) 45%, var(--sky) 100%);
+        background: linear-gradient(180deg, #ffffff 0%, var(--ice) 40%, var(--sky) 72%, var(--amber-soft) 100%);
         -webkit-background-clip: text;
         background-clip: text;
         -webkit-text-fill-color: transparent;
@@ -300,9 +308,9 @@
       .hero-title em {
         font-style: italic;
         font-weight: 600;
-        color: var(--azure-bright);
+        color: var(--sunset);
         background: none;
-        -webkit-text-fill-color: var(--azure-bright);
+        -webkit-text-fill-color: var(--sunset);
       }
 
       .hero-lede {

--- a/screening-command.html
+++ b/screening-command.html
@@ -51,6 +51,11 @@
         --border-strong: rgba(232, 121, 249, 0.4);
         --glow: rgba(168, 85, 247, 0.55);
         --muted: rgba(240, 171, 252, 0.6);
+        /* Warm/cool accents — subtle pink and silver highlights over the purple base */
+        --pink: #f472b6;
+        --pink-soft: #fbcfe8;
+        --silver: #d4d4d8;
+        --silver-bright: #f4f4f5;
       }
 
       * { box-sizing: border-box; }
@@ -75,7 +80,9 @@
         z-index: 0;
         background:
           radial-gradient(ellipse 80% 60% at 15% 0%, rgba(168, 85, 247, 0.22), transparent 60%),
-          radial-gradient(ellipse 60% 50% at 85% 10%, rgba(139, 92, 246, 0.18), transparent 55%),
+          radial-gradient(ellipse 55% 45% at 88% 6%, rgba(244, 114, 182, 0.18), transparent 60%),
+          radial-gradient(ellipse 60% 50% at 85% 40%, rgba(139, 92, 246, 0.18), transparent 55%),
+          radial-gradient(ellipse 45% 35% at 10% 85%, rgba(212, 212, 216, 0.10), transparent 60%),
           radial-gradient(ellipse 70% 40% at 50% 100%, rgba(63, 40, 98, 0.55), transparent 60%);
       }
 
@@ -127,7 +134,8 @@
         box-shadow:
           0 0 0 1px rgba(232, 121, 249, 0.4),
           0 8px 24px rgba(168, 85, 247, 0.35),
-          inset 0 1px 0 rgba(255, 255, 255, 0.18);
+          0 4px 16px rgba(244, 114, 182, 0.22),
+          inset 0 1px 0 rgba(244, 244, 245, 0.28);
       }
       .page-h1 {
         font-family: 'Playfair Display', serif;
@@ -135,7 +143,7 @@
         font-weight: 700;
         letter-spacing: -0.01em;
         margin: 0;
-        background: linear-gradient(180deg, #ffffff 0%, var(--ice) 45%, var(--azure-bright) 100%);
+        background: linear-gradient(180deg, var(--silver-bright) 0%, var(--ice) 40%, var(--azure-bright) 72%, var(--pink-soft) 100%);
         -webkit-background-clip: text;
         background-clip: text;
         -webkit-text-fill-color: transparent;
@@ -245,8 +253,8 @@
       .hero-eyebrow::before {
         content: '';
         width: 7px; height: 7px; border-radius: 50%;
-        background: var(--azure);
-        box-shadow: 0 0 12px var(--azure);
+        background: var(--pink);
+        box-shadow: 0 0 12px var(--pink);
         animation: pulse 2.2s ease-in-out infinite;
       }
       @keyframes pulse {
@@ -263,7 +271,7 @@
         color: var(--mist);
         margin: 0 0 1.25rem;
         padding-bottom: 0.12em;
-        background: linear-gradient(180deg, #ffffff 0%, var(--ice) 45%, var(--azure-bright) 100%);
+        background: linear-gradient(180deg, var(--silver-bright) 0%, var(--ice) 40%, var(--azure-bright) 72%, var(--pink-soft) 100%);
         -webkit-background-clip: text;
         background-clip: text;
         -webkit-text-fill-color: transparent;
@@ -272,9 +280,9 @@
       @media (max-width: 720px) { .hero-title .nowrap { white-space: normal; } }
       .hero-title em {
         font-style: italic; font-weight: 600;
-        color: var(--azure-bright);
+        color: var(--pink);
         background: none;
-        -webkit-text-fill-color: var(--azure-bright);
+        -webkit-text-fill-color: var(--pink);
       }
       .hero-lede {
         color: var(--ice);

--- a/screening-command.html
+++ b/screening-command.html
@@ -54,7 +54,6 @@
         /* Warm/cool accents — subtle pink and silver highlights over the purple base */
         --pink: #f472b6;
         --pink-soft: #fbcfe8;
-        --silver: #d4d4d8;
         --silver-bright: #f4f4f5;
       }
 


### PR DESCRIPTION
## Summary

Two small UI-only color refreshes in response to user feedback that the
module pages leaned too heavily on their single-hue palettes.

### `logistics.html` — "add a little bit yellow and orange, is too green"
- New `--amber`, `--amber-soft`, `--marigold`, `--sunset` tokens on `:root`.
- Ambient `body::before` gains a soft amber glow (top-right) and a
  marigold glow (bottom-left) layered over the existing green radials.
- `header.topbar h1` and `.hero-title` gradients pick up an amber-soft
  stop at 100%.
- `.hero-title em` (italic emphasis) shifts from azure-bright to sunset.
- `.hero-eyebrow::before` pulse dot switches from azure-bright to amber.
- `.header-logo` gains a subtle amber halo on top of the existing green shadow.

The green palette stays dominant — this is a warm accent pass, not a
reskin.

### `screening-command.html` — "add a little bit pink and silver"
- New `--pink`, `--pink-soft`, `--silver`, `--silver-bright` tokens.
- Ambient `body::before` gains a pink glow (top-right) and a silver
  glow (bottom-left) over the existing purple radials.
- `.page-h1` and `.hero-title` gradients now start on silver-bright and
  end on pink-soft, with azure-bright in the middle.
- `.hero-title em` italic color shifts from azure-bright to pink.
- `.hero-eyebrow::before` pulse dot switches from azure to pink.
- `.header-logo` gains a pink halo + brighter silver inset highlight.

## Scope

Pure UI/CSS inside two standalone module HTML files. No changes to:
- Compliance logic (`src/domain/`, `src/services/`, `src/risk/`)
- Netlify functions (`netlify/functions/`)
- Constants, tests, or skills
- Rate limiting, auth, or CSP config

Per CLAUDE.md §8, pure UI changes are exempt from regulatory citation.

## Test plan

- [ ] Visit `/logistics` on the deployed preview — confirm the green base
      is preserved, with visible but subtle yellow/orange warmth in the
      ambient background, hero title tail, italic emphasis, and eyebrow dot.
- [ ] Visit `/screening-command` on the deployed preview — confirm the
      purple base is preserved, with visible pink + silver accents in the
      ambient background, title gradients, and italic emphasis.
- [ ] Check both pages at mobile breakpoint (`<720px`) — no layout regressions.
- [ ] Module-view active state (`?embed=…`) still hides the hero/summary
      correctly.