### PR TITLE
Emergency: env flag to bypass login rate limit (drain stuck 429 bucket)

### DIFF
--- a/netlify/functions/auth-login.mts
+++ b/netlify/functions/auth-login.mts
@@ -146,13 +146,26 @@ export default async (req: Request, context: Context): Promise<Response> => {
 
   // Rate limit BEFORE touching the body — a flood of malformed JSON
   // must still count against the attacker's budget.
-  const rl = await checkRateLimit(req, {
-    max: RL_MAX,
-    windowMs: RL_WINDOW_MS,
-    namespace: 'hawkeye-login',
-    clientIp,
-  });
-  if (rl) return rl;
+  //
+  // MLRO-lockout recovery: the live rate-limit bucket was still
+  // holding residual counts from the 5/15 baseline after the raise
+  // to 100/15, leaving the sole operator stuck at 429 long after
+  // the raise deployed. To drain the bucket cleanly, bypass the
+  // rate limit when HAWKEYE_LOGIN_RATE_LIMIT_DISABLED=1 in the env.
+  // Leave the env var unset in normal operation — the 100/15 cap
+  // still applies. Regulatory basis: FDL No.(10)/2025 Art.20-21
+  // (operator access is a precondition for CO duties; lock-in is
+  // an availability failure).
+  const rateLimitDisabled = process.env.HAWKEYE_LOGIN_RATE_LIMIT_DISABLED === '1';
+  if (!rateLimitDisabled) {
+    const rl = await checkRateLimit(req, {
+      max: RL_MAX,
+      windowMs: RL_WINDOW_MS,
+      namespace: 'hawkeye-login',
+      clientIp,
+    });
+    if (rl) return rl;
+  }
 
   const envelopeRaw = process.env.HAWKEYE_BRAIN_PASSWORD_HASH;
   const jwtSecret = process.env.HAWKEYE_JWT_SECRET;


### PR DESCRIPTION
## MLRO is locked at 429 even after the 100/15min raise

The rate-limit blob store holds a per-IP counter that doesn't reset when the `RL_MAX` constant changes in code — it keeps counting residual hits from the earlier 5/15 window. The operator stays at 429 until the 15-min window expires.

## Fix

Add an env escape hatch: set `HAWKEYE_LOGIN_RATE_LIMIT_DISABLED=1` in Netlify → the login endpoint skips the rate-limit check entirely. Leave unset in normal ops → 100/15 still enforced.

## After merge

1. Wait ~2 min for redeploy.
2. Netlify → env vars → add `HAWKEYE_LOGIN_RATE_LIMIT_DISABLED=1` (All scopes, All contexts) → Save → **Trigger deploy → Clear cache and deploy site**.
3. Sign in — no 429.
4. Once signed in, delete `HAWKEYE_LOGIN_RATE_LIMIT_DISABLED` from Netlify (or set it to anything other than `1`) → redeploy → 100/15 is back on.

https://claude.ai/code/session_01DV66DtqhDJh7mJuWvj8byC