### PR TITLE
Widen landing-page shells to 1800px + URL-sanitiser XSS guard

### DIFF
--- a/compliance-ops.html
+++ b/compliance-ops.html
@@ -98,7 +98,7 @@
       .shell {
         position: relative;
         z-index: 1;
-        max-width: 1440px;
+        max-width: 1800px;
         margin: 0 auto;
         padding: 1.5rem 2.25rem 3rem;
         width: 100%;

--- a/index.html
+++ b/index.html
@@ -254,7 +254,7 @@
         body::before { opacity: 0.55; }
       }
       .app {
-        max-width: 1440px;
+        max-width: 1800px;
         margin: 0 auto;
         padding: 2rem 2.5rem;
       }

--- a/logistics.html
+++ b/logistics.html
@@ -108,7 +108,7 @@
       .shell {
         position: relative;
         z-index: 1;
-        max-width: 1440px;
+        max-width: 1800px;
         margin: 0 auto;
         padding: 1.75rem 2.25rem 4rem;
         width: 100%;

--- a/routines.html
+++ b/routines.html
@@ -91,7 +91,7 @@
       .shell {
         position: relative;
         z-index: 1;
-        max-width: 1440px;
+        max-width: 1800px;
         margin: 0 auto;
         padding: 2.5rem 2rem 4rem;
         width: 100%;
@@ -492,7 +492,7 @@
         position: relative; z-index: 1;
         padding: 2rem; border-top: 1px solid var(--border);
         display: flex; justify-content: space-between; align-items: center;
-        gap: 16px; max-width: 1440px; margin: 0 auto; width: 100%;
+        gap: 16px; max-width: 1800px; margin: 0 auto; width: 100%;
       }
       .footer-text { font-family: 'DM Mono', monospace; font-size: 10px; letter-spacing: 2px; text-transform: uppercase; color: var(--steel); }
 

--- a/screening-command-modules.js
+++ b/screening-command-modules.js
@@ -915,6 +915,19 @@
     return String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/</g, '&lt;')
       .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
   }
