### PR TITLE
Fix cron autopilot silent double-dispatch (localStorage dedup is a no-op in Node)

### DIFF
--- a/netlify/functions/asana-super-brain-autopilot-cron.mts
+++ b/netlify/functions/asana-super-brain-autopilot-cron.mts
@@ -20,6 +20,10 @@
 
 import type { Config } from '@netlify/functions';
 import { getStore } from '@netlify/blobs';
+import {
+  filterUndispatchedCasesBlob,
+  markCaseDispatchedBlob,
+} from '../../src/services/dispatchDedupBlob';
 
 const AUDIT_STORE = 'asana-autopilot-audit';
 const CASES_STORE = 'compliance-cases'; // optional — ops may not have it set up yet
@@ -75,6 +79,25 @@ export default async (): Promise<Response> => {
     return Response.json({ ok: true, dispatched: 0, reason: 'no cases' });
   }
 
+  // Runtime-correct dedup. runSuperBrainBatch's skipAlreadyDispatched
+  // guard is backed by dispatchAuditLog which lives in browser
+  // localStorage — always empty in the Netlify Node runtime, so the
+  // sync guard is a no-op here. Pre-filter with the Blobs-backed
+  // dedup index so overlapping cron runs cannot double-dispatch.
+  // FDL No.10/2025 Art.24 (audit trail integrity).
+  const { remaining: pendingCases, skippedIds: preSkipped } =
+    await filterUndispatchedCasesBlob(cases);
+
+  if (pendingCases.length === 0) {
+    await writeAudit({
+      event: 'autopilot_idle',
+      reason: 'every open case already dispatched in prior run',
+      preSkippedCount: preSkipped.length,
+      at: startedAtIso,
+    });
+    return Response.json({ ok: true, dispatched: 0, preSkipped: preSkipped.length });
+  }
+
   // Defer the real dispatch to a dynamic import so the cron
   // module stays lightweight at cold-start time. The dispatcher
   // talks to Asana via the standard asanaClient path (env vars
@@ -84,10 +107,13 @@ export default async (): Promise<Response> => {
   const items: Array<{ caseId: string; verdict?: string; ok: boolean; error?: string }> = [];
   try {
     const batchModule = await import('../../src/services/superBrainBatchDispatcher');
-    const typedCases = cases as unknown as Parameters<typeof batchModule.runSuperBrainBatch>[0];
+    const typedCases = pendingCases as unknown as Parameters<typeof batchModule.runSuperBrainBatch>[0];
     const summary = await batchModule.runSuperBrainBatch(typedCases, {
       trigger: 'cron',
-      skipAlreadyDispatched: true,
+      // Pre-filter already handled dedup via the Blobs index; the
+      // sync guard is a no-op in Node so leaving it on would only
+      // add cost with zero effect.
+      skipAlreadyDispatched: false,
       consecutiveFailureLimit: 3,
       nowIso: startedAtIso,
     });
@@ -100,6 +126,20 @@ export default async (): Promise<Response> => {
         ok: item.ok,
         error: item.error,
       });
+      if (item.ok && !item.skipped) {
+        // CAS-safe write. On conflict (another run marked first) we
+        // still get ok: true with alreadyMarked: true, which is the
+        // correct outcome.
+        await markCaseDispatchedBlob({
+          caseId: item.caseId,
+          dispatchedAtIso: startedAtIso,
+          verdict: item.verdict,
+          runId: `autopilot-${startedAtIso}`,
+        }).catch(() => {
+          // Best effort — if the dedup store is unreachable we keep
+          // going; the audit entry below still records the dispatch.
+        });
+      }
     }
     await writeAudit({
       event: 'autopilot_batch',
@@ -110,6 +150,7 @@ export default async (): Promise<Response> => {
         failed: summary.failed,
         aborted: summary.aborted,
         durationMs: summary.durationMs,
+        preSkippedFromDedupIndex: preSkipped.length,
       },
       at: startedAtIso,
     });

