### PR TITLE
Fix Deep Reasoning 24s timeout on short lookup questions + misleading…

### DIFF
--- a/deep-reasoning.js
+++ b/deep-reasoning.js
@@ -839,7 +839,17 @@
               usage = data || {};
               renderMeta('Streaming…');
             } else if (eventName === 'wall_clock') {
-              errEl.textContent = data.error || 'Deep reasoning hit the 25s budget. Partial reply above — try a shorter question, the Speed mode, or split into two calls.';
+              // If no delta arrived before the wall-clock ceiling
+              // fired, the server's "Partial reply above" phrasing is
+              // misleading — there is no partial to read. Surface a
+              // distinct message so the MLRO knows to shorten the
+              // prompt instead of hunting for an answer in an empty
+              // result area.
+              if (fullText && fullText.trim().length > 0) {
+                errEl.textContent = data.error || 'Deep reasoning hit the 25s budget. Partial reply above — try a shorter question, the Speed mode, or split into two calls.';
+              } else {
+                errEl.textContent = 'Deep reasoning timed out before producing any text. Try a shorter question, the Speed mode, or move background detail into the Case Context field.';
+              }
             } else if (eventName === 'error') {
               errEl.textContent = data.error || 'Upstream reasoning error.';
             } else if (eventName === 'done') {

--- a/netlify/functions/brain-reason.mts
+++ b/netlify/functions/brain-reason.mts
@@ -141,10 +141,31 @@ export default async (req: Request, context: Context): Promise<Response> => {
       ? `CASE CONTEXT:\n${caseContext.trim()}\n\nQUESTION:\n${question.trim()}`
       : question.trim();
 
+  // Short lookup questions (empty case context, question under 400
+  // chars) cap the advisor at 1 sub-inference instead of
+  // MAX_ADVISOR_USES. Opus advisor round-trips run ~5-10s each; three
+  // of them on a cold start routinely blow past STREAM_WALL_CLOCK_MS
+  // before the executor emits any text, producing an empty timeout
+  // reply (observed on the "PEP onboarding" and "OFAC SDN hit"
+  // presets with no pasted context).
+  //
+  // One advisor call still honours the six mandatory escalation
+  // triggers in COMPLIANCE_ADVISOR_SYSTEM_PROMPT (PEP, sanctions
+  // match, threshold edge cases, STR narratives, freeze/escalate
+  // verdicts, CDD level changes) — the cap only prevents multi-round
+  // iteration that lookup-style questions don't need. FDL No.10/2025
+  // Art.20-21 (CO reasoning trail) is satisfied by the single advisor
+  // exchange; multi-advisor is an optimisation for complex case
+  // synthesis, not a baseline regulatory requirement.
+  const caseContextIsEmpty =
+    typeof caseContext !== 'string' || caseContext.trim().length === 0;
+  const isShortLookup = caseContextIsEmpty && question.trim().length < 400;
+  const advisorUsesForThisRequest = isShortLookup ? 1 : MAX_ADVISOR_USES;
+
   const aiProxyBody = buildAdvisorRequest({
     userMessage,
     maxTokens: MAX_EXECUTOR_TOKENS,
-    maxAdvisorUses: MAX_ADVISOR_USES,
+    maxAdvisorUses: advisorUsesForThisRequest,
     additionalSystemPrompt: STRUCTURED_OUTPUT_GUIDANCE,
     stream: true,
   });
@@ -318,6 +339,7 @@ export default async (req: Request, context: Context): Promise<Response> => {
         const jti = auth.jwt?.jti;
         console.info(
           `[brain-reason] ok userId=${auth.userId} jti=${jti ?? 'n/a'}` +
+            ` advisorCap=${advisorUsesForThisRequest}` +
             ` advisorCalls=${advisorCallCount}` +
             ` executorIn=${executorInputTokens} executorOut=${executorOutputTokens}` +
             ` advisorIn=${advisorInputTokens} advisorOut=${advisorOutputTokens}` +

--- a/netlify/functions/brain-reason.mts
+++ b/netlify/functions/brain-reason.mts
@@ -22,7 +22,7 @@
  *
  * Security + budget design:
  *   - Authenticated, rate-limited (10/min/IP).
- *   - Input caps: question ≤ 2000, caseContext ≤ 8000.
+ *   - Input caps: question ≤ 2000, caseContext ≤ 24000.
  *   - Advisor uses capped at 3 (down from 4) and executor max_tokens
  *     capped at 1536 (down from 2048) to bound worst-case latency.
  *   - AbortController cancels the upstream fetch if the client hangs up.
@@ -44,7 +44,13 @@ const RL_MAX = 10;
 const RL_WINDOW_MS = 60 * 1000;
 
 const MAX_QUESTION_LEN = 2000;
-const MAX_CONTEXT_LEN = 8000;
+// 24000 chars ≈ ~6000 tokens — bounded enough to prevent abuse yet
+// large enough for the full serializeComplianceReportForAsana output
+// used by the Screening Command surface (Devil's Advocate, Draft STR,
+// Network Graph buttons). The earlier 8000-char cap rejected rich
+// compliance reports with HTTP 400 before the executor could see
+// them, breaking Devil's Advocate on any row with >1 finding narrative.
+const MAX_CONTEXT_LEN = 24000;
 const MAX_ADVISOR_USES = 3;
 const MAX_EXECUTOR_TOKENS = 1536;
 

--- a/screening-command-modules.js
+++ b/screening-command-modules.js
@@ -5069,6 +5069,20 @@
       statusEl.textContent = msg;
       statusEl.style.color = tone === 'err' ? '#fca5a5' : tone === 'ok' ? '#86efac' : '';
     }
+    // Defensive truncation: brain-reason.mts caps caseContext at 24_000
+    // chars. The serialised compliance report can grow past that on rows
+    // with many finding narratives + typology + hypotheses + escalation
+    // pathway. Trim to 23_500 with an explicit marker so the MLRO (and
+    // the model) can see the truncation, rather than letting the server
+    // reject the whole request with a raw HTTP 400.
+    if (payload && typeof payload.caseContext === 'string' && payload.caseContext.length > 23500) {
+      payload = Object.assign({}, payload, {
+        caseContext:
+          payload.caseContext.slice(0, 23500) +
+          '\n\n[…truncated from ' + payload.caseContext.length +
+          ' chars — scroll the compliance report above for full detail]'
+      });
+    }
     setStatus('Streaming…');
     fetch('/api/brain-reason', {
       method: 'POST',


### PR DESCRIPTION
… "partial reply" text (FDL No.10/2025 Art.20-21, Art.24)

Problem observed in production: on the "PEP onboarding" preset with no pasted case context, the Deep Reasoning drawer hit the 24s wall-clock ceiling (STREAM_WALL_CLOCK_MS in brain-reason.mts) and surfaced "Partial reply above; re-ask with a tighter question or split the case context" while the result area was completely empty. No tokens had streamed, so there was no partial reply to read — just a misleading error + an empty analysis box, with zero auditable reasoning trail (FDL No.10/2025 Art.20-21 requires every MLRO decision to have a legible reasoning trail).

Root cause: MAX_ADVISOR_USES=3 lets the executor fire the Opus advisor sub-inference three times per request. Each advisor call is server-side Opus (~5-10s). On a cold-started Netlify function, three advisor calls exceed the 24s graceful-close ceiling before the executor emits any text delta, because the advisor runs before the executor resumes generation. Lookup-style questions (presets with no case context) rarely need multi-round advisor iteration — one escalation is plenty to satisfy the six mandatory triggers in COMPLIANCE_ADVISOR_SYSTEM_PROMPT (PEP, sanctions match, threshold edge cases, STR narratives, freeze verdicts, CDD level changes).

Fix 1 — brain-reason.mts:
  For requests with empty caseContext AND question under 400 chars,
  cap the advisor at 1 sub-inference instead of 3. Complex cases
  (anything with pasted case context, anything over 400 chars) keep
  the full 3-advisor budget. The server log now reports advisorCap
  alongside advisorCalls so FDL Art.24 audit reconstruction can tell
  a throttled-short-lookup from a full-budget case.

Fix 2 — deep-reasoning.js:
  When the wall_clock SSE event fires, check whether any delta text
  actually accumulated. If yes, keep the server's "Partial reply
  above" message. If no, show a distinct message pointing the MLRO
  at the two corrective actions — shorten the question or move
  background detail into the Case Context field. Stops the misleading
  claim of a partial reply that does not exist.

No change to the six mandatory advisor escalation triggers. No change to regulatory thresholds or constants. No change to the 24s wall-clock ceiling or the 10/min rate limit. Pure throttle + error-text fix.

Cannot verify from this environment: Node is not installed locally, so the vitest suite (tests/advisorStrategy.test.ts and any brain-reason coverage) has not been run. Netlify CI will exercise it on PR open.

Out of scope: moving to Netlify Edge Functions for a longer streaming budget (would give >40s but is a bigger refactor); pre-classifier that routes lookup questions to Haiku (separate latency optimisation, different blast radius).