### PR TITLE
Force Netlify function-pack rebuild after PR #409 auth fix did not de…

### DIFF
--- a/netlify/functions/asana-toast-stream.mts
+++ b/netlify/functions/asana-toast-stream.mts
@@ -27,6 +27,9 @@ import { getStore } from '@netlify/blobs';
 import { checkRateLimit } from './middleware/rate-limit.mts';
 import { authenticate } from './middleware/auth.mts';
 
+// Build marker — force Netlify function-pack rebuild after PR #409 auth
+// hardening failed to deploy on the prior commit. Safe to remove on the
+// next unrelated edit. FDL No.(10)/2025 Art.20-21.
 const TOAST_STREAM_STORE = 'asana-toast-stream';
 
 interface PendingToast {

--- a/netlify/functions/sanctions-ingest-status.mts
+++ b/netlify/functions/sanctions-ingest-status.mts
@@ -34,6 +34,9 @@ import type { Context } from '@netlify/functions';
 import { getStore } from '@netlify/blobs';
 import { checkRateLimit } from './middleware/rate-limit.mts';
 import { authenticate } from './middleware/auth.mts';
+// Build marker — force Netlify function-pack rebuild after PR #409 auth
+// hardening failed to deploy on the prior commit. Safe to remove on the
+// next unrelated edit. FDL No.(10)/2025 Art.20-21, Art.24.
 
 /** Walk every page of a blob-store listing — the SDK paginates by default. */
 async function listAllBlobs(


### PR DESCRIPTION
…ploy (FDL No.(10)/2025 Art.20-21, Art.24)

PR #409 merged the authentication hardening for asana-toast-stream and sanctions-ingest-status into main, and the static-side deploy landed correctly — the new CSP hash in netlify.toml is visible on the live site's response headers. The function pack, however, kept serving the pre-PR code for both endpoints: curl against /api/asana-toast-stream returns the old plain-text "Unauthorized" (the legacy hand-rolled check) instead of the JSON envelope the middleware produces, and /.netlify/functions/sanctions-ingest-status still returns 200 anonymously.

This is Netlify's incremental function builder retaining a cached artifact for these two .mts files even though the underlying source changed. Touching each file with an explanatory comment invalidates the cache entry and forces a rebuild on the next deploy.

The comments are intentionally informational (not the usual "what the code does" noise — CLAUDE.md §Formatting forbids that). They document a real incident + the remediation strategy, so any future maintainer who hits the same cache issue knows this is the precedent. Remove them on the next unrelated edit.

Regulatory basis:
  - FDL No.(10)/2025 Art.20-21 (operator access — the MLRO SPA poll loop against /api/asana-toast-stream fails silently until the auth middleware actually runs; authoritative copy of the bearer comparison must deploy before the next MLRO login cycle or toast events pile up undelivered).
  - FDL No.(10)/2025 Art.24 (10-year audit — /sanctions-ingest- status is gated behind auth for a reason; anonymous exposure of the per-source ingest rollup does not meet the "queryable by operators, not exfiltrated in bulk" bar).