### PR TITLE
Add 30-day run-history timeline per routine

### DIFF
--- a/netlify/functions/routine-history.mts
+++ b/netlify/functions/routine-history.mts
@@ -1,0 +1,204 @@
+/**
+ * Routine History — per-routine, per-day run-count timeline.
+ *
+ * GET /api/routine-history?id=<routineId>&days=<N>
+ *
+ * Lists the audit-blob prefixes `YYYY-MM-DD/` for one registered
+ * routine over the last N days (default 30, max 90) and returns a
+ * per-day run count. Powers the sparkline/heatmap surfaced in the
+ * routines.html drawer so MLROs can see SLA misses and flappy
+ * routines at a glance without scraping the audit store by hand.
+ *
+ * Response shape:
+ *   {
+ *     fetchedAtIso: string,
+ *     id: string,
+ *     storeName: string,
+ *     freshnessDays: number,
+ *     expectedPerDay: number | null,
+ *     days: Array<{ dateIso: 'YYYY-MM-DD', count: number }>,
+ *     totalRuns: number,
+ *     activeDays: number,
+ *     lastRunDateIso: string | null,
+ *     firstSeenDateIso: string | null
+ *   }
+ *
+ * Day grid ordering: oldest first, today last. Clients render
+ * left-to-right.
+ *
+ * Auth & rate-limit:
+ *   Authenticated via the shared `authenticate` middleware.
+ *   Rate-limited to 60 req / 15 min per IP.
+ *   Enumeration protection: `id` must match the server-side
+ *   allow-list; unknown ids get a generic 404 so attackers cannot
+ *   probe arbitrary blob stores.
+ *
+ * Regulatory basis:
+ *   FDL No.10/2025 Art.24       (10-year audit retention; a 30-day
+ *                                timeline is the MLRO-facing
+ *                                manifestation that supports MoE
+ *                                inspection evidence)
+ *   Cabinet Res 134/2025 Art.19 (internal reporting)
+ *   NIST AI RMF MEASURE-4       (continuous validation)
+ */
+
+import type { Config, Context } from '@netlify/functions';
+import { getStore } from '@netlify/blobs';
+import { checkRateLimit } from './middleware/rate-limit.mts';
+import { authenticate } from './middleware/auth.mts';
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin':
+    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://hawkeye-sterling-v2.netlify.app',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+  'Access-Control-Max-Age': '600',
+  Vary: 'Origin',
+} as const;
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return Response.json(body, {
+    ...init,
+    headers: { ...CORS_HEADERS, ...(init.headers ?? {}) },
+  });
+}
+
+interface RoutineHistoryEntry {
+  id: string;
+  storeName: string;
+  /** How many days back a single run is still considered fresh. */
+  freshnessDays: number;
+  /**
+   * Cron-derived expected runs per calendar day. `null` for
+   * non-uniform schedules (weekdays-only, weekly) where SLA
+   * highlighting is out of scope here — the client still gets the
+   * raw counts and can decide what to draw.
+   */
+  expectedPerDay: number | null;
+}
+
+/**
+ * Mirror of the registry in `routines-status.mts`, extended with the
+ * cron-derived expected runs per day. Keep in sync with that file and
+ * with the client-side ROUTINES array in `routines.html`.
+ */
+const REGISTRY: RoutineHistoryEntry[] = [
+  { id: 'sanctions-ingest', storeName: 'sanctions-ingest-audit', freshnessDays: 1, expectedPerDay: 96 },
+  { id: 'sanctions-delta-screen', storeName: 'sanctions-delta-screen-audit', freshnessDays: 1, expectedPerDay: 6 },
+  { id: 'sanctions-watch', storeName: 'sanctions-watch-audit', freshnessDays: 1, expectedPerDay: 1 },
+  { id: 'asana-reconcile', storeName: 'asana-reconcile-audit', freshnessDays: 1, expectedPerDay: 288 },
+  { id: 'asana-retry-queue', storeName: 'asana-retry-audit', freshnessDays: 1, expectedPerDay: 1440 },
+  { id: 'asana-super-brain-autopilot', storeName: 'autopilot-audit', freshnessDays: 1, expectedPerDay: 96 },
+  { id: 'asana-sync', storeName: 'asana-sync-audit', freshnessDays: 1, expectedPerDay: 288 },
+  { id: 'brain-clamp', storeName: 'brain-clamp-audit', freshnessDays: 1, expectedPerDay: 24 },
+  { id: 'chain-anchor', storeName: 'chain-anchor-audit', freshnessDays: 1, expectedPerDay: 24 },
+  { id: 'ai-governance-self-audit', storeName: 'ai-governance-audit', freshnessDays: 1, expectedPerDay: 1 },
+  { id: 'cbuae-fx', storeName: 'cbuae-fx-audit', freshnessDays: 1, expectedPerDay: 1 },
+  { id: 'expiry-scan', storeName: 'expiry-scan-audit', freshnessDays: 1, expectedPerDay: 1 },
+  { id: 'red-team', storeName: 'red-team-audit', freshnessDays: 1, expectedPerDay: 1 },
+  { id: 'regulatory-drift', storeName: 'regulatory-drift-audit', freshnessDays: 1, expectedPerDay: 1 },
+  { id: 'regulatory-horizon', storeName: 'regulatory-horizon-audit', freshnessDays: 1, expectedPerDay: 1 },
+  { id: 'tm-scan', storeName: 'tm-scan-audit', freshnessDays: 1, expectedPerDay: 1 },
+  { id: 'morning-briefing', storeName: 'briefing-audit', freshnessDays: 1, expectedPerDay: null },
+  { id: 'asana-weekly-customer-status', storeName: 'weekly-cust-audit', freshnessDays: 7, expectedPerDay: null },
+  { id: 'asana-weekly-digest', storeName: 'weekly-digest-audit', freshnessDays: 7, expectedPerDay: null },
+  { id: 'cdd-weekly-status', storeName: 'cdd-status-audit', freshnessDays: 7, expectedPerDay: null },
+];
+
+const MAX_DAYS = 90;
+const DEFAULT_DAYS = 30;
+
+function dayPrefix(offsetDays: number): string {
+  const d = new Date(Date.now() - offsetDays * 24 * 60 * 60 * 1000);
+  return d.toISOString().slice(0, 10);
+}
+
+function parseDaysParam(raw: string | null): number {
+  if (!raw) return DEFAULT_DAYS;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_DAYS;
+  return Math.min(n, MAX_DAYS);
+}
+
+export default async (req: Request, context: Context): Promise<Response> => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+  }
+  if (req.method !== 'GET') {
+    return jsonResponse({ error: 'Method not allowed' }, { status: 405 });
+  }
+
+  const rl = await checkRateLimit(req, {
+    max: 60,
+    clientIp: context.ip,
+    namespace: 'routine-history',
+  });
+  if (rl) return rl;
+
+  const auth = authenticate(req);
+  if (!auth.ok) return auth.response!;
+
+  const url = new URL(req.url);
+  const id = (url.searchParams.get('id') ?? '').trim();
+  if (!/^[a-z0-9-]{1,64}$/.test(id)) {
+    return jsonResponse({ error: 'Invalid routine id' }, { status: 400 });
+  }
+
+  const entry = REGISTRY.find((r) => r.id === id);
+  if (!entry) {
+    return jsonResponse({ error: 'Unknown routine' }, { status: 404 });
+  }
+
+  const days = parseDaysParam(url.searchParams.get('days'));
+  const store = getStore(entry.storeName);
+
+  // Build an empty day grid from (days-1) days ago up to today, then
+  // fill counts in parallel. A single failing prefix cannot stall the
+  // others — each list call is wrapped in its own try/catch.
+  const grid: Array<{ dateIso: string; count: number }> = [];
+  for (let i = days - 1; i >= 0; i--) {
+    grid.push({ dateIso: dayPrefix(i), count: 0 });
+  }
+
+  await Promise.all(
+    grid.map(async (slot) => {
+      try {
+        const listing = await store.list({ prefix: slot.dateIso + '/' });
+        const blobs = (listing?.blobs ?? []) as Array<{ key: string }>;
+        slot.count = blobs.length;
+      } catch {
+        slot.count = 0;
+      }
+    })
+  );
+
+  let totalRuns = 0;
+  let activeDays = 0;
+  let lastRunDateIso: string | null = null;
+  let firstSeenDateIso: string | null = null;
+  for (const slot of grid) {
+    if (slot.count > 0) {
+      totalRuns += slot.count;
+      activeDays += 1;
+      if (!firstSeenDateIso) firstSeenDateIso = slot.dateIso;
+      lastRunDateIso = slot.dateIso;
+    }
+  }
+
+  return jsonResponse({
+    fetchedAtIso: new Date().toISOString(),
+    id: entry.id,
+    storeName: entry.storeName,
+    freshnessDays: entry.freshnessDays,
+    expectedPerDay: entry.expectedPerDay,
+    days: grid,
+    totalRuns,
+    activeDays,
+    lastRunDateIso,
+    firstSeenDateIso,
+  });
+};
+
+export const config: Config = {
+  path: '/api/routine-history',
+};

