### PR TITLE
Extract 3 pure widget helpers from renderSubjectScreening (748→696 lines)

### DIFF
--- a/screening-command-modules.js
+++ b/screening-command-modules.js
@@ -962,6 +962,72 @@
     return String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/</g, '&lt;')
       .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
   }
+
+  // ---------------------------------------------------------------
+  // Shared form-widget builders (extracted from renderSubjectScreening
+  // to keep the outer function focused on layout rather than widget
+  // markup). These helpers only depend on esc() from this scope; no
+  // closure state, so they are safe to reuse across render calls.
+  // Regulatory basis: FDL No.10/2025 Art.20-21 (MLRO situational
+  // awareness depends on stable form payloads — behaviour-preserving
+  // refactor; the generated HTML is byte-identical).
+  // ---------------------------------------------------------------
+
+  function widgetCheckboxGroup(fieldName, items) {
+    return items.map(function (it) {
+      return '<label class="mv-check" style="align-items:flex-start;line-height:1.45">' +
+        '<input type="checkbox" name="' + fieldName + '" value="' + esc(it.id) + '" checked>' +
+        '<span>' +
+          '<strong>' + esc(it.label) + '</strong>' +
+          (it.citation ? '<br><em style="opacity:.65;font-size:11px;font-style:normal">' + esc(it.citation) + '</em>' : '') +
+          (it.detail ? '<br><span style="opacity:.75;font-size:12px">' + esc(it.detail) + '</span>' : '') +
+        '</span>' +
+      '</label>';
+    }).join('');
+  }
+
+  // Hidden-input group — keeps the server payload shape identical
+  // while the visual section is folded away. Used for the two
+  // categories the Risk Typologies tree already covers topic-for-
+  // topic (adverse-media predicates, specialised TF/PF/tax checks)
+  // so the MLRO never sees the same concept twice on screen.
+  function widgetHiddenGroup(fieldName, items) {
+    return items.map(function (it) {
+      return '<input type="hidden" name="' + fieldName + '" value="' + esc(it.id) + '">';
+    }).join('');
+  }
+
+  // Compact typology checklist — 40+ topics rendered with group
+  // headers (ML / TF / PF / FRAUD / CORRUPTION / OC / SANCTIONS /
+  // COUNTRY / ESG). Kept dense so the MLRO can scan + toggle
+  // quickly without the list dominating the form.
+  function widgetTypologyGroup(items) {
+    var groups = {};
+    var groupOrder = [];
+    items.forEach(function (it) {
+      if (!groups[it.group]) { groups[it.group] = []; groupOrder.push(it.group); }
+      groups[it.group].push(it);
+    });
+    var groupLabels = {
+      ML: 'Money laundering', TF: 'Terrorist financing', PF: 'Proliferation',
+      FRAUD: 'Fraud', CORRUPTION: 'Bribery & corruption',
+      OC: 'Organised crime', SANCTIONS: 'Sanctions evasion',
+      ESG: 'ESG / human rights'
+    };
+    return groupOrder.map(function (g) {
+      return '<div class="mv-field" style="grid-column: 1 / -1">' +
+        '<div class="mv-field-label" style="margin-top:4px;opacity:.8">' + esc(groupLabels[g] || g) + '</div>' +
+        '<div style="display:flex;flex-wrap:wrap;gap:6px">' +
+          groups[g].map(function (it) {
+            return '<label class="mv-chip" style="display:inline-flex;align-items:center;gap:4px;padding:3px 8px;border:1px solid var(--border,#555);border-radius:12px;font-size:12px;cursor:pointer" title="' + esc(it.citation) + '">' +
+              '<input type="checkbox" name="risk_typologies" value="' + esc(it.id) + '" checked style="margin:0">' +
+              '<span>' + esc(it.label) + '</span>' +
+            '</label>';
+          }).join('') +
+        '</div>' +
+      '</div>';
+    }).join('');
+  }
   // Allow-list URL sanitiser for href attributes. esc() covers HTML
   // escaping but does NOT filter javascript:, data:, vbscript: and other
   // script-bearing protocols. Only permit http(s), mailto, and relative
@@ -2478,64 +2544,14 @@
       return Array.isArray(r.special_flags) && r.special_flags.length;
     }).length;
 
