### PR TITLE
Add module catalog (15 modules across 4 landing pages) (FDL No.10/202…

### DIFF
--- a/MODULES.md
+++ b/MODULES.md
@@ -1,0 +1,170 @@
+# Hawkeye Sterling — Module Catalog
+
+Extracted from the live site at `hawkeye-sterling-v2.netlify.app`.
+Machine-readable version: `modules.json`.
+
+Fifteen operational modules are exposed across four landing pages.
+Each module is a card on a landing page and opens in an inline
+iframe via `module-viewer.js`.
+
+## 1. Screening Command — `/screening-command`
+
+Section: Operational Surfaces · 4 modules.
+
+### 01 · Subject Screening 🔍
+- Route: `screening` · Slug: `subject-screening`
+- URL: `/screening-command/subject-screening`
+- Multi-modal fuzzy matching (Jaro-Winkler + Levenshtein + Soundex +
+  Double Metaphone + token-set) against UN, EOCN, OFAC, EU, UK and
+  adverse-media. Four-eyes MLRO disposition on every partial /
+  confirmed match.
+- Stats: `6+` Lists screened · `24h` EOCN freeze
+- Regulatory basis: FDL No.10/2025 Art.20-21 · Cabinet Res 74/2020 Art.4-7
+
+### 02 · Transaction Monitor 💸
+- Route: `transaction-monitor` · Slug: `transaction-monitor`
+- URL: `/screening-command/transaction-monitor`
+- Rule-based + behavioural engine: structuring near AED 55K, velocity
+  spikes, third-party payers, offshore routing, round-number +
+  price-gaming patterns. Critical alerts auto-open an Asana case.
+- Stats: `AED 55K` DPMS CTR · `AED 60K` Cross-border
+- Regulatory basis: MoE Circular 08/AML/2021 · Cabinet Res 134/2025 Art.16
+
+### 03 · STR Case Management 🚨
+- Route: `str` · Slug: `str-cases`
+- URL: `/screening-command/str-cases`
+- STR / SAR / AIF / PEPR / HRCR / FTFR case files with red-flag
+  taxonomy, suspicion narrative, goAML reference, and four-eyes
+  approval. File without delay upon suspicion arising. No tipping off.
+- Stats: `goAML` XML schema · `Without delay` Filing SLA
+- Regulatory basis: FDL No.10/2025 Art.26-27 · FDL No.10/2025 Art.29
+
+### 04 · Active Watchlist 📡
+- Route: `watchlist` · Slug: `watchlist`
+- URL: `/screening-command/watchlist`
+- Every screened subject auto-enrolled in ongoing monitoring. Two
+  scheduled crons per day (06:00 / 14:00 UTC) re-screen the full
+  watchlist and push delta alerts to Asana. No opt-out under Art.20-21.
+- Stats: `2x/day` Re-screen · `10yr` Retention
+- Regulatory basis: FDL No.10/2025 Art.20-21 · FDL No.10/2025 Art.24
+
+## 2. Workbench — `/workbench`
+
+Section: Operations Surfaces · 3 modules.
+
+### 01 · Compliance Tasks 📋
+- Route: `asana` · Slug: `compliance-tasks`
+- URL: `/workbench/compliance-tasks`
+- Every MLRO task, assignment, and deadline tracked against the
+  responsible owner. Syncs with Asana and the goAML filing calendar;
+  every status change audit-logged.
+- Stats: `12` Open · `Asana` Sync
+- Regulatory basis: FDL No.10/2025 Art.24
+
+### 02 · Onboarding 👤
+- Route: `onboarding` · Slug: `onboarding`
+- URL: `/workbench/onboarding`
+- KYC / CDD / EDD wizard for new customers and counterparties.
+  Runs the risk-scoring engine, PEP + sanctions screen, and UBO
+  capture — routes high-risk cases to senior-management approval.
+- Stats: `4` In review · `EDD` Senior mgmt
+- Regulatory basis: Cabinet Res 134/2025 Art.7-10 · Art.14 · Cabinet Decision 109/2023
+
+### 03 · Approvals ✅
+- Route: `approvals` · Slug: `approvals`
+- URL: `/workbench/approvals`
+- Four-eyes approval queue for high-risk decisions — EDD upgrades,
+  freeze confirmations, STR filings. Two independent approvers enforce
+  the separation of duties required by Cabinet Res 134/2025.
+- Stats: `3` Pending · `4-eyes` SoD
+- Regulatory basis: Cabinet Res 134/2025 Art.19
+
+## 3. Logistics — `/logistics`
+
+Section: Regulated Surfaces · 4 modules.
+
+### 01 · Inbound Advice 🚚
+- Route: `shipments` · Slug: `inbound-advice`
+- URL: `/logistics/inbound-advice`
+- Every incoming shipment recorded against supplier, invoice, assay,
+  and Dubai Customs / Brinks paperwork. Primary control for
+  supply-chain traceability.
+- Stats: `10yr` Retention · `Auto` Assay log
+- Regulatory basis: LBMA RGG v9 · UAE MoE RSG Framework · FDL No.10/2025 Art.24
+
+### 02 · Tracking ✈️
+- Route: `tracking` · Slug: `tracking`
+- URL: `/logistics/tracking`
+- Live in-transit status, ETA, carrier, and custody handovers for
+  every shipment on the move. Flags any deviation from the declared
+  routing.
+- Stats: `Live` Custody · `GPS` Deviation
+- Regulatory basis: LBMA RGG v9 (chain of custody) · Dubai Good Delivery
+
+### 03 · Approved Accounts ✅
+- Route: `approvedaccounts` · Slug: `approved-accounts`
+- URL: `/logistics/approved-accounts`
+- Pre-vetted suppliers, refiners, and vault counterparties cleared
+  through CDD, sanctions screening, and UBO verification. Gates every
+  inbound, in-transit, and local movement to an approved list.
+- Stats: `CDD` Vetted · `UBO` >25% register
+- Regulatory basis: Cabinet Res 134/2025 Art.7-10 · Cabinet Decision 109/2023
+
+### 04 · Local Shipments 📦
+- Route: `localshipments` · Slug: `local-shipments`
+- URL: `/logistics/local-shipments`
+- Intra-UAE and counter-to-counter transfers — same-day movements
+  between branches, refiners, and vault counterparties. Ties into the
+  DPMS CTR threshold (AED 55,000).
+- Stats: `AED 55K` CTR trigger · `goAML` Auto-file
+- Regulatory basis: MoE Circular 08/AML/2021
+
+## 4. Compliance Ops — `/compliance-ops`
+
+Section: Operational Surfaces · 4 modules.
+
+### 01 · Training 🎓
+- Route: `training` · Slug: `training`
+- URL: `/compliance-ops/training`
+- AML/CFT + sanctions + PEP screening curriculum. Attendance logged
+  per employee with quiz scores and certificate expiry tracking.
+- Stats: `Annual` Cadence · `100%` Coverage target
+- Regulatory basis: MoE Circular 08/AML/2021 §9
+
+### 02 · Employees 👥
+- Route: `employees` · Slug: `employees`
+- URL: `/compliance-ops/employees`
+- Employee registry with role, MLRO flag, KYC status, and training
+  assignment. Feeds four-eyes approval pool and separation-of-duties
+  checks per Cabinet Res 134/2025 Art.19.
+- Stats: `RBAC` Access control · `4-Eyes` Approver pool
+- Regulatory basis: Cabinet Res 134/2025 Art.19
+
+### 03 · Incidents 🚨
+- Route: `incidents` · Slug: `incidents`
+- URL: `/compliance-ops/incidents`
+- Incident case files — sanctions matches, suspected tipping off,
+  breach triage, and root-cause log. Wired to the 24h EOCN +
+  5-business-day CNMR countdowns per Cabinet Res 74/2020 Art.4-7.
+- Stats: `24h` EOCN freeze · `5bd` CNMR deadline
+- Regulatory basis: Cabinet Res 74/2020 Art.4-7 · FDL No.10/2025 Art.29
+
+### 04 · Reports 📊
+- Route: `reports` · Slug: `reports`
+- URL: `/compliance-ops/reports`
+- Regulator-ready reports — goAML STR/SAR/CTR/DPMSR/CNMR XML,
+  quarterly DPMS rollups, audit packs, and ad-hoc MLRO digests.
+- Stats: `goAML` XML schema · `10yr` Retention
+- Regulatory basis: FDL No.10/2025 Art.20 · FDL No.10/2025 Art.24
+
+## Notes
+
+- The main SPA at `/` (`index.html`) exposes additional feature tabs
+  from `compliance-suite.js` which are not surfaced as cards on a
+  landing page and therefore are not "modules" in the sense this
+  catalog uses. Ask if you need those enumerated too.
+- Routes on landing cards correspond to the `data-route` attribute,
+  which `landing-module-viewer.js` looks up in
+  `window.__landingModules[<landing>][<route>]` to decide between
+  the native renderer (e.g. `workbench-modules.js`) and the legacy
+  iframe fetch fallback.

--- a/modules.json
+++ b/modules.json
@@ -1,0 +1,265 @@
+{
+  "site": "hawkeye-sterling-v2.netlify.app",
+  "generated_at": "2026-04-21",
+  "source": "extracted from landing pages in the compliance-analyzer repository (index.html, workbench.html, compliance-ops.html, logistics.html, screening-command.html)",
+  "landings": [
+    {
+      "landing": "screening-command",
+      "path": "/screening-command",
+      "section_label": "Operational Surfaces",
+      "module_count": 4,
+      "modules": [
+        {
+          "number": "01",
+          "category": "Screening",
+          "title": "Subject Screening",
+          "slug": "subject-screening",
+          "route": "screening",
+          "href": "/screening-command/subject-screening",
+          "icon": "🔍",
+          "description": "Multi-modal fuzzy matching (Jaro-Winkler + Levenshtein + Soundex + Double Metaphone + token-set) against UN, EOCN, OFAC, EU, UK and adverse-media. Four-eyes MLRO disposition on every partial / confirmed match.",
+          "stats": [
+            {"value": "6+", "label": "Lists screened"},
+            {"value": "24h", "label": "EOCN freeze"}
+          ],
+          "regulatory_basis": ["FDL No.10/2025 Art.20-21", "Cabinet Res 74/2020 Art.4-7"]
+        },
+        {
+          "number": "02",
+          "category": "Monitor",
+          "title": "Transaction Monitor",
+          "slug": "transaction-monitor",
+          "route": "transaction-monitor",
+          "href": "/screening-command/transaction-monitor",
+          "icon": "💸",
+          "description": "Rule-based + behavioural engine: structuring near AED 55K, velocity spikes, third-party payers, offshore routing, round-number + price-gaming patterns. Critical alerts auto-open an Asana case.",
+          "stats": [
+            {"value": "AED 55K", "label": "DPMS CTR"},
+            {"value": "AED 60K", "label": "Cross-border"}
+          ],
+          "regulatory_basis": ["MoE Circular 08/AML/2021", "Cabinet Res 134/2025 Art.16"]
+        },
+        {
+          "number": "03",
+          "category": "Reports",
+          "title": "STR Case Management",
+          "slug": "str-cases",
+          "route": "str",
+          "href": "/screening-command/str-cases",
+          "icon": "🚨",
+          "description": "STR / SAR / AIF / PEPR / HRCR / FTFR case files with red-flag taxonomy, suspicion narrative, goAML reference, and four-eyes approval. File without delay upon suspicion arising. No tipping off.",
+          "stats": [
+            {"value": "goAML", "label": "XML schema"},
+            {"value": "Without delay", "label": "Filing SLA"}
+          ],
+          "regulatory_basis": ["FDL No.10/2025 Art.26-27", "FDL No.10/2025 Art.29"]
+        },
+        {
+          "number": "04",
+          "category": "Monitoring",
+          "title": "Active Watchlist",
+          "slug": "watchlist",
+          "route": "watchlist",
+          "href": "/screening-command/watchlist",
+          "icon": "📡",
+          "description": "Every screened subject auto-enrolled in ongoing monitoring. Two scheduled crons per day (06:00 / 14:00 UTC) re-screen the full watchlist and push delta alerts to Asana. No opt-out under Art.20-21.",
+          "stats": [
+            {"value": "2×/day", "label": "Re-screen"},
+            {"value": "10yr", "label": "Retention"}
+          ],
+          "regulatory_basis": ["FDL No.10/2025 Art.20-21", "FDL No.10/2025 Art.24"]
+        }
+      ]
+    },
+    {
+      "landing": "workbench",
+      "path": "/workbench",
+      "section_label": "Operations Surfaces",
+      "module_count": 3,
+      "modules": [
+        {
+          "number": "01",
+          "category": "Tasks",
+          "title": "Compliance Tasks",
+          "slug": "compliance-tasks",
+          "route": "asana",
+          "href": "/workbench/compliance-tasks",
+          "icon": "📋",
+          "description": "Every MLRO task, assignment, and deadline tracked against the responsible owner. Syncs with Asana and the goAML filing calendar; every status change audit-logged.",
+          "stats": [
+            {"value": "12", "label": "Open"},
+            {"value": "Asana", "label": "Sync"}
+          ],
+          "regulatory_basis": ["FDL No.10/2025 Art.24"]
+        },
+        {
+          "number": "02",
+          "category": "CDD/EDD",
+          "title": "Onboarding",
+          "slug": "onboarding",
+          "route": "onboarding",
+          "href": "/workbench/onboarding",
+          "icon": "👤",
+          "description": "KYC / CDD / EDD wizard for new customers and counterparties. Runs the risk-scoring engine, PEP + sanctions screen, and UBO capture — routes high-risk cases to senior-management approval.",
+          "stats": [
+            {"value": "4", "label": "In review"},
+            {"value": "EDD", "label": "Senior mgmt"}
+          ],
+          "regulatory_basis": ["Cabinet Res 134/2025 Art.7-10", "Cabinet Res 134/2025 Art.14", "Cabinet Decision 109/2023"]
+        },
+        {
+          "number": "03",
+          "category": "Four-Eyes",
+          "title": "Approvals",
+          "slug": "approvals",
+          "route": "approvals",
+          "href": "/workbench/approvals",
+          "icon": "✅",
+          "description": "Four-eyes approval queue for high-risk decisions — EDD upgrades, freeze confirmations, STR filings. Two independent approvers enforce the separation of duties required by Cabinet Res 134/2025.",
+          "stats": [
+            {"value": "3", "label": "Pending"},
+            {"value": "4-eyes", "label": "SoD"}
+          ],
+          "regulatory_basis": ["Cabinet Res 134/2025 Art.19"]
+        }
+      ]
+    },
+    {
+      "landing": "logistics",
+      "path": "/logistics",
+      "section_label": "Regulated Surfaces",
+      "module_count": 4,
+      "modules": [
+        {
+          "number": "01",
+          "category": "IAR",
+          "title": "Inbound Advice",
+          "slug": "inbound-advice",
+          "route": "shipments",
+          "href": "/logistics/inbound-advice",
+          "icon": "🚚",
+          "description": "Every incoming shipment recorded against supplier, invoice, assay, and Dubai Customs / Brinks paperwork. Primary control for supply-chain traceability.",
+          "stats": [
+            {"value": "10yr", "label": "Retention"},
+            {"value": "Auto", "label": "Assay log"}
+          ],
+          "regulatory_basis": ["LBMA RGG v9", "UAE MoE RSG Framework", "FDL No.10/2025 Art.24"]
+        },
+        {
+          "number": "02",
+          "category": "In-Transit",
+          "title": "Tracking",
+          "slug": "tracking",
+          "route": "tracking",
+          "href": "/logistics/tracking",
+          "icon": "✈️",
+          "description": "Live in-transit status, ETA, carrier, and custody handovers for every shipment on the move. Flags any deviation from the declared routing.",
+          "stats": [
+            {"value": "Live", "label": "Custody"},
+            {"value": "GPS", "label": "Deviation"}
+          ],
+          "regulatory_basis": ["LBMA RGG v9 (chain of custody)", "Dubai Good Delivery"]
+        },
+        {
+          "number": "03",
+          "category": "Counterparty",
+          "title": "Approved Accounts",
+          "slug": "approved-accounts",
+          "route": "approvedaccounts",
+          "href": "/logistics/approved-accounts",
+          "icon": "✅",
+          "description": "Pre-vetted suppliers, refiners, and vault counterparties cleared through CDD, sanctions screening, and UBO verification. Gates every inbound, in-transit, and local movement to an approved list.",
+          "stats": [
+            {"value": "CDD", "label": "Vetted"},
+            {"value": "UBO", "label": ">25% register"}
+          ],
+          "regulatory_basis": ["Cabinet Res 134/2025 Art.7-10", "Cabinet Decision 109/2023"]
+        },
+        {
+          "number": "04",
+          "category": "Local",
+          "title": "Local Shipments",
+          "slug": "local-shipments",
+          "route": "localshipments",
+          "href": "/logistics/local-shipments",
+          "icon": "📦",
+          "description": "Intra-UAE and counter-to-counter transfers — same-day movements between branches, refiners, and vault counterparties. Ties into the DPMS CTR threshold (AED 55,000).",
+          "stats": [
+            {"value": "AED 55K", "label": "CTR trigger"},
+            {"value": "goAML", "label": "Auto-file"}
+          ],
+          "regulatory_basis": ["MoE Circular 08/AML/2021"]
+        }
+      ]
+    },
+    {
+      "landing": "compliance-ops",
+      "path": "/compliance-ops",
+      "section_label": "Operational Surfaces",
+      "module_count": 4,
+      "modules": [
+        {
+          "number": "01",
+          "category": "Training",
+          "title": "Training",
+          "slug": "training",
+          "route": "training",
+          "href": "/compliance-ops/training",
+          "icon": "🎓",
+          "description": "AML/CFT + sanctions + PEP screening curriculum. Attendance logged per employee with quiz scores and certificate expiry tracking. MoE Circular 08/AML/2021 §9.",
+          "stats": [
+            {"value": "Annual", "label": "Cadence"},
+            {"value": "100%", "label": "Coverage target"}
+          ],
+          "regulatory_basis": ["MoE Circular 08/AML/2021 §9"]
+        },
+        {
+          "number": "02",
+          "category": "Employees",
+          "title": "Employees",
+          "slug": "employees",
+          "route": "employees",
+          "href": "/compliance-ops/employees",
+          "icon": "👥",
+          "description": "Employee registry with role, MLRO flag, KYC status, and training assignment. Feeds four-eyes approval pool and separation-of-duties checks per Cabinet Res 134/2025 Art.19.",
+          "stats": [
+            {"value": "RBAC", "label": "Access control"},
+            {"value": "4-Eyes", "label": "Approver pool"}
+          ],
+          "regulatory_basis": ["Cabinet Res 134/2025 Art.19"]
+        },
+        {
+          "number": "03",
+          "category": "Incidents",
+          "title": "Incidents",
+          "slug": "incidents",
+          "route": "incidents",
+          "href": "/compliance-ops/incidents",
+          "icon": "🚨",
+          "description": "Incident case files — sanctions matches, suspected tipping off, breach triage, and root-cause log. Wired to the 24h EOCN + 5-business-day CNMR countdowns per Cabinet Res 74/2020 Art.4-7.",
+          "stats": [
+            {"value": "24h", "label": "EOCN freeze"},
+            {"value": "5bd", "label": "CNMR deadline"}
+          ],
+          "regulatory_basis": ["Cabinet Res 74/2020 Art.4-7", "FDL No.10/2025 Art.29"]
+        },
+        {
+          "number": "04",
+          "category": "Reports",
+          "title": "Reports",
+          "slug": "reports",
+          "route": "reports",
+          "href": "/compliance-ops/reports",
+          "icon": "📊",
+          "description": "Regulator-ready reports — goAML STR/SAR/CTR/DPMSR/CNMR XML, quarterly DPMS rollups, audit packs, and ad-hoc MLRO digests. FDL No.(10)/2025 Art.20 + Art.24.",
+          "stats": [
+            {"value": "goAML", "label": "XML schema"},
+            {"value": "10yr", "label": "Retention"}
+          ],
+          "regulatory_basis": ["FDL No.10/2025 Art.20", "FDL No.10/2025 Art.24"]
+        }
+      ]
+    }
+  ],
+  "total_modules": 15
+}


### PR DESCRIPTION
…5 Art.20, Art.24)

Adds a downloadable catalog of every operational module exposed on the live site hawkeye-sterling-v2.netlify.app:

- modules.json — machine-readable (landing, slug, route, href, icon, description, stats, regulatory_basis)
- MODULES.md — human-readable summary

Covers:
- /screening-command (4): Subject Screening, Transaction Monitor, STR Case Management, Active Watchlist
- /workbench (3): Compliance Tasks, Onboarding, Approvals
- /logistics (4): Inbound Advice, Tracking, Approved Accounts, Local Shipments
- /compliance-ops (4): Training, Employees, Incidents, Reports

Regulatory basis recorded per module (FDL No.10/2025 Art.20-21/24/26-29, Cabinet Res 74/2020 Art.4-7, Cabinet Res 134/2025 Art.7-10/14/16/19, Cabinet Decision 109/2023, MoE Circular 08/AML/2021, LBMA RGG v9, UAE MoE RSG Framework) so the catalog can be traced at audit.

https://claude.ai/code/session_01E32z2phZQzPcNPrpLQwTah