--- a/routines.html
+++ b/routines.html
@@ -333,6 +333,59 @@
         color: var(--mist); word-break: break-word;
       }
       .drawer-cell .v.reg { color: var(--azure-bright); }
+      /* 30-day run-history heatmap — one cell per day, oldest on the
+         left, today on the right. Colour bands surface SLA misses
+         (zero-count days with an expected-per-day > 0 are flagged
+         in accent-magenta to match the drawer sign-in block). */
+      .drawer-timeline {
+        margin-bottom: 18px; padding: 14px 16px; border-radius: 10px;
+        background: rgba(10, 22, 40, 0.6);
+        border: 1px solid var(--border);
+      }
+      .drawer-timeline[hidden] { display: none; }
+      .drawer-timeline-head {
+        display: flex; justify-content: space-between; align-items: baseline;
+        margin-bottom: 10px; gap: 10px; flex-wrap: wrap;
+      }
+      .drawer-timeline-head .k {
+        font-family: 'DM Mono', monospace; font-size: 9.5px;
+        letter-spacing: 1.8px; text-transform: uppercase; color: var(--steel);
+      }
+      .drawer-timeline-head .v {
+        font-family: 'DM Mono', monospace; font-size: 10.5px;
+        color: var(--mist); letter-spacing: 1px;
+      }
+      .timeline-row {
+        display: grid;
+        grid-template-columns: repeat(30, 1fr);
+        gap: 2px; height: 28px;
+      }
+      .timeline-cell {
+        border-radius: 2px;
+        background: rgba(47, 125, 255, 0.07);
+        border: 1px solid transparent;
+        transition: transform 0.12s ease;
+      }
+      .timeline-cell:hover { transform: scaleY(1.18); }
+      .timeline-cell[data-state="low"]  { background: rgba(47, 125, 255, 0.32); }
+      .timeline-cell[data-state="ok"]   { background: rgba(47, 125, 255, 0.65); }
+      .timeline-cell[data-state="high"] { background: rgba(127, 193, 255, 0.9); }
+      .timeline-cell[data-state="miss"] {
+        background: rgba(236, 72, 153, 0.08);
+        border-color: rgba(236, 72, 153, 0.55);
+      }
+      .timeline-foot {
+        display: flex; justify-content: space-between; align-items: center;
+        margin-top: 10px; gap: 10px; flex-wrap: wrap;
+        font-family: 'DM Mono', monospace; font-size: 9.5px;
+        letter-spacing: 1.2px; color: var(--steel);
+      }
+      .timeline-legend { display: flex; gap: 12px; align-items: center; }
+      .timeline-legend .sw {
+        display: inline-block; width: 10px; height: 10px;
+        border-radius: 2px; margin-right: 4px; vertical-align: middle;
+        border: 1px solid transparent;
+      }
       .drawer-actions {
         display: flex; gap: 10px; flex-wrap: wrap; margin-top: 6px;
       }