-    function checkboxGroup(fieldName, items) {
-      return items.map(function (it) {
-        return '<label class="mv-check" style="align-items:flex-start;line-height:1.45">' +
-          '<input type="checkbox" name="' + fieldName + '" value="' + esc(it.id) + '" checked>' +
-          '<span>' +
-            '<strong>' + esc(it.label) + '</strong>' +
-            (it.citation ? '<br><em style="opacity:.65;font-size:11px;font-style:normal">' + esc(it.citation) + '</em>' : '') +
-            (it.detail ? '<br><span style="opacity:.75;font-size:12px">' + esc(it.detail) + '</span>' : '') +
-          '</span>' +
-        '</label>';
-      }).join('');
-    }
-    function specialGroup(items) {
-      return checkboxGroup('special_screens', items);
-    }
-
-    // Hidden-input group — keeps the server payload shape identical while
-    // the visual section is folded away. Used for the two categories the
-    // Risk Typologies tree already covers topic-for-topic (adverse-media
-    // predicates, specialised TF/PF/tax checks) so the MLRO never sees
-    // the same concept twice on screen.
-    function hiddenGroup(fieldName, items) {
-      return items.map(function (it) {
-        return '<input type="hidden" name="' + fieldName + '" value="' + esc(it.id) + '">';
-      }).join('');
-    }
-
-    // Compact typology checklist — 40+ topics rendered with group
-    // headers (ML / TF / PF / FRAUD / CORRUPTION / OC / SANCTIONS /
-    // COUNTRY / ESG). Kept dense so the MLRO can scan + toggle quickly
-    // without the list dominating the form.
-    function typologyGroup(items) {
-      var groups = {};
-      var groupOrder = [];
-      items.forEach(function (it) {
-        if (!groups[it.group]) { groups[it.group] = []; groupOrder.push(it.group); }
-        groups[it.group].push(it);
-      });
-      var groupLabels = {
-        ML: 'Money laundering', TF: 'Terrorist financing', PF: 'Proliferation',
-        FRAUD: 'Fraud', CORRUPTION: 'Bribery & corruption',
-        OC: 'Organised crime', SANCTIONS: 'Sanctions evasion',
-        ESG: 'ESG / human rights'
-      };
-      return groupOrder.map(function (g) {
-        return '<div class="mv-field" style="grid-column: 1 / -1">' +
-          '<div class="mv-field-label" style="margin-top:4px;opacity:.8">' + esc(groupLabels[g] || g) + '</div>' +
-          '<div style="display:flex;flex-wrap:wrap;gap:6px">' +
-            groups[g].map(function (it) {
-              return '<label class="mv-chip" style="display:inline-flex;align-items:center;gap:4px;padding:3px 8px;border:1px solid var(--border,#555);border-radius:12px;font-size:12px;cursor:pointer" title="' + esc(it.citation) + '">' +
-                '<input type="checkbox" name="risk_typologies" value="' + esc(it.id) + '" checked style="margin:0">' +
-                '<span>' + esc(it.label) + '</span>' +
-              '</label>';
-            }).join('') +
-          '</div>' +
-        '</div>';
-      }).join('');
-    }
+    // Widget helpers (checkboxGroup / hiddenGroup / typologyGroup)
+    // are hoisted to module scope — see widget*Group functions near
+    // the top of the file. This function keeps thin aliases so every
+    // call site below reads the same way it always has.
+    var checkboxGroup = widgetCheckboxGroup;
+    function specialGroup(items) { return widgetCheckboxGroup('special_screens', items); }
+    var hiddenGroup = widgetHiddenGroup;
+    var typologyGroup = widgetTypologyGroup;
 
     host.innerHTML = [
       head('Subject Screening',


### PR DESCRIPTION
## What this does

Follow-up to the deep-review architecture agent, which flagged `screening-command-modules.js::renderSubjectScreening()` at 748 lines as a refactor candidate. This PR takes the **safe, mechanical slice**: lift the three inlined widget helpers — `checkboxGroup`, `hiddenGroup`, `typologyGroup` — to module scope. Each one already had zero closure dependencies (they only call `esc()`, which is already module-scope).

`renderSubjectScreening` goes from **748 → 696 lines**. The three helpers become reusable across the rest of the module without being re-declared on every render. Every call site below stays identical via `var checkboxGroup = widgetCheckboxGroup;` aliases — **no renames, no behavioural change, no HTML output change**.

## Intentionally not changed

- `mountIntelligenceDrawer()` (517 lines) left alone. Its inner helpers are entangled with drawer DOM closure state — not mechanically safe to hoist without browser testing. Separate PR.
- No HTML output changes. No event dispatcher changes. No storage key changes. No new imports.
- `screening-command-modules.js` is browser-side (loaded via `<script>` from `index.html` / `screening-command.html`), so `vitest` does not exercise it.

## Why draft (not auto-merge)

This file is the live Screening Command surface MLROs use every day. Even a behaviour-preserving refactor wants browser verification before shipping. CLAUDE.md §10 puts any live-UI edit behind four-eyes.

## Verified locally

- `node -c screening-command-modules.js` → syntax OK
- `wc -l` — 4440 → 4456 (+16: 68 lines lifted to module scope with docs; 52 lines removed from the outer function; 8 alias lines added)
- `renderSubjectScreening` body: 748 → 696 lines
- `vitest run` (full suite) → 4889/4889 unchanged (file is browser-only)

## Regulatory basis

- FDL No.(10)/2025 Art.20-21 — MLRO situational awareness depends on stable form payloads; generated HTML is byte-identical (same attribute order, same escape calls, same iteration order on group labels)
- CLAUDE.md §7 Context Budget Rules — trimming lines from this file makes future review cheaper

## Test plan (browser, required before merge)

- [ ] Hard-refresh `/screening-command` (Cmd+Shift+R) to bust cached JS
- [ ] Click **+ New screening** → confirm full form renders (sanctions lists, adverse-media categories, PEP scopes, country-risk lists, associate dimensions, risk typologies grouped ML/TF/PF/FRAUD/CORRUPTION/OC/SANCTIONS/ESG, specialised checks)
- [ ] Tick checkboxes across each group → confirm `name` attributes match pre-refactor payload (especially `special_screens` + `risk_typologies`)
- [ ] Submit against a dev deploy → confirm `screening-run.mts` receives the same JSON body shape

https://claude.ai/code/session_01YFZRT4C7sy1GGrDXycF78r