+  // Allow-list URL sanitiser for href attributes. esc() covers HTML
+  // escaping but does NOT filter javascript:, data:, vbscript: and other
+  // script-bearing protocols. Only permit http(s), mailto, and relative
+  // URLs; anything else returns '#' so a malicious register-entry URL
+  // or tampered backend hit cannot execute on click.
+  function safeUrl(u) {
+    var s = String(u == null ? '' : u).trim();
+    if (!s) return '#';
+    if (/^\/\//.test(s)) return s;
+    if (/^[\/#?]/.test(s)) return s;
+    if (/^https?:\/\//i.test(s) || /^mailto:/i.test(s)) return s;
+    return '#';
+  }
   function fmtDate(iso) {
     if (!iso) return '—';
     try {
@@ -1169,7 +1182,7 @@
                     var meta = [h.source, h.publishedAt ? fmtDate(h.publishedAt) : ''].filter(Boolean).map(esc).join(' · ');
                     return '<li style="margin-bottom:2px">' +
                       (h.url
-                        ? '<a href="' + esc(h.url) + '" target="_blank" rel="noopener noreferrer">' + esc(title) + '</a>'
+                        ? '<a href="' + esc(safeUrl(h.url)) + '" target="_blank" rel="noopener noreferrer">' + esc(title) + '</a>'
                         : esc(title)) +
                       (meta ? ' — <span style="opacity:.75">' + meta + '</span>' : '') +
                     '</li>';
@@ -1182,7 +1195,7 @@
 
             var knownSourceLine = r.known_adverse_source && r.known_adverse_source.url
               ? '<div class="mv-list-meta" data-tone="warn">' +
-                  'Public source: <a href="' + esc(r.known_adverse_source.url) + '" target="_blank" rel="noopener noreferrer">' +
+                  'Public source: <a href="' + esc(safeUrl(r.known_adverse_source.url)) + '" target="_blank" rel="noopener noreferrer">' +
                     esc(r.known_adverse_source.source) +
                   '</a>' +
                   (r.known_adverse_source.summary

--- a/screening-command.html
+++ b/screening-command.html
@@ -895,7 +895,7 @@
     </footer>
     <script src="brain-boot.js?v=3"></script>
     <script src="intelligence-drawer.js?v=1"></script>
-    <script src="screening-command-modules.js?v=6"></script>
+    <script src="screening-command-modules.js?v=7"></script>
     <script src="landing-module-viewer.js?v=15"></script>
     <script src="module-enhancements.js?v=1"></script>
   </body>

--- a/workbench.html
+++ b/workbench.html
@@ -107,7 +107,7 @@
       .shell {
         position: relative;
         z-index: 1;
-        max-width: 1440px;
+        max-width: 1800px;
         margin: 0 auto;
         padding: 2.5rem 2rem 4rem;
         width: 100%;
@@ -670,7 +670,7 @@
         position: relative; z-index: 1;
         padding: 2rem; border-top: 1px solid var(--border);
         display: flex; justify-content: space-between; align-items: center;
-        gap: 16px; max-width: 1440px; margin: 0 auto; width: 100%;
+        gap: 16px; max-width: 1800px; margin: 0 auto; width: 100%;
       }
       .footer-text { font-family: 'DM Mono', monospace; font-size: 10px; letter-spacing: 2px; text-transform: uppercase; color: var(--steel); }
 


### PR DESCRIPTION
## Summary

Two independent but related improvements that landed together in the zero-bug sweep.

### 1. Layout — expand landing shells to match Screening Command

Five landing pages (`index.html`, `logistics.html`, `compliance-ops.html`, `workbench.html`, `routines.html`) were pinned at `max-width: 1440px` while Screening Command had already been widened to `1800px`. On 1920+ px viewports this left substantial dead space on the left + right margins — same "use the full space" feedback that triggered the Screening Command widening.

All five shells now run `max-width: 1800px` (+ the matching footer containers in workbench.html and routines.html that duplicated the 1440 constraint). No inner-content layout change — hero + card grids are already responsive via `auto-fit`/`auto-fill`.

### 2. Security — URL-sanitiser XSS guard on the screening card

Zero-bug sweep found that `href` attributes interpolated user-controllable URLs via `esc()` only. `esc()` HTML-escapes but does NOT filter `javascript:` / `data:` / `vbscript:` protocols. A malicious register-entry URL (or tampered backend adverse-media hit URL) could therefore inject a click-to-execute XSS vector despite HTML-escaping.

Added `safeUrl()` allow-listing `http(s)`, `mailto`, and relative / protocol-relative URLs; everything else returns `#`. Applied at both href sites:
- `adverseItemsLine` hit-title anchor
- `knownSourceLine` public-source anchor

Cache-bust bump `?v=6 → ?v=7`.

### Verification

- `node --check screening-command-modules.js` — clean
- **292 functional checks** green (matcher precision/recall, compliance-report block, backend row shape, data-shape invariants, edge cases)
- **XSS harness** — all user-controllable fields properly escaped; `javascript:` protocol rejected from every href

## Regulatory basis

- **FDL No.(10)/2025 Art.24** — audit trail integrity (click-executing XSS on the MLRO workbench could compromise the session and forge audit entries)
- **Art.29** — no tipping off (hijacked MLRO click could exfiltrate subject data)

## Test plan

- [x] Verify all 5 landing pages widen to 1800px
- [x] Verify `screening-command-modules.js` still passes 292 checks
- [x] Verify XSS harness: `javascript:alert()` in a hit URL no longer survives to the rendered `href`
- [ ] Manual UI: open each landing page on a 1920+ px viewport, confirm content now uses the full width (red-margin feedback gone)
- [ ] Manual UI: hard-reload `screening-command.html` (v=7), confirm screening + compliance report still render identically for ozcan halac

https://claude.ai/code/session_016KJo7YENG7AQxq3eqT6nMt