### PR TITLE
Document 17 env vars referenced in functions but missing from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -461,3 +461,105 @@ HYPERLIQUID_NETWORK=testnet
 # Netlify (set automatically by Netlify, do not set locally)
 # ─────────────────────────────────────────────────────────────────────────
 # NETLIFY_BLOBS_CONTEXT=
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# MLRO authentication + audit chain integrity
+# ─────────────────────────────────────────────────────────────────────────
+# [REQUIRED] HMAC-SHA256 secret used to sign the MLRO session JWT.
+# Rotate on any suspected compromise; rotation invalidates every
+# outstanding session. 32+ bytes of cryptographic randomness.
+# FDL No.(10)/2025 Art.20-21 (CO auth).
+HAWKEYE_JWT_SECRET=REPLACE_ME_WITH_32B_HEX_SECRET
+
+# [OPTIONAL] JWT lifetime in seconds. Defaults to one year if unset.
+# Shorten during incident response; lengthen for operational comfort.
+HAWKEYE_JWT_TTL_SEC=31536000
+
+# [REQUIRED] bcrypt hash of the MLRO login password. Generate with
+# `npx bcrypt-cli hash <password> 12` and paste here. NEVER commit
+# the plaintext password. CLAUDE.md Seguridad §5.
+HAWKEYE_BRAIN_PASSWORD_HASH=REPLACE_ME_WITH_BCRYPT_HASH
+
+# [REQUIRED] HMAC-SHA256 key used to seal every audit record in the
+# 10-year blob store. Rotating this key breaks the ability to verify
+# older records — coordinate with MoE / internal audit before rotation.
+# FDL No.(10)/2025 Art.24.
+HAWKEYE_AUDIT_HMAC_KEY=REPLACE_ME_WITH_32B_HEX_SECRET
+
+# [REQUIRED for regulator-portal] Master key that signs one-time
+# regulator access codes. Rotate after every inspection cycle.
+# Cabinet Res 71/2024 (administrative penalties — inspectors must
+# authenticate via signed code, not shared password).
+HAWKEYE_REGULATOR_MASTER_KEY=REPLACE_ME_WITH_32B_HEX_SECRET
+
+# [OPTIONAL] Regulator-code TTL in minutes (default 60). Shorter =
+# stricter inspection window; longer = operator convenience.
+HAWKEYE_REGULATOR_CODE_TTL_MINUTES=60
+
+# [REQUIRED for /api/inspector/*] Comma-separated bearer keys for MoE
+# inspectors. Each key is 32+ bytes of hex. Rotate per inspection.
+HAWKEYE_INSPECTOR_KEYS=REPLACE_ME_COMMA_SEPARATED_HEX_KEYS
+
+# [OPTIONAL] CORS allowlist for the SPA. Defaults to the canonical
+# production origin; override for staging / preview deploys.
+HAWKEYE_ALLOWED_ORIGIN=https://hawkeye-sterling-v2.netlify.app
+
+# [EMERGENCY-ONLY] Set to "1" to bypass the /api/hawkeye-login rate
+# limiter during MLRO lockout recovery. MUST be unset in steady-state.
+# CLAUDE.md Seguridad §1.
+# HAWKEYE_LOGIN_RATE_LIMIT_DISABLED=
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Cron tenant scoping (multi-tenant deployments)
+# ─────────────────────────────────────────────────────────────────────────
+# [OPTIONAL] Comma-separated tenant IDs that the clamp-reason weekly
+# digest cron should process. When unset the cron runs for every
+# tenant in the workspace.
+HAWKEYE_CLAMP_CRON_TENANTS=
+
+# [OPTIONAL] Comma-separated tenant IDs for sanctions-delta-screen
+# cron. Same semantics as HAWKEYE_CLAMP_CRON_TENANTS.
+HAWKEYE_DELTA_SCREEN_TENANTS=
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Sanctions / adverse media
+# ─────────────────────────────────────────────────────────────────────────
+# [OPTIONAL] Upstream proxy URL for sanctions list fetches. When unset
+# the ingest crons go direct to UN / OFAC / EU / UK / UAE / EOCN
+# endpoints. Set to a corporate HTTP proxy if required by network
+# policy.
+HAWKEYE_SANCTIONS_PROXY_URL=
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Asana (PR #407 16-project module catalog)
+# ─────────────────────────────────────────────────────────────────────────
+# PR #407 introduced two alias env vars that some modules read in
+# addition to the canonical ASANA_PAT. Populate whichever your
+# module reader expects — they are functionally equivalent.
+# FDL No.(10)/2025 Art.20-21, Art.24.
+ASANA_API_TOKEN=
+ASANA_ACCESS_TOKEN=
+
+# [OPTIONAL] Fallback Asana project GID when the 16-project catalog
+# resolver cannot map a module. Set to your MLRO Central Digest
+# project as the sane default so nothing drops silently.
+ASANA_DEFAULT_PROJECT_GID=
+
+# [OPTIONAL] Asana section name that screening-save.mts writes new
+# screenings into within the Subject Screening & Watchlist project.
+# Defaults to "Screenings" if unset.
+ASANA_SECTION_SCREENINGS_NAME=Screenings
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Continuous monitor
+# ─────────────────────────────────────────────────────────────────────────
+# [OPTIONAL] Feature flag. Set to "1" to dispatch delta alerts to the
+# Compliance Tasks Master Queue Asana project on every scheduled run.
+# Unset/"0" = audit-only (blob store writes + no Asana task).
+CONTINUOUS_MONITOR_DISPATCH_ASANA=0
+


### PR DESCRIPTION
## What this does

Docs-only follow-up from tonight's deep review. Deploy-health agent flagged 17 env vars read via `process.env` in `netlify/functions/*.mts` and `src/services/*.ts` that were never in `.env.example`. Missing any of them produces a silent runtime 500 — particularly painful for security-critical ones (`HAWKEYE_JWT_SECRET`, `HAWKEYE_AUDIT_HMAC_KEY`, `HAWKEYE_REGULATOR_MASTER_KEY`).

## Added (17 vars, grouped + marked)

**MLRO auth + audit (5 REQUIRED, 2 OPTIONAL, 1 EMERGENCY-ONLY):**
- `HAWKEYE_JWT_SECRET`, `HAWKEYE_JWT_TTL_SEC`, `HAWKEYE_BRAIN_PASSWORD_HASH`, `HAWKEYE_AUDIT_HMAC_KEY`, `HAWKEYE_REGULATOR_MASTER_KEY`, `HAWKEYE_REGULATOR_CODE_TTL_MINUTES`, `HAWKEYE_INSPECTOR_KEYS`, `HAWKEYE_ALLOWED_ORIGIN`, `HAWKEYE_LOGIN_RATE_LIMIT_DISABLED`

**Cron tenant scoping (2 OPTIONAL):**
- `HAWKEYE_CLAMP_CRON_TENANTS`, `HAWKEYE_DELTA_SCREEN_TENANTS`

**Sanctions / adverse media (1 OPTIONAL):**
- `HAWKEYE_SANCTIONS_PROXY_URL`

**Asana PR #407 catalog (4 OPTIONAL/alias):**
- `ASANA_API_TOKEN`, `ASANA_ACCESS_TOKEN`, `ASANA_DEFAULT_PROJECT_GID`, `ASANA_SECTION_SCREENINGS_NAME`

**Continuous monitor (1 OPTIONAL feature flag):**
- `CONTINUOUS_MONITOR_DISPATCH_ASANA`

Each carries `[REQUIRED]` / `[OPTIONAL]` / `[EMERGENCY-ONLY]` markers matching the repo's existing `.env.example` idiom, plus the rotation + regulatory impact where it matters (e.g. `HAWKEYE_AUDIT_HMAC_KEY` rotation breaks verification of records pre-rotation).

`CACHET_API_TOKEN` + `CACHET_BASE_URL` were reported by the agent but already documented in `.env.example` — not duplicated.

## Scope

Zero runtime change. Only `.env.example` modified (+102 lines).

## Regulatory basis

- FDL No.(10)/2025 Art.20-21 — every CO secret documented so runbook operators don't miss one during env migration
- FDL No.(10)/2025 Art.24 — `HAWKEYE_AUDIT_HMAC_KEY` rotation impact called out
- Cabinet Res 71/2024 — inspector + regulator keys marked for rotation-per-inspection

## Test plan

- [x] All 17 vars resolve `^#?\s*<NAME>=` in `.env.example`
- [ ] Operator following the Netlify env migration runbook no longer drops a var

https://claude.ai/code/session_01YFZRT4C7sy1GGrDXycF78r