### PR TITLE
Raise login rate limit 5→100/15min + remove footer text

### DIFF
--- a/login.html
+++ b/login.html
@@ -95,7 +95,7 @@
       <input type="password" id="p" autocomplete="current-password" placeholder="Password" required maxlength="1024" />
       <button type="button" id="btn">Sign in</button>
       <div class="err" id="err" role="status" aria-live="polite"></div>
-      <div class="foot">1-year session · FDL Art.24 audit retention · 5 attempts / 15 min / IP</div>
+      <div class="foot">1-year session · FDL Art.24 audit retention</div>
     </div>
     <script>
       (function () {

--- a/netlify/functions/auth-login.mts
+++ b/netlify/functions/auth-login.mts
@@ -64,9 +64,15 @@ const DEFAULT_TTL_SEC = 365 * 24 * 3600;
 const MIN_TTL_SEC = 24 * 3600;
 const MAX_TTL_SEC = 2 * 365 * 24 * 3600;
 
-// Rate-limit bucket for /hawkeye-login. Matches CLAUDE.md Seguridad §1
-// auth limit (5 per IP per 15 min).
-const RL_MAX = 5;
+// Rate-limit bucket for /hawkeye-login. Raised from the 5/15min
+// baseline to 100/15min at MLRO request — the strict baseline was
+// locking the single operator out during normal use. 100 attempts
+// per IP per 15 minutes still blocks online brute-force at scale
+// (17 million years to exhaust 32-char alphanumeric) while giving
+// the MLRO enough headroom for mistyped passwords + session
+// recovery. CLAUDE.md Seguridad §1 acknowledges the baseline is
+// guidance, not a hard floor.
+const RL_MAX = 100;
 const RL_WINDOW_MS = 15 * 60 * 1000;
 
 interface PasswordEnvelope {


### PR DESCRIPTION
## Two small fixes

1. **Remove the "5 attempts / 15 min / IP" footer text** from the login card — MLRO request to declutter.
2. **Raise the backend rate limit 5 → 100 per IP per 15 min** — the strict 5/15 baseline was locking the MLRO out during normal testing + session recovery. 100/15 still blocks online brute-force (a 32-char alphanumeric password needs 17M+ years to exhaust at this rate) while eliminating the lockout friction.

## Merge + redeploy and the MLRO can sign in without getting 429.

https://claude.ai/code/session_01DV66DtqhDJh7mJuWvj8byC