### PR TITLE
Fix /api/hawkeye-login 404 (take 2) — drop config.path shadowing

### DIFF
--- a/netlify/functions/auth-login.mts
+++ b/netlify/functions/auth-login.mts
@@ -228,7 +228,14 @@ export default async (req: Request, context: Context): Promise<Response> => {
   });
 };
 
+// The route `/api/hawkeye-login` is wired via an explicit redirect
+// in netlify.toml (belt-and-braces — some Netlify deploys failed to
+// surface the `config.path` registration, yielding a 404 at the
+// documented URL; see commit 664a180 for the incident). The function
+// intentionally does NOT set `config.path` here: if it did, the
+// default `/.netlify/functions/auth-login` URL would be shadowed and
+// the toml redirect would break. Keeping the method constraint so a
+// stray GET returns 405 at the function layer.
 export const config: Config = {
-  path: '/api/hawkeye-login',
   method: ['POST', 'OPTIONS'],
 };


### PR DESCRIPTION
## Root cause (still 404 after PR #394)

`auth-login.mts` exports:

```ts
export const config: Config = {
  path: '/api/hawkeye-login',
  method: ['POST', 'OPTIONS'],
};
```

When Netlify honours `config.path` it registers the function **only** at the custom path and removes the default `/.netlify/functions/auth-login` URL. When Netlify does NOT honour `config.path` (observed on this deploy), the custom path never surfaces AND the default URL never surfaces either — the function is unreachable from both sides. The toml redirect added in PR #394 points to the default URL, so it 404s end-to-end.

## Fix

Drop the `path` property. The function reverts to the default `/.netlify/functions/auth-login` URL, which the toml redirect from PR #394 routes `/api/hawkeye-login` into. Keep the `method` constraint so a GET still returns 405 at the function layer.

## After merge

1. Wait ~2 min for redeploy.
2. GET `https://hawkeye-sterling-v2.netlify.app/api/hawkeye-login` must now return `{"error":"Method not allowed."}` (405) — NOT the 404 HTML page.
3. `/login.html` sign-in with `Fortuna1$Fortuna1$Fortuna1$` must succeed.

## Regulatory

FDL No.(10)/2025 Art.20-21 (CO duties require working auth), Art.24 (JWT `jti` → audit trail).

https://claude.ai/code/session_01DV66DtqhDJh7mJuWvj8byC