### PR TITLE
Fix Netlify deploy: JSDoc */N closes block comment early in 4 cron files

### DIFF
--- a/netlify/functions/adverse-media-hot-sweep-cron.mts
+++ b/netlify/functions/adverse-media-hot-sweep-cron.mts
@@ -1,7 +1,7 @@
 /**
  * Adverse Media Hot Sweep cron — generated from routines.html catalog.
  *
- * Schedule: `0 */6 * * *` (every 6 hours)
+ * Schedule: every 6 hours (see `schedule` below)
  * Module: screening_and_watchlist (Asana board resolved via the 16-project catalog)
  * Audit store: am-hot-audit
  * Regulatory basis: FATF Rec 10 · FDL Art.29

--- a/netlify/functions/goaml-submission-health-cron.mts
+++ b/netlify/functions/goaml-submission-health-cron.mts
@@ -1,7 +1,7 @@
 /**
  * goAML Submission Health cron — generated from routines.html catalog.
  *
- * Schedule: `*/30 * * * *` (every 30 min)
+ * Schedule: every 30 min (see `schedule` below)
  * Module: str_cases (Asana board resolved via the 16-project catalog)
  * Audit store: goaml-health-audit
  * Regulatory basis: FDL No.10/2025 Art.26-27

--- a/netlify/functions/str-deadline-watch-cron.mts
+++ b/netlify/functions/str-deadline-watch-cron.mts
@@ -1,7 +1,7 @@
 /**
  * STR Deadline Watch cron — generated from routines.html catalog.
  *
- * Schedule: `*/15 * * * *` (every 15 min)
+ * Schedule: every 15 min (see `schedule` below)
  * Module: str_cases (Asana board resolved via the 16-project catalog)
  * Audit store: str-deadline-audit
  * Regulatory basis: FDL No.10/2025 Art.26-27

--- a/netlify/functions/structuring-pattern-sweep-cron.mts
+++ b/netlify/functions/structuring-pattern-sweep-cron.mts
@@ -1,7 +1,7 @@
 /**
  * Structuring Pattern Sweep cron — generated from routines.html catalog.
  *
- * Schedule: `*/30 * * * *` (every 30 min)
+ * Schedule: every 30 min (see `schedule` below)
  * Module: transaction_monitoring (Asana board resolved via the 16-project catalog)
  * Audit store: structuring-audit
  * Regulatory basis: MoE Circular 08/AML/2021


### PR DESCRIPTION
## Root cause of every failed deploy since #407

Netlify's production deploys for `hawkeye-sterling-v2` have failed at the **Functions** stage on every commit since #407 (7f170a3, 45084eb, 70dedf8). The underlying failure is the same each time.

esbuild (Netlify's function bundler) parses `/** ... */` block comments and terminates at the **first** `*/` it sees. Four cron files introduced in #407 contain a JSDoc header of the form:

```
/**
 * Schedule: `*/N * * * *` (every N min)
 */
```

The backticks around the cron expression are irrelevant to the block-comment scanner, so the comment closes early at `*/`, and the rest of the file becomes unparseable JavaScript:

```
error: Unexpected "*"
 4 │  * Schedule: `0 */6 * * *` (every 6 hours)
   ╵                       ^
```

Because Netlify bundles the whole functions pack as one deploy step, a single broken file takes **all 126 `.mts` functions down** with it.

## Files fixed

- `netlify/functions/adverse-media-hot-sweep-cron.mts`
- `netlify/functions/goaml-submission-health-cron.mts`
- `netlify/functions/str-deadline-watch-cron.mts`
- `netlify/functions/structuring-pattern-sweep-cron.mts`

Each line 4 JSDoc header rewritten from `` `*/N * * * *` `` → plain English. The canonical cron string is preserved in the `schedule:` property on the `config` export ~30 lines below, so no operational information is lost.

## Verification

```
npx esbuild <each file> --bundle --platform=node --format=esm
```
All four now bundle clean. Other `.mts` files carry cron strings only inside proper single-quoted string literals (`schedule: '*/5 * * * *'`) — those are fine and untouched.

## Regulatory basis

- FDL No.(10)/2025 Art.20-21 — scheduled compliance crons must deploy reliably for CO accountability.
- FDL No.(10)/2025 Art.24 — audit writes from STR deadline watch + goAML submission health must reach the 10-year blob store; a failed deploy silently drops both.

## Test plan

- [x] Local `esbuild` bundle of all 4 files → exit 0
- [ ] Netlify Deploy Preview for this PR → `hawkeye-sterling-v2` builds green
- [ ] After merge → production deploy on main passes Functions stage

https://claude.ai/code/session_01YFZRT4C7sy1GGrDXycF78r