### PR TITLE
Fix Netlify deploy: remove path: from 33 cron functions (path+schedule forbidden)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -39,6 +39,20 @@
   status = 200
   force = true
 
+# Scheduled routine functions — Netlify forbids combining config.path
+# with config.schedule (ntl.fyi/custom-path-scheduled-functions). All
+# 33 `*-cron.mts` functions under netlify/functions therefore drop
+# their `path:` declaration and live at their default URL. This glob
+# preserves the stable `/api/routines/<slug>` surface used by
+# routines.html dry-run buttons and CI smoke tests by rewriting to
+# the default function URL (`<slug>-cron`). Regulatory basis: FDL
+# No.(10)/2025 Art.20-21 (CO visibility), Art.24 (10-year audit).
+[[redirects]]
+  from = "/api/routines/*"
+  to = "/.netlify/functions/:splat-cron"
+  status = 200
+  force = true
+
 # Unified Asana task-creation endpoint used by /workbench, /logistics,
 # /compliance-ops and /routines to create tasks in their dedicated
 # Asana project. The backend routes by { source } and reads the target

--- a/netlify/functions/adverse-media-hot-sweep-cron.mts
+++ b/netlify/functions/adverse-media-hot-sweep-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/adverse-media-hot-sweep',
   schedule: '0 */6 * * *',
 };

--- a/netlify/functions/advisor-budget-tracker-cron.mts
+++ b/netlify/functions/advisor-budget-tracker-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/advisor-budget-tracker',
   schedule: '0 2 * * *',
 };

--- a/netlify/functions/asm-compliance-audit-cron.mts
+++ b/netlify/functions/asm-compliance-audit-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/asm-compliance-audit',
   schedule: '0 4 * * 3',
 };

--- a/netlify/functions/brain-lessons-archive-cron.mts
+++ b/netlify/functions/brain-lessons-archive-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/brain-lessons-archive',
   schedule: '0 2 * * *',
 };

--- a/netlify/functions/bullion-assay-drift-cron.mts
+++ b/netlify/functions/bullion-assay-drift-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/bullion-assay-drift',
   schedule: '30 8 * * *',
 };

--- a/netlify/functions/cahra-supplier-review-cron.mts
+++ b/netlify/functions/cahra-supplier-review-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/cahra-supplier-review',
   schedule: '0 4 * * 2',
 };

--- a/netlify/functions/carbon-scope-supply-chain-cron.mts
+++ b/netlify/functions/carbon-scope-supply-chain-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/carbon-scope-supply-chain',
   schedule: '0 4 * * 1',
 };

--- a/netlify/functions/chain-of-custody-verify-cron.mts
+++ b/netlify/functions/chain-of-custody-verify-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/chain-of-custody-verify',
   schedule: '0 8 * * *',
 };

--- a/netlify/functions/child-labour-ilo182-sweep-cron.mts
+++ b/netlify/functions/child-labour-ilo182-sweep-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/child-labour-ilo182-sweep',
   schedule: '30 4 * * 2',
 };

--- a/netlify/functions/clamp-reason-weekly-digest-cron.mts
+++ b/netlify/functions/clamp-reason-weekly-digest-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/clamp-reason-weekly-digest',
   schedule: '0 6 * * 1',
 };

--- a/netlify/functions/cross-border-aed60k-xcheck-cron.mts
+++ b/netlify/functions/cross-border-aed60k-xcheck-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/cross-border-aed60k-xcheck',
   schedule: '0 7 * * *',
 };

--- a/netlify/functions/customs-declaration-recon-cron.mts
+++ b/netlify/functions/customs-declaration-recon-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/customs-declaration-recon',
   schedule: '30 7 * * *',
 };

--- a/netlify/functions/dual-use-export-sweep-cron.mts
+++ b/netlify/functions/dual-use-export-sweep-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/dual-use-export-sweep',
   schedule: '30 5 * * *',
 };

--- a/netlify/functions/eocn-ingest-retry-cron.mts
+++ b/netlify/functions/eocn-ingest-retry-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/eocn-ingest-retry',
   schedule: '0 * * * *',
 };

--- a/netlify/functions/four-eyes-sla-sweep-cron.mts
+++ b/netlify/functions/four-eyes-sla-sweep-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/four-eyes-sla-sweep',
   schedule: '0 * * * *',
 };

--- a/netlify/functions/goaml-submission-health-cron.mts
+++ b/netlify/functions/goaml-submission-health-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/goaml-submission-health',
   schedule: '*/30 * * * *',
 };

--- a/netlify/functions/grievance-mechanism-monitor-cron.mts
+++ b/netlify/functions/grievance-mechanism-monitor-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/grievance-mechanism-monitor',
   schedule: '45 5 * * *',
 };

--- a/netlify/functions/lbma-audit-countdown-cron.mts
+++ b/netlify/functions/lbma-audit-countdown-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/lbma-audit-countdown',
   schedule: '0 9 * * *',
 };

--- a/netlify/functions/mercury-minamata-sweep-cron.mts
+++ b/netlify/functions/mercury-minamata-sweep-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/mercury-minamata-sweep',
   schedule: '0 4 * * 5',
 };

--- a/netlify/functions/modern-slavery-indicator-sweep-cron.mts
+++ b/netlify/functions/modern-slavery-indicator-sweep-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/modern-slavery-indicator-sweep',
   schedule: '0 4 * * 4',
 };

--- a/netlify/functions/pep-rescreen-by-tier-cron.mts
+++ b/netlify/functions/pep-rescreen-by-tier-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/pep-rescreen-by-tier',
   schedule: '30 3 * * *',
 };

