### PR TITLE
SECURITY: fix /login.html password-in-URL leak + default MLRO name to Luisa Fernanda

### DIFF
--- a/login.html
+++ b/login.html
@@ -73,17 +73,30 @@
     </style>
   </head>
   <body>
-    <form class="card" id="loginForm" autocomplete="off">
+    <!--
+      SECURITY NOTE: this is a <div>, not a <form>. An earlier
+      version used <form> without method="post" + action, which
+      caused the browser to default-submit via GET whenever the JS
+      submit handler failed to attach (observed 2026-04-20 — the
+      password leaked into location.search). A non-form container
+      makes it structurally impossible for the browser to serialize
+      credentials into the URL; every submission is driven by the
+      JS click handler below which POSTs JSON to /api/hawkeye-login.
+      Enter-to-submit is wired manually on each input.
+      Regulatory: FDL No.(10)/2025 Art.24 (no credential in logs);
+      CLAUDE.md Seguridad §5 (no plaintext password on the wire).
+    -->
+    <div class="card" id="loginForm" role="form" aria-label="MLRO sign-in">
       <h1>HAWKEYE STERLING V2</h1>
       <p class="sub">MLRO sign-in — one password, every surface unlocks for the session.</p>
       <label for="u">Name</label>
-      <input type="text" id="u" name="name" autocomplete="username" placeholder="Name" required maxlength="120" />
+      <input type="text" id="u" autocomplete="username" value="Luisa" required maxlength="120" />
       <label for="p">Password</label>
-      <input type="password" id="p" name="password" autocomplete="current-password" placeholder="Password" required maxlength="1024" />
-      <button type="submit" id="btn">Sign in</button>
+      <input type="password" id="p" autocomplete="current-password" placeholder="Password" required maxlength="1024" />
+      <button type="button" id="btn">Sign in</button>
       <div class="err" id="err" role="status" aria-live="polite"></div>
       <div class="foot">1-year session · FDL Art.24 audit retention · 5 attempts / 15 min / IP</div>
-    </form>
+    </div>
     <script>
       (function () {
         var JWT_KEY = 'hawkeye.session.jwt';
@@ -114,7 +127,6 @@
           return;
         }
 
-        var form = document.getElementById('loginForm');
         var uEl = document.getElementById('u');
         var pEl = document.getElementById('p');
         var btn = document.getElementById('btn');
@@ -122,9 +134,14 @@
 
         var savedName = get(NAME_KEY);
         if (savedName) uEl.value = savedName;
+        // If the name field is pre-populated (default "Luisa" or a saved
+        // name), focus the password box so the MLRO goes straight to
+        // typing the password.
+        if (uEl.value) {
+          try { pEl.focus(); } catch (_) {}
+        }
 
-        form.addEventListener('submit', function (ev) {
-          ev.preventDefault();
+        function doSignIn() {
           err.textContent = '';
           btn.disabled = true;
           btn.textContent = 'Signing in…';
@@ -164,7 +181,21 @@
               pEl.focus();
             }
           });
-        });
+        }
+
+        btn.addEventListener('click', doSignIn);
+        // Enter key on either input triggers sign-in. We bind keydown on
+        // the inputs directly (not a form submit event) so the browser
+        // cannot fall back to a default GET submission that serializes
+        // the password into the URL.
+        function onKey(ev) {
+          if (ev.key === 'Enter' || ev.keyCode === 13) {
+            ev.preventDefault();
+            doSignIn();
+          }
+        }
+        uEl.addEventListener('keydown', onKey);
+        pEl.addEventListener('keydown', onKey);
       })();
     </script>
   </body>

--- a/login.html
+++ b/login.html
@@ -90,7 +90,7 @@
       <h1>HAWKEYE STERLING V2</h1>
       <p class="sub">MLRO sign-in — one password, every surface unlocks for the session.</p>
       <label for="u">Name</label>
-      <input type="text" id="u" autocomplete="username" value="Luisa" required maxlength="120" />
+      <input type="text" id="u" autocomplete="username" value="Luisa Fernanda" required maxlength="120" />
       <label for="p">Password</label>
       <input type="password" id="p" autocomplete="current-password" placeholder="Password" required maxlength="1024" />
       <button type="button" id="btn">Sign in</button>


### PR DESCRIPTION
## URGENT — password leaked into URL

Production MLRO sign-in observed posting credentials via GET. The URL ended up as `/login.html?name=LUISA&password=Fortuna1%24Fortuna1%24Fortuna1%24`. The password landed in the location bar + browser history + any observability tool that captured the request URL.

**Root cause**: the `<form>` had no `method="post"` / `action`. When the JS submit handler failed to attach or was bypassed, the browser default-submitted via GET, serializing the password into the URL.

## Fix

Structural — the credential container is now a `<div>`, not a `<form>`. A non-form ancestor makes it **impossible** for the browser to serialize credentials into the URL:

- `<div role="form">` replaces `<form>`.
- `<button type="button">` (never triggers form submission).
- Inputs have no `name` attribute (browser cannot auto-build a query string).
- Enter-to-submit wired manually via `keydown` on each input with `preventDefault`.
- Every sign-in path goes through `doSignIn()` → `fetch('/api/hawkeye-login', method:'POST', body: JSON)`.

## UX

- Name field defaults to `Luisa Fernanda`.
- Focus jumps to the Password input when the Name field is pre-populated.

## What you should do right now

1. **Rotate the password** — the old one may appear in browser history, router logs, Netlify edge logs, or any tool that captured the URL. Generate a new hash:
   ```
   HAWKEYE_PASSWORD='your-new-password' node scripts/hash-password.mjs
   ```
   Paste the new `pbkdf2-sha256$…` envelope into Netlify `HAWKEYE_BRAIN_PASSWORD_HASH`, redeploy.
2. **Clear browser history** for `hawkeye-sterling-v2.netlify.app` on every device that hit the leaking form.
3. **Review Netlify access logs** to confirm no third party observed the query.

## Regulatory

- FDL No.(10)/2025 Art.24 — credentials must not persist in audit artefacts.
- FDL No.(10)/2025 Art.29 — no tipping off; a URL carrying the password could leak via shared tabs / referrer headers.
- CLAUDE.md Seguridad §5 — password hashing + secure transport.

https://claude.ai/code/session_01DV66DtqhDJh7mJuWvj8byC