### PR TITLE
Restore config.path on /api/hawkeye-login (revert PR #395 hypothesis)

### DIFF
--- a/netlify/functions/auth-login.mts
+++ b/netlify/functions/auth-login.mts
@@ -228,14 +228,15 @@ export default async (req: Request, context: Context): Promise<Response> => {
   });
 };
 
-// The route `/api/hawkeye-login` is wired via an explicit redirect
-// in netlify.toml (belt-and-braces — some Netlify deploys failed to
-// surface the `config.path` registration, yielding a 404 at the
-// documented URL; see commit 664a180 for the incident). The function
-// intentionally does NOT set `config.path` here: if it did, the
-// default `/.netlify/functions/auth-login` URL would be shadowed and
-// the toml redirect would break. Keeping the method constraint so a
-// stray GET returns 405 at the function layer.
+// Route registration via both `config.path` AND an explicit
+// netlify.toml redirect. Every other .mts function in this repo
+// (screening-run, screening-save, transaction-monitor, asana-*)
+// uses `config.path` successfully on this deploy, so the earlier
+// hypothesis that `config.path` was shadowing the default URL was
+// wrong — restoring it here. The toml redirect stays as a
+// belt-and-braces second path so `/api/hawkeye-login` resolves
+// regardless of which registration Netlify actually honours.
 export const config: Config = {
+  path: '/api/hawkeye-login',
   method: ['POST', 'OPTIONS'],
 };


### PR DESCRIPTION
## PR #395 hypothesis was wrong

Every other `.mts` function in this repo — `screening-run.mts`, `screening-save.mts`, `transaction-monitor.mts`, `asana-*.mts` — declares `config.path = '/api/...'` and works correctly on this deploy. So removing `config.path` was the wrong fix.

## Restore

- `config.path` restored on `auth-login.mts`.
- netlify.toml redirect (from PR #394) kept as a belt-and-braces second route.

## Diagnostic if 404 persists after merge

If `GET /api/hawkeye-login` still returns the Netlify 404 after this deploy, the function isn't being **built** (TypeScript error, missing dependency at esbuild time). Next step would be to check the Netlify deploy log for this function's build status.

## Regulatory

FDL No.(10)/2025 Art.20-21 (MLRO must be able to sign in), Art.24 (`jti` → audit trail).

https://claude.ai/code/session_01DV66DtqhDJh7mJuWvj8byC