--- a/netlify/functions/policy-refresh-after-circular-cron.mts
+++ b/netlify/functions/policy-refresh-after-circular-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/policy-refresh-after-circular',
   schedule: '0 3 * * 3',
 };

--- a/netlify/functions/records-retention-sweep-cron.mts
+++ b/netlify/functions/records-retention-sweep-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/records-retention-sweep',
   schedule: '30 1 * * *',
 };

--- a/netlify/functions/recycled-vs-mined-origin-cron.mts
+++ b/netlify/functions/recycled-vs-mined-origin-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/recycled-vs-mined-origin',
   schedule: '0 5 * * 4',
 };

--- a/netlify/functions/refiner-accreditation-check-cron.mts
+++ b/netlify/functions/refiner-accreditation-check-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/refiner-accreditation-check',
   schedule: '30 4 * * *',
 };

--- a/netlify/functions/str-deadline-watch-cron.mts
+++ b/netlify/functions/str-deadline-watch-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/str-deadline-watch',
   schedule: '*/15 * * * *',
 };

--- a/netlify/functions/structuring-pattern-sweep-cron.mts
+++ b/netlify/functions/structuring-pattern-sweep-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/structuring-pattern-sweep',
   schedule: '*/30 * * * *',
 };

--- a/netlify/functions/subject-resolution-review-cron.mts
+++ b/netlify/functions/subject-resolution-review-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/subject-resolution-review',
   schedule: '30 5 * * *',
 };

--- a/netlify/functions/supplier-saq-rollover-cron.mts
+++ b/netlify/functions/supplier-saq-rollover-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/supplier-saq-rollover',
   schedule: '0 7 * * 1',
 };

--- a/netlify/functions/tbml-indicator-sweep-cron.mts
+++ b/netlify/functions/tbml-indicator-sweep-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/tbml-indicator-sweep',
   schedule: '30 6 * * *',
 };

--- a/netlify/functions/vasp-wallet-flow-anomaly-cron.mts
+++ b/netlify/functions/vasp-wallet-flow-anomaly-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/vasp-wallet-flow-anomaly',
   schedule: '0 * * * *',
 };

--- a/netlify/functions/velocity-spike-detector-cron.mts
+++ b/netlify/functions/velocity-spike-detector-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/velocity-spike-detector',
   schedule: '0 * * * *',
 };

--- a/netlify/functions/water-stewardship-cahra-cron.mts
+++ b/netlify/functions/water-stewardship-cahra-cron.mts
@@ -29,6 +29,5 @@ export default async (): Promise<Response> => {
 };
 
 export const config: Config = {
-  path: '/api/routines/water-stewardship-cahra',
   schedule: '30 4 * * 5',
 };


### PR DESCRIPTION
## Real root cause of every failed deploy since #407

Every production deploy since #407 merged has failed at the **'building site'** stage with:

```
Configuration error: Scheduled functions must not specify a custom path.
Please remove the "path" configuration.
https://ntl.fyi/custom-path-scheduled-functions
```

PR #407 introduced 33 new cron functions, each with both `path:` and `schedule:` in their exported `config`:

```ts
export const config: Config = {
  path: '/api/routines/<slug>',
  schedule: '<cron-expression>',
};
```

Netlify **rejects this combination at config-resolve time — before esbuild ever runs**, which takes the whole build down in ~30 seconds. (Earlier fixes in #412 and #413 addressed CI format and a JSDoc comment bug, but neither touched this.)

This precedent was already documented in `netlify.toml` for `continuous-monitor` — the pattern just wasn't applied when the 33 new crons were added.

## Fix

1. **Stripped `path:` from all 33 `*-cron.mts` files.** Each cron now lives at its default URL (`/.netlify/functions/<slug>-cron`) and continues to fire on its declared schedule automatically.
2. **Added one glob redirect in `netlify.toml`** so the stable `/api/routines/<slug>` surface used by `routines.html` dry-run buttons + CI smoke tests keeps working:

   ```toml
   [[redirects]]
     from = "/api/routines/*"
     to = "/.netlify/functions/:splat-cron"
     status = 200
     force = true
   ```

## Verification

```bash
NETLIFY_SITE_ID=dummy npx netlify build --offline
```
→ No 'Configuration error'. No 'error'. No 'fail' lines. Config resolves cleanly.

esbuild bundle-test on all 126 `.mts` functions → 0 failures.

## Regulatory basis

- FDL No.(10)/2025 Art.20-21 — scheduled compliance crons (STR deadline watch, goAML submission health, PEP rescreen, EOCN ingest retry, LBMA audit countdown, records retention sweep, continuous monitor backup, etc.) must deploy for CO accountability.
- FDL No.(10)/2025 Art.24 — audit writes from every scheduled routine must reach the 10-year blob store; with the build failing none of the 33 routines have fired in production.

## Test plan

- [x] Local `netlify build --offline` → clean (no configuration error)
- [x] `esbuild` on all 126 `.mts` files → 0 failures
- [ ] Netlify Deploy Preview for this PR → `hawkeye-sterling-v2` builds green
- [ ] Post-merge production deploy passes 'building site' stage
- [ ] Post-deploy: `curl -X POST /api/routines/str-deadline-watch` → 200 (glob redirect resolves)
- [ ] Netlify dashboard shows all 33 scheduled functions listed and next-fire times populated

https://claude.ai/code/session_01YFZRT4C7sy1GGrDXycF78r