@@ -658,6 +711,23 @@
             <div class="v" id="drawerLastSeen">—</div>
           </div>
         </div>
+        <section class="drawer-timeline" id="drawerTimeline" hidden>
+          <div class="drawer-timeline-head">
+            <span class="k">30-day run history</span>
+            <span class="v" id="drawerTimelineSummary">—</span>
+          </div>
+          <div class="timeline-row" id="drawerTimelineRow" role="img" aria-label="30-day run history heatmap"></div>
+          <div class="timeline-foot">
+            <span id="drawerTimelineStart">—</span>
+            <div class="timeline-legend" aria-hidden="true">
+              <span><span class="sw" style="background: rgba(47, 125, 255, 0.32)"></span>Low</span>
+              <span><span class="sw" style="background: rgba(47, 125, 255, 0.65)"></span>OK</span>
+              <span><span class="sw" style="background: rgba(127, 193, 255, 0.9)"></span>High</span>
+              <span><span class="sw" style="background: rgba(236, 72, 153, 0.08); border-color: rgba(236, 72, 153, 0.55)"></span>Miss</span>
+            </div>
+            <span id="drawerTimelineEnd">—</span>
+          </div>
+        </section>
         <div class="drawer-auth" id="drawerAuth" hidden>
           <div class="drawer-auth-head">
             MLRO Sign-in <span class="tag">Required</span>
