### PR TITLE
Fix env-check.mts Context type — use @netlify/functions Context inste…

### DIFF
--- a/netlify/functions/env-check.mts
+++ b/netlify/functions/env-check.mts
@@ -43,7 +43,7 @@
  * state legible).
  */
 
-import type { Config } from '@netlify/functions';
+import type { Config, Context } from '@netlify/functions';
 import { checkRateLimit } from './middleware/rate-limit.mts';
 
 const CORS_HEADERS = {
@@ -120,7 +120,7 @@ function checkGroup(group: VarGroup): {
   return { configured, missing };
 }
 
-export default async (req: Request, context: { ip?: string }): Promise<Response> => {
+export default async (req: Request, context: Context): Promise<Response> => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { status: 204, headers: CORS_HEADERS });
   }


### PR DESCRIPTION
…ad of loose ad-hoc shape (follow-up to #435)

PR #435 deploy failed on Netlify's esbuild step. Most likely cause: the second-arg type was declared as { ip?: string } rather than the Context type exported by @netlify/functions. Other functions in this tree (asana-config.mts, brain-reason.mts, etc.) all use Context; the ad-hoc shape I shipped triggers a TypeScript strict-mode error when esbuild compiles the function bundle.

No runtime change — structurally identical (Context has an optional ip field). Pure type import correction.

If this doesn't fix the deploy, the next candidates are:
  - checkRateLimit call signature drift in middleware/rate-limit.mts
  - a build-time environment issue unrelated to this file
  - Netlify function bundle-size overflow

Please share the actual deploy log if this doesn't green up — I've been diagnosing blind.

Regulatory basis: FDL No.(10)/2025 Art.20-21 (restoring the diagnostic endpoint added in #435 so CO visibility into env-var state is actually available), Art.24.