### PR TITLE
Fix /api/hawkeye-login 404 — add explicit netlify.toml redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -50,6 +50,19 @@
   status = 200
   force = true
 
+# MLRO sign-in JWT endpoint. The function itself declares
+# `config.path = "/api/hawkeye-login"` in auth-login.mts, but on some
+# Netlify deploys the config.path registration does not surface the
+# route (observed 404 from prod on 2026-04-20). This explicit redirect
+# is the belt-and-braces that guarantees /api/hawkeye-login reaches
+# the handler regardless of the config.path wiring.
+# Regulatory basis: FDL No.(10)/2025 Art.20-21, Art.24.
+[[redirects]]
+  from = "/api/hawkeye-login"
+  to = "/.netlify/functions/auth-login"
+  status = 200
+  force = true
+
 # Read-only project-GID lookup per MLRO surface, used by pages to render
 # "View in Asana" links without hardcoding GIDs.
 [[redirects]]


### PR DESCRIPTION
## Root cause

`GET https://hawkeye-sterling-v2.netlify.app/api/hawkeye-login` returns a Netlify 404 "Page not found" in production (MLRO-reported, screenshot confirmed). The function `netlify/functions/auth-login.mts` declares `config.path = "/api/hawkeye-login"` but on this deploy that registration is not surfacing the route → the MLRO sign-in form cannot post credentials → every protected surface bounces back to `/login.html` indefinitely.

## Fix

Add an explicit redirect in `netlify.toml`, matching the pattern already used for `/api/asana/task` and `/api/asana/config`.

## After merge

1. Wait ~2 min for Netlify redeploy.
2. In a browser, open `https://hawkeye-sterling-v2.netlify.app/api/hawkeye-login` — should now return `{"error":"Method not allowed."}` (405), NOT a 404 HTML page.
3. Return to `/login.html`, enter any Name + password `Fortuna1$Fortuna1$Fortuna1$`, click Sign in — should succeed and redirect to `/`.

If the response is still 404 post-deploy, the env vars `HAWKEYE_BRAIN_PASSWORD_HASH` and `HAWKEYE_JWT_SECRET` are missing — then the endpoint fails closed at 503 with a different error body. Either way the 404 must be fixed first so we can see the real error.

## Regulatory basis

- FDL No.(10)/2025 Art.20-21 — the MLRO must be able to authenticate to exercise CO duties.
- FDL No.(10)/2025 Art.24 — JWT `jti` correlates the session to the 10-year audit trail.

https://claude.ai/code/session_01DV66DtqhDJh7mJuWvj8byC