### PR TITLE
Fix CI: prettier formatting on 3 files from PR #407

### DIFF
--- a/src/agents/definitions/supportingAgents.ts
+++ b/src/agents/definitions/supportingAgents.ts
@@ -45,7 +45,11 @@ export const SUPPORTING_AGENTS: readonly SupportingAgentSpec[] = Object.freeze([
       'Iterative adverse-media deep-dive. Search → reason → extract → cite → loop. Produces a curated evidence dossier with full source preservation.',
     owner: 'MLRO',
     inputs: ['subjectName', 'customerCode', 'aliases', 'context'],
-    outputs: ['dossier (markdown)', 'citations (RFC7231 URLs + timestamps)', 'confidence per claim'],
+    outputs: [
+      'dossier (markdown)',
+      'citations (RFC7231 URLs + timestamps)',
+      'confidence per claim',
+    ],
     regulatoryBasis:
       'FATF Rec 10 (ongoing CDD) · FDL Art.29 (no tipping off on the queries themselves) · Cabinet Res 134/2025 Art.14',
     asanaProject: 'screening_and_watchlist',
@@ -82,8 +86,7 @@ export const SUPPORTING_AGENTS: readonly SupportingAgentSpec[] = Object.freeze([
     owner: 'Compliance Officer',
     inputs: ['legalEntityId', 'depth (default 5)', 'jurisdictionBlacklist'],
     outputs: ['ownershipGraph (nodes + edges)', 'shellCompanyFlags', 'layeringIndicators'],
-    regulatoryBasis:
-      'Cabinet Decision 109/2023 (UBO register) · FATF Rec 24-25 · FDL Art.14',
+    regulatoryBasis: 'Cabinet Decision 109/2023 (UBO register) · FATF Rec 24-25 · FDL Art.14',
     asanaProject: 'cdd_ubo_pep',
     guards: [
       'Cross-jurisdiction queries require MLRO explicit approval if any hop sits in a secrecy jurisdiction',
@@ -153,8 +156,7 @@ export const SUPPORTING_AGENTS: readonly SupportingAgentSpec[] = Object.freeze([
     owner: 'MLRO',
     inputs: ['subjectCode', 'runId', 'depth (surface|deep)'],
     outputs: ['lifeStoryMarkdown', 'regulatoryChecklist'],
-    regulatoryBasis:
-      'Cabinet Res 134/2025 Art.7-10 (CDD depth) · FATF Rec 10 · FDL Art.24',
+    regulatoryBasis: 'Cabinet Res 134/2025 Art.7-10 (CDD depth) · FATF Rec 10 · FDL Art.24',
     asanaProject: 'screening_and_watchlist',
     guards: [
       'Report flagged as CONFIDENTIAL (FDL Art.29)',
@@ -171,8 +173,7 @@ export const SUPPORTING_AGENTS: readonly SupportingAgentSpec[] = Object.freeze([
     owner: 'MLRO',
     inputs: ['subjectCode', 'windowDays (default 365)'],
     outputs: ['timelineEvents', 'gapReport', 'anomalyMarkers'],
-    regulatoryBasis:
-      'FDL Art.24 (audit record must be contiguous) · Cabinet Res 134/2025 Art.19',
+    regulatoryBasis: 'FDL Art.24 (audit record must be contiguous) · Cabinet Res 134/2025 Art.19',
     asanaProject: 'audit_inspection',
     guards: [
       'Cross-tenant data access forbidden',
@@ -243,8 +244,7 @@ export const SUPPORTING_AGENTS: readonly SupportingAgentSpec[] = Object.freeze([
     owner: 'MLRO',
     inputs: ['modelId', 'baselineWindowDays', 'currentWindowDays'],
     outputs: ['driftMetric', 'topShiftedFactors', 'recommendation'],
-    regulatoryBasis:
-      'EU AI Act Art.15 · NIST AI RMF MEASURE-2.4 · ISO/IEC 42001 §8.2',
+    regulatoryBasis: 'EU AI Act Art.15 · NIST AI RMF MEASURE-2.4 · ISO/IEC 42001 §8.2',
     asanaProject: 'governance_and_retention',
     guards: [
       'Drift alerts paginated to avoid alert storms',
@@ -262,6 +262,4 @@ export function agentsByModule(key: ModuleKey): readonly SupportingAgentSpec[] {
   return SUPPORTING_AGENTS.filter((a) => a.asanaProject === key);
 }
 
-export const SUPPORTING_AGENT_IDS: readonly string[] = SUPPORTING_AGENTS.map(
-  (a) => a.id,
-);
+export const SUPPORTING_AGENT_IDS: readonly string[] = SUPPORTING_AGENTS.map((a) => a.id);

--- a/src/services/asanaModuleProjects.ts
+++ b/src/services/asanaModuleProjects.ts
@@ -247,8 +247,7 @@ export const MODULE_PROJECTS: readonly ModuleProjectSpec[] = Object.freeze([
       'Finding — Remediated',
       'Closed',
     ],
-    regulatoryBasis:
-      'Cabinet Res 71/2024 · FDL No.10/2025 Art.21, 24 · LBMA RGG v9 Step 5',
+    regulatoryBasis: 'Cabinet Res 71/2024 · FDL No.10/2025 Art.21, 24 · LBMA RGG v9 Step 5',
     owner: 'MLRO',
   },
   {
@@ -265,8 +264,7 @@ export const MODULE_PROJECTS: readonly ModuleProjectSpec[] = Object.freeze([
       'KPI Report',
       'Archived',
     ],
-    regulatoryBasis:
-      'Cabinet Res 134/2025 Art.19 · FDL No.10/2025 Art.20-21',
+    regulatoryBasis: 'Cabinet Res 134/2025 Art.19 · FDL No.10/2025 Art.20-21',
     owner: 'MLRO',
   },
   {
@@ -287,8 +285,7 @@ export const MODULE_PROJECTS: readonly ModuleProjectSpec[] = Object.freeze([
       'Refresher Cycle',
       'External Webinar Attendance',
     ],
-    regulatoryBasis:
-      'Cabinet Res 134/2025 Art.11, 18 · FDL No.10/2025 Art.20-22 · FATF Rec 18',
+    regulatoryBasis: 'Cabinet Res 134/2025 Art.11, 18 · FDL No.10/2025 Art.20-22 · FATF Rec 18',
     owner: 'MLRO',
   },
   {
@@ -306,8 +303,7 @@ export const MODULE_PROJECTS: readonly ModuleProjectSpec[] = Object.freeze([
       'Approved — Live',
       'Rejected',
     ],
-    regulatoryBasis:
-      'Cabinet Res 134/2025 Art.7-10 · FDL No.10/2025 Art.12-14 · FATF Rec 10',
+    regulatoryBasis: 'Cabinet Res 134/2025 Art.7-10 · FDL No.10/2025 Art.12-14 · FATF Rec 10',
     owner: 'Compliance Officer',
   },
   {
@@ -316,16 +312,8 @@ export const MODULE_PROJECTS: readonly ModuleProjectSpec[] = Object.freeze([
     name: 'Compliance Tasks — Master Queue',
     description:
       'The canonical MLRO single to-do list — every open task across every module, sorted by priority + deadline.',
-    sections: [
-      'Today',
-      'This Week',
-      'Next 30 Days',
-      'Blocked',
-      'In Review',
-      'Done',
-    ],
-    regulatoryBasis:
-      'FDL No.10/2025 Art.20-21 · Cabinet Res 134/2025 Art.19',
+    sections: ['Today', 'This Week', 'Next 30 Days', 'Blocked', 'In Review', 'Done'],
+    regulatoryBasis: 'FDL No.10/2025 Art.20-21 · Cabinet Res 134/2025 Art.19',
     owner: 'MLRO',
   },
   {
@@ -442,11 +430,7 @@ export function getModuleProjectGid(key: ModuleKey): string | undefined {
  * ROUTINES were never populated.
  */
 export function resolveAsanaProjectGid(key: ModuleKey): string {
-  return (
-    getModuleProjectGid(key) ||
-    readEnv('ASANA_SCREENINGS_PROJECT_GID') ||
-    '1213759768596515'
-  );
+  return getModuleProjectGid(key) || readEnv('ASANA_SCREENINGS_PROJECT_GID') || '1213759768596515';
 }
 
 export function getAllModuleEnvVars(): readonly string[] {
@@ -457,6 +441,4 @@ export function moduleProjectByKey(key: ModuleKey): ModuleProjectSpec | undefine
   return MODULE_PROJECTS.find((p) => p.key === key);
 }
 
-export const MODULE_KEYS_IN_CATALOG: readonly ModuleKey[] = MODULE_PROJECTS.map(
-  (p) => p.key,
-);
+export const MODULE_KEYS_IN_CATALOG: readonly ModuleKey[] = MODULE_PROJECTS.map((p) => p.key);

--- a/src/services/routineRunner.ts
+++ b/src/services/routineRunner.ts
@@ -60,14 +60,16 @@ function readToken(): string {
   // approverPool.ts, asanaCentralMlroMirror.ts) so TS treats `process`
   // as potentially-defined rather than always-undefined.
   if (typeof process !== 'undefined' && process.env?.ASANA_TOKEN) return process.env.ASANA_TOKEN;
-  if (typeof process !== 'undefined' && process.env?.ASANA_ACCESS_TOKEN) return process.env.ASANA_ACCESS_TOKEN;
-  if (typeof process !== 'undefined' && process.env?.ASANA_API_TOKEN) return process.env.ASANA_API_TOKEN;
+  if (typeof process !== 'undefined' && process.env?.ASANA_ACCESS_TOKEN)
+    return process.env.ASANA_ACCESS_TOKEN;
+  if (typeof process !== 'undefined' && process.env?.ASANA_API_TOKEN)
+    return process.env.ASANA_API_TOKEN;
   return '';
 }
 
 async function writeRoutineAudit(
   storeName: string,
-  payload: Record<string, unknown>,
+  payload: Record<string, unknown>
 ): Promise<boolean> {
   try {
     const store = getStore({ name: storeName, consistency: 'strong' });
@@ -85,7 +87,7 @@ async function writeRoutineAudit(
 async function postHeartbeatTask(
   projectGid: string,
   spec: RoutineSpec,
-  note: string,
+  note: string
 ): Promise<{ gid?: string; error?: string }> {
   const token = readToken();
   if (!token) return { error: 'ASANA_TOKEN not configured' };
@@ -134,7 +136,7 @@ async function postHeartbeatTask(
  */
 export async function runRoutine(
   spec: RoutineSpec,
-  opts: RoutineRunOptions = {},
+  opts: RoutineRunOptions = {}
 ): Promise<RoutineRunResult> {
   const ranAt = new Date().toISOString();
   const dispatch = opts.dispatch !== false;
@@ -190,6 +192,8 @@ export async function runRoutine(
     asanaError: posted.error,
     auditWritten,
     dryRun,
-    message: posted.error ? `Asana dispatch failed: ${posted.error}` : `Posted to Asana (${posted.gid}).`,
+    message: posted.error
+      ? `Asana dispatch failed: ${posted.error}`
+      : `Posted to Asana (${posted.gid}).`,
   };
 }


### PR DESCRIPTION
## Summary

The CI `lint-and-test (20)` job has been failing on `main` since PR #407 merged (commit 7f170a3). Root cause: the **"Check formatting"** step (`npm run format:check` → `prettier --check 'src/**/*.{ts,tsx}'`) flags three files introduced by #407.

Files reformatted via `prettier --write`:
- `src/agents/definitions/supportingAgents.ts`
- `src/services/asanaModuleProjects.ts`
- `src/services/routineRunner.ts`

No logic change — pure whitespace/line-break adjustments to match the repo's prettier config. Verified locally: `npx prettier --check 'src/**/*.{ts,tsx}'` now reports "All matched files use Prettier code style!".

## Scope

CLAUDE.md §8 regulatory-citation exemption applies — this is tooling hygiene, no regulatory constant or decision logic touched.

## Not covered by this PR

The user reported Netlify production deploys (main@7f170a3 and Deploy Preview #407 @462153f) are also **failing at "building site" stage**. That is a separate failure from the CI format check — the Netlify deploy log is gated behind auth and I was unable to fetch it. Likely candidates:

1. Netlify's automatic esbuild of `netlify/functions/*.mts` failing on one of the 54 function files changed by #407.
2. Secrets scanning (less likely — scanned, no hits).

Recommend pulling the Netlify log from https://app.netlify.com/projects/hawkeye-sterling-v2/deploys/69e67731b7e58c2687b8b224 to identify the exact failing function.

Also note: on `main` today, `tsc --noEmit` has pre-existing errors in `src/ui/warroom/WarRoomPanel.tsx` (missing `@types/react` JSX types) and `src/utils/{jwt,asanaEnvCheck,goamlSchemaValidator}.ts` (missing `@types/node` + `@xmldom/xmldom`) — **PR #408 already fixes those**; this PR intentionally does not duplicate that work.

## Test plan

- [x] `npx prettier --check 'src/**/*.{ts,tsx}'` passes locally
- [ ] CI `lint-and-test (20)` → **Check formatting** step passes on this PR
- [ ] Confirm Netlify deploy failure is unrelated to prettier (expected — separate issue)

https://claude.ai/code/session_01YFZRT4C7sy1GGrDXycF78r