@@ -871,6 +941,123 @@
         } catch (_e) { /* ignore */ }
         refreshAuthBlock();
         drawer.classList.add('open');
+        // Kick off the 30-day history fetch. Requires auth — if there
+        // is no token yet, the section stays hidden until sign-in.
+        loadRoutineTimeline(r.id);
+      }
+
+      // ── 30-day run-history timeline ────────────────────────────────
+      // Surfaces SLA misses and flappy routines at a glance. Powered by
+      // /api/routine-history, which walks audit-blob YYYY-MM-DD/ prefixes
+      // for the requested routine. Supports MoE inspection evidence
+      // under FDL No.10/2025 Art.24.
+      async function loadRoutineTimeline(routineId) {
+        const section = document.getElementById('drawerTimeline');
+        if (!section) return;
+        const token = getAuthToken();
+        if (!token) { section.hidden = true; return; }
+        // Paint a loading state immediately so the drawer does not
+        // shift when the fetch resolves.
+        renderTimelineLoading();
+        try {
+          const res = await fetch(
+            '/api/routine-history?id=' + encodeURIComponent(routineId) + '&days=30',
+            { method: 'GET', headers: { 'Authorization': 'Bearer ' + token } }
+          );
+          if (!DRAWER_ROUTINE || DRAWER_ROUTINE.id !== routineId) return; // drawer closed / switched
+          if (!res.ok) { renderTimelineMessage('History unavailable (HTTP ' + res.status + ')'); return; }
+          const data = await res.json();
+          renderTimeline(data);
+        } catch (_err) {
+          if (!DRAWER_ROUTINE || DRAWER_ROUTINE.id !== routineId) return;
+          renderTimelineMessage('Network error loading history');
+        }
+      }
+
+      function renderTimelineLoading() {
+        const section = document.getElementById('drawerTimeline');
+        const row = document.getElementById('drawerTimelineRow');
+        const summary = document.getElementById('drawerTimelineSummary');
+        const startEl = document.getElementById('drawerTimelineStart');
+        const endEl = document.getElementById('drawerTimelineEnd');
+        if (!section || !row) return;
+        row.innerHTML = Array.from({ length: 30 })
+          .map(() => '<div class="timeline-cell" aria-hidden="true"></div>')
+          .join('');
+        if (summary) summary.textContent = 'Loading…';
+        if (startEl) startEl.textContent = '';
+        if (endEl) endEl.textContent = '';
+        section.hidden = false;
+      }
+
+      function renderTimelineMessage(msg) {
+        const section = document.getElementById('drawerTimeline');
+        const row = document.getElementById('drawerTimelineRow');
+        const summary = document.getElementById('drawerTimelineSummary');
+        const startEl = document.getElementById('drawerTimelineStart');
+        const endEl = document.getElementById('drawerTimelineEnd');
+        if (!section || !row) return;
+        row.innerHTML = '';
+        if (summary) summary.textContent = msg;
+        if (startEl) startEl.textContent = '';
+        if (endEl) endEl.textContent = '';
+        section.hidden = false;
+      }
+
+      function renderTimeline(data) {
+        const section = document.getElementById('drawerTimeline');
+        const row = document.getElementById('drawerTimelineRow');
+        const summary = document.getElementById('drawerTimelineSummary');
+        const startEl = document.getElementById('drawerTimelineStart');
+        const endEl = document.getElementById('drawerTimelineEnd');
+        if (!section || !row) return;
+        if (!data || !Array.isArray(data.days) || data.days.length === 0) {
+          renderTimelineMessage('No history available');
+          return;
+        }
+        const expected = typeof data.expectedPerDay === 'number' && data.expectedPerDay > 0
+          ? data.expectedPerDay : null;
+        const cells = data.days.map(slot => {
+          const count = typeof slot.count === 'number' ? slot.count : 0;
+          let state;
+          if (count === 0) {
+            state = expected ? 'miss' : 'empty';
+          } else if (expected) {
+            const ratio = count / expected;
+            if (ratio < 0.5) state = 'low';
+            else if (ratio > 1.5) state = 'high';
+            else state = 'ok';
+          } else {
+            state = 'ok';
+          }
+          const label = slot.dateIso + ' · ' + count + ' run' + (count === 1 ? '' : 's');
+          const attrs = state === 'empty' ? '' : ' data-state="' + state + '"';
+          return '<div class="timeline-cell"' + attrs
+            + ' data-date="' + slot.dateIso + '"'
+            + ' data-count="' + count + '"'
+            + ' title="' + label + '"'
+            + ' aria-label="' + label + '"></div>';
+        }).join('');
+        row.innerHTML = cells;
+        startEl.textContent = data.days[0].dateIso;
+        endEl.textContent = data.days[data.days.length - 1].dateIso;
+
+        const totalRuns = typeof data.totalRuns === 'number' ? data.totalRuns : 0;
+        const activeDays = typeof data.activeDays === 'number' ? data.activeDays : 0;
+        const parts = [
+          totalRuns + ' run' + (totalRuns === 1 ? '' : 's'),
+          activeDays + '/' + data.days.length + ' days'
+        ];
+        if (expected) {
+          const expectedTotal = expected * data.days.length;
+          const pct = expectedTotal > 0
+            ? Math.round((totalRuns / expectedTotal) * 100) : 0;
+          const misses = data.days.filter(d => d.count === 0).length;
+          parts.push(pct + '% of SLA');
+          if (misses > 0) parts.push(misses + ' miss' + (misses === 1 ? '' : 'es'));
+        }
+        summary.textContent = parts.join(' · ');
+        section.hidden = false;
       }
 
       // Inline MLRO sign-in. Same contract as screening-command.js →
@@ -918,6 +1105,7 @@
           if (drawerAuthMsg) drawerAuthMsg.textContent = 'Signed in.';
           refreshAuthBlock();
           fetchLiveStatus();
+          if (DRAWER_ROUTINE) loadRoutineTimeline(DRAWER_ROUTINE.id);
         } catch (err) {
           if (drawerAuthMsg) drawerAuthMsg.textContent = 'Network error signing in.';
         } finally {
@@ -972,6 +1160,10 @@
           if (res.ok) {
             drawerRunMsg.textContent = 'Triggered. Refreshing status…';
             setTimeout(fetchLiveStatus, 1500);
+            if (DRAWER_ROUTINE) {
+              const id = DRAWER_ROUTINE.id;
+              setTimeout(() => loadRoutineTimeline(id), 1500);
+            }
           } else if (res.status === 404) {
             drawerRunMsg.textContent = 'Routine endpoint not deployed (' + DRAWER_ROUTINE.id + '-cron).';
           } else if (res.status === 401 || res.status === 403) {


### PR DESCRIPTION
## Summary

Surface a 30-day run-count heatmap in the routines drawer so MLROs can spot SLA misses and flappy routines at a glance. Supports MoE inspection evidence under **FDL No.10/2025 Art.24** (10-year audit retention), **Cabinet Res 134/2025 Art.19** (internal reporting), and **NIST AI RMF MEASURE-4** (continuous validation).

## What changed

**New endpoint** `GET /api/routine-history?id=<id>&days=<N>` (`netlify/functions/routine-history.mts`)
- Walks the audit-blob `YYYY-MM-DD/` prefixes for one registered routine and returns a per-day run count (default 30, max 90).
- Same auth, rate-limit (60 / 15 min), and CORS shape as `routines-status`.
- List calls run in parallel, each wrapped in try/catch so a single failing prefix can't stall the rest.
- `id` validated against a server-side allow-list with a generic 404 for unknown ids — cannot be used to probe arbitrary blob stores.
- Response includes `expectedPerDay` (cron-derived) so the client can compute SLA miss highlighting.

**Drawer heatmap** (`routines.html`)
- 30-cell row (oldest left → today right) inserted between the meta grid and the MLRO sign-in block.
- Four colour bands against cron-expected daily rate:
  - `low` (< 0.5× expected)
  - `ok` (0.5×–1.5×)
  - `high` (> 1.5×)
  - `miss` — zero count on a day where `expectedPerDay > 0`, flagged in the existing accent-magenta
- Cell tooltip: `YYYY-MM-DD · N runs`
- Summary line: total runs, active days, % of SLA, miss count
- Reloads after drawer sign-in and after a successful manual "Run now"
- Weekly/weekdays-only routines have `expectedPerDay: null` — they get a neutral "ok / empty" view rather than false-miss highlighting

## Test plan

- [ ] Open `/routines`, sign in, click any continuous routine → 30-cell heatmap appears with counts
- [ ] Click a weekly routine → cells render without false-miss highlighting
- [ ] Any day with zero runs on a continuous/daily routine shows the magenta "miss" cell
- [ ] Hover a cell → tooltip shows `YYYY-MM-DD · N runs`
- [ ] Click "Run now" → after ~1.5s the timeline refreshes and today's cell increments
- [ ] Invalid id: `GET /api/routine-history?id=not-real` → 404
- [ ] Malformed id: `GET /api/routine-history?id=../..` → 400
- [ ] Unauthenticated: `GET /api/routine-history?id=sanctions-ingest` (no token) → 401
- [ ] Rate-limit: 61st request within 15 min → 429

## Known pre-existing condition (out of scope)

The big inline `<script>` block in `routines.html`, `workbench.html`, `compliance-ops.html`, and `screening-command.html` is **not** in the `script-src` hash allow-list in `netlify.toml` — neither before nor after this change. I confirmed by hashing the `HEAD` version against the six hashes in the CSP. This PR adds code to that block but does not create the condition. A follow-up should either hash these blocks or move them to external `.js` files allowed by `'self'`.

## Follow-ups from the original ticket (separate PRs)

- Dedupe routine registry (`routines.html` + `routines-status.mts` + now `routine-history.mts`) → single JSON source
- Dependency pipeline view via vendored xyflow
- Stale-routine auto-alert via `brain-clamp` → Asana
- Drill-in to the audit entry itself (render summary + reasoningChain)

https://claude.ai/code/session_01STsSX1yDhNcVkY8SNKBfwu