--- a/src/services/dispatchDedupBlob.ts
+++ b/src/services/dispatchDedupBlob.ts
@@ -1,0 +1,106 @@
+/**
+ * Dispatch Dedup Blob — Netlify-Blobs-backed idempotency index for the
+ * server-side autopilot cron path.
+ *
+ * Why a separate module from dispatchAuditLog.ts:
+ *
+ *   dispatchAuditLog.ts stores its ring buffer in browser localStorage
+ *   and is therefore a no-op in the Netlify Node runtime. The cron at
+ *   netlify/functions/asana-super-brain-autopilot-cron.mts runs every
+ *   15 minutes in Node, where `typeof localStorage === 'undefined'`
+ *   makes the `skipAlreadyDispatched` guard in runSuperBrainBatch()
+ *   silently ineffective. Left un-addressed, every cron tick would
+ *   re-dispatch every open case — doubling Asana task creation,
+ *   inflating the audit trail, and eventually tripping Asana's rate
+ *   limiter.
+ *
+ *   This module gives the cron a runtime-appropriate dedup path. It
+ *   intentionally does NOT touch the browser dispatchAuditLog surface
+ *   — the in-SPA listener (autoDispatchListener.ts) continues to use
+ *   localStorage and is untouched.
+ *
+ * Storage model:
+ *   - One Netlify Blob key per dispatch index: `by-case/<caseId>.json`
+ *   - Each key, if present, records the first successful dispatch:
+ *       { caseId, dispatchedAtIso, verdict?, runId }
+ *   - Checking "has this case been dispatched?" is a single
+ *     `getWithMetadata` call. Marking a dispatch is a CAS write with
+ *     `onlyIfMatch: etag`. On CAS conflict (another cron run racing
+ *     through the same case), we treat the existing record as
+ *     authoritative and return `{ ok: true, alreadyMarked: true }` —
+ *     duplicate-dispatch is the failure mode we are preventing, so
+ *     losing the write on conflict is exactly what we want.
+ *
+ *   - A separate rolling index `recent.json` would be tempting for
+ *     fast queries, but any RMW on a single shared blob re-introduces
+ *     exactly the race we are closing here. Stick with per-case keys.
+ *
+ * Regulatory basis:
+ *   - FDL No.10/2025 Art.24 (immutable 10-year audit retention —
+ *     dedup prevents the audit log from recording the same decision
+ *     twice under different timestamps).
+ *   - Cabinet Res 134/2025 Art.19 (auditable internal review).
+ */
+
+import { getStore } from '@netlify/blobs';
+
+const STORE_NAME = 'dispatch-dedup';
+const KEY = (caseId: string): string => `by-case/${encodeURIComponent(caseId)}.json`;
+
+export interface DispatchMarker {
+  caseId: string;
+  dispatchedAtIso: string;
+  verdict?: string;
+  runId?: string;
+}
+
+export async function hasCaseBeenDispatchedBlob(caseId: string): Promise<boolean> {
+  const store = getStore(STORE_NAME);
+  const raw = await store.get(KEY(caseId), { type: 'json' }).catch(() => null);
+  return raw !== null && raw !== undefined;
+}
+
+export async function markCaseDispatchedBlob(
+  marker: DispatchMarker
+): Promise<{ ok: boolean; alreadyMarked?: boolean }> {
+  const store = getStore(STORE_NAME);
+  const withMeta = await store
+    .getWithMetadata(KEY(marker.caseId), { type: 'json' })
+    .catch(() => null);
+
+  // Already marked — treat as success. The first writer wins; any
+  // subsequent dispatch attempt for the same case was by definition
+  // a duplicate and we do NOT want to stomp the original timestamp.
+  if (withMeta && withMeta.data) {
+    return { ok: true, alreadyMarked: true };
+  }
+
+  try {
+    await store.setJSON(KEY(marker.caseId), marker, {
+      onlyIfMatch: withMeta?.etag,
+    } as Parameters<typeof store.setJSON>[2]);
+    return { ok: true };
+  } catch {
+    // CAS conflict — another writer marked it between our read and
+    // our write. That is still the correct outcome (the case is now
+    // recorded as dispatched). Surface alreadyMarked so the caller
+    // skips the follow-up Asana task creation.
+    return { ok: true, alreadyMarked: true };
+  }
+}
+
+export async function filterUndispatchedCasesBlob<T extends { id: string }>(
+  cases: readonly T[]
+): Promise<{ remaining: T[]; skippedIds: string[] }> {
+  const remaining: T[] = [];
+  const skippedIds: string[] = [];
+  for (const c of cases) {
+    const seen = await hasCaseBeenDispatchedBlob(c.id);
+    if (seen) {
+      skippedIds.push(c.id);
+    } else {
+      remaining.push(c);
+    }
+  }
+  return { remaining, skippedIds };
+}


### PR DESCRIPTION
## Real bug surfaced by the deep-review CAS investigation

The deep-review CAS agent flagged `asana-super-brain-autopilot-cron.mts:54` as a "race condition". I initially dismissed it as a false positive (the line itself is a pure read), but tracing the `skipAlreadyDispatched` guard led to a worse bug:

**The dedup guard is a silent no-op in Node.**

`runSuperBrainBatch(..., { skipAlreadyDispatched: true })` calls `hasCaseInAuditLogCheck()` → `readAuditLog()` → reads `localStorage`. In `src/services/dispatchAuditLog.ts:60`:

```ts
if (typeof localStorage === 'undefined') return [];
```

The cron runs in the Netlify Node runtime where `localStorage` **is** undefined. So:

- `hasCaseInAuditLogCheck()` returns `false` on every call
- `recordDispatch()` is a silent no-op
- **Every 15-minute cron tick re-dispatches every open case**

Consequence: duplicate Asana tasks, audit log entries for the same decision under multiple timestamps (direct FDL Art.24 violation), eventual Asana rate-limit trip.

## Fix

Added `src/services/dispatchDedupBlob.ts` — a Netlify-Blobs-backed dedup index with CAS-safe writes. One key per case (`by-case/<id>.json`), deliberately **not** a single rolling-index blob because RMW on a shared blob would re-introduce the same race.

Wired into the cron:

1. Pre-filter open cases via `filterUndispatchedCasesBlob` — anything already dispatched in a prior run is skipped before reaching the batch.
2. `skipAlreadyDispatched` switched to `false` (the sync guard is dead in Node).
3. After each successful dispatch, CAS-write the marker via `markCaseDispatchedBlob`. First writer wins.

## Untouched on purpose

- `dispatchAuditLog.ts` (browser localStorage ring buffer) — still used by the in-SPA auto-dispatch listener; fine in the browser context.
- `superBrainBatchDispatcher.ts` — public API unchanged. The cron is the only caller that crosses the runtime boundary, so the fix lives at the cron, not at the batch.

## Verification

- `tsc --noEmit` → exit 0
- `esbuild` bundle of the cron → clean
- No new cross-layer imports break Netlify's auto-bundling

## Regulatory basis

- FDL No.(10)/2025 Art.24 — dedup prevents 10-year audit log from double-recording decisions
- FDL No.(10)/2025 Art.26-27 — STR filing "without delay" must fire exactly once
- Cabinet Res 134/2025 Art.19 — auditable internal review must not record the same case twice
- CLAUDE.md Regulatory Coding Rule §3 — every compliance action logged exactly once

## Draft for your review

Not auto-merged. Changes compliance decision wiring → wants four-eyes per CLAUDE.md §10.

## Test plan

- [ ] Force two concurrent cron invocations in a 100ms window → confirm one Asana task per case (not two)
- [ ] Delete a case's dedup marker manually → confirm next tick re-dispatches that single case
- [ ] Leave one open case across 8 cron ticks → confirm exactly one dispatch

https://claude.ai/code/session_01YFZRT4C7sy1GGrDXycF78r