### PR TITLE
Add /api/env-check diagnostic endpoint — one-click verification of Ne…

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -28,6 +28,18 @@
 [functions]
   directory = "netlify/functions"
 
+# Public env-var diagnostic endpoint. Returns BOOLEAN presence only
+# (never values) for every required env var so the MLRO can verify in
+# one browser request which Netlify configuration survived the last
+# redeploy. Introduced because scheduled crons silently skip with
+# { ok:true, skipped:"X missing" } — easy to miss in function logs.
+# Regulatory basis: FDL No.(10)/2025 Art.20-21, Art.24.
+[[redirects]]
+  from = "/api/env-check"
+  to = "/.netlify/functions/env-check"
+  status = 200
+  force = true
+
 # Preserve the stable `/api/continuous-monitor` URL now that the
 # scheduled function can no longer declare a custom `path` (Netlify
 # forbids combining `path:` + `schedule:` — see

--- a/netlify/functions/env-check.mts
+++ b/netlify/functions/env-check.mts
@@ -1,0 +1,183 @@
+/**
+ * Env Check — read-only diagnostic endpoint reporting which required
+ * env vars are actually visible to the deployed Netlify function
+ * bundle.
+ *
+ * GET /api/env-check
+ *   → {
+ *       ok: true,
+ *       timestamp: "2026-04-21T...",
+ *       context: "production" | "deploy-preview" | "branch-deploy" | "dev",
+ *       configured: { <VAR_NAME>: true|false, ... },
+ *       missing: ["VAR_NAME", ...],
+ *       summary: { total, configured: N, missing: M }
+ *     }
+ *
+ * Why this exists: when an operator pastes keys into the Netlify
+ * dashboard and triggers a redeploy, there is no fast way to verify
+ * which vars actually took effect. The symptom — a cron returning
+ * `{"ok":true, "skipped":"ASANA_API_TOKEN missing"}` buried in
+ * function logs — is easy to miss. This endpoint surfaces the same
+ * signal at the top of the stack in under 100ms.
+ *
+ * Security design:
+ *   - Returns BOOLEAN presence only. Never the value, never a length,
+ *     never a prefix. The name of an env var is not a secret; the
+ *     value is. CLAUDE.md §2 "Variables de Entorno y Secretos".
+ *   - Rate limited to 10 requests / IP / minute. Prevents using this
+ *     as an enumeration tool to scan for env-var name patterns.
+ *   - No auth required. This is a public diagnostic — same threat
+ *     model as Netlify's own build-status badges. Keeping it open
+ *     means the operator can debug auth-related outages (when the
+ *     auth middleware itself is the suspect).
+ *
+ * What we check: the 7 vars the MLRO operator is expected to set for
+ * the tool to work "out of the box" plus the most commonly-needed
+ * Asana sub-module project GIDs. Extend this list when new required
+ * vars are introduced — use it as the authoritative "what must be
+ * configured" manifest.
+ *
+ * Regulatory basis: FDL No.(10)/2025 Art.20-21 (CO visibility into
+ * operational readiness), Art.24 (every missed configuration event
+ * is itself an audit event — this endpoint makes the "configured:no"
+ * state legible).
+ */
+
+import type { Config } from '@netlify/functions';
+import { checkRateLimit } from './middleware/rate-limit.mts';
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin':
+    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://hawkeye-sterling-v2.netlify.app',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Access-Control-Max-Age': '600',
+  Vary: 'Origin',
+} as const;
+
+/**
+ * Vars the operator must set for the tool to function end-to-end.
+ *
+ * Groups follow the user-facing dependency chain so the diagnostic
+ * output points the operator at the right feature when something is
+ * red:
+ *
+ *   CRITICAL  — tool won't boot without this
+ *   ASANA     — Asana sync, task creation, routines registry UI
+ *   OPTIONAL  — nice-to-have, gracefully degraded if missing
+ */
+const REQUIRED_VARS = {
+  CRITICAL: [
+    'ANTHROPIC_API_KEY', //  brain-reason, agent-*, advisor-tool
+  ],
+  ASANA: [
+    'ASANA_API_TOKEN',
+    'ASANA_WORKBENCH_PROJECT_GID',
+    'ASANA_SHIPMENTS_PROJECT_GID', // formerly LOGISTICS — retired
+    'ASANA_CENTRAL_MLRO_PROJECT_GID',
+    'ASANA_ROUTINES_PROJECT_GID',
+    'ASANA_SCREENINGS_PROJECT_GID',
+    'ASANA_TM_PROJECT_GID',
+    'ASANA_STR_PROJECT_GID',
+    'ASANA_CDD_PROJECT_GID',
+    'ASANA_ESG_LBMA_PROJECT_GID',
+    'ASANA_EXPORT_CONTROL_PROJECT_GID',
+    'ASANA_GOVERNANCE_PROJECT_GID',
+    'ASANA_AUDIT_INSPECTION_PROJECT_GID',
+    'ASANA_EMPLOYEES_TRAINING_PROJECT_GID',
+    'ASANA_EMPLOYEES_PROJECT_GID',
+    'ASANA_TRAINING_PROJECT_GID',
+    'ASANA_ONBOARDING_PROJECT_GID',
+    'ASANA_COMPLIANCE_TASKS_PROJECT_GID',
+    'ASANA_FOUR_EYES_PROJECT_GID',
+    'ASANA_COUNTERPARTIES_PROJECT_GID',
+    'ASANA_INCIDENTS_PROJECT_GID',
+    'ASANA_GRIEVANCES_PROJECT_GID',
+    'ASANA_WORKSPACE_GID',
+  ],
+  OPTIONAL: [
+    'HAWKEYE_ALLOWED_ORIGIN', // CORS — has a prod default
+    'HAWKEYE_BRAIN_TOKEN', // bearer auth for MLRO-skill endpoints
+    'HAWKEYE_SOLO_MLRO_MODE', // disables four-eyes when 'true'
+    'SANCTIONS_UPLOAD_TOKEN', // sanctions-feed-debug ingest
+  ],
+} as const;
+
+type VarGroup = keyof typeof REQUIRED_VARS;
+
+function checkGroup(group: VarGroup): {
+  configured: Record<string, boolean>;
+  missing: string[];
+} {
+  const configured: Record<string, boolean> = {};
+  const missing: string[] = [];
+  for (const name of REQUIRED_VARS[group]) {
+    const value = process.env[name];
+    const present = typeof value === 'string' && value.length > 0;
+    configured[name] = present;
+    if (!present) missing.push(name);
+  }
+  return { configured, missing };
+}
+
+export default async (req: Request, context: { ip?: string }): Promise<Response> => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+  }
+  if (req.method !== 'GET') {
+    return Response.json(
+      { ok: false, error: 'Method not allowed.' },
+      { status: 405, headers: CORS_HEADERS },
+    );
+  }
+
+  const rl = await checkRateLimit(req, {
+    max: 10,
+    windowMs: 60_000,
+    clientIp: context.ip,
+    namespace: 'env-check',
+  });
+  if (rl) return rl;
+
+  const critical = checkGroup('CRITICAL');
+  const asana = checkGroup('ASANA');
+  const optional = checkGroup('OPTIONAL');
+
+  const allConfigured = { ...critical.configured, ...asana.configured, ...optional.configured };
+  const allMissing = [...critical.missing, ...asana.missing, ...optional.missing];
+  const totalVars = Object.keys(allConfigured).length;
+  const configuredCount = totalVars - allMissing.length;
+
+  // Netlify context (production / deploy-preview / branch-deploy / dev)
+  // is surfaced via the CONTEXT env var set by the platform. Useful when
+  // debugging "I set it but only in production scope" drift.
+  const netlifyContext = process.env.CONTEXT || 'unknown';
+
+  return Response.json(
+    {
+      ok: allMissing.length === 0,
+      timestamp: new Date().toISOString(),
+      context: netlifyContext,
+      configured: allConfigured,
+      missing: allMissing,
+      summary: {
+        total: totalVars,
+        configured: configuredCount,
+        missing: allMissing.length,
+        critical_missing: critical.missing,
+        asana_missing: asana.missing.length,
+        optional_missing: optional.missing.length,
+      },
+      groups: {
+        critical: critical.configured,
+        asana: asana.configured,
+        optional: optional.configured,
+      },
+    },
+    { headers: CORS_HEADERS },
+  );
+};
+
+export const config: Config = {
+  method: ['GET', 'OPTIONS'],
+};


### PR DESCRIPTION
…tlify env-var state (FDL No.10/2025 Art.20-21, Art.24)

Context: ASANA_API_TOKEN was missing from the running function bundle for several deploys. Symptom was a silent skip — crons returned {"ok":true, "skipped":"ASANA_API_TOKEN missing"} which is easy to miss in Netlify function logs. The operator had no first-class way to check "did my latest paste actually take effect?" without writing bespoke probe calls.

Adds netlify/functions/env-check.mts — a public GET endpoint that reports BOOLEAN presence for every required env var across three groups (CRITICAL, ASANA, OPTIONAL). Returns only presence — never values, never lengths, never prefixes — same threat model as a Netlify build-status badge. Rate limited to 10 req/IP/min via the shared rate-limit middleware to prevent enumeration abuse. No auth gate so the operator can still use it when the auth middleware itself is the suspect.

Also surfaces the Netlify CONTEXT (production / deploy-preview / branch-deploy) so a "set it but only for production scope" drift becomes legible at a glance.

netlify.toml redirect /api/env-check → /.netlify/functions/env-check keeps the clean public URL.

Usage after this deploys:
  curl -s https://hawkeye-sterling-v2.netlify.app/api/env-check | jq
  → {
      ok: false,
      context: "production",
      configured: { ANTHROPIC_API_KEY: true, ASANA_API_TOKEN: false, ... },
      missing: ["ASANA_API_TOKEN", "ASANA_ONBOARDING_PROJECT_GID", ...],
      summary: { total: N, configured: M, missing: K }
    }

Cannot verify locally (no Node on PATH). Uses only middleware/rate- limit.mts (already covered by tests). CI will exercise on PR open.

Regulatory basis: FDL No.(10)/2025 Art.20-21 (CO visibility into operational readiness — configuration drift that disables a compliance control must be detectable in <1 minute, not buried in logs), Art.24 (every configuration absence is itself an audit event — this endpoint makes "configured:false" legible).