### PR TITLE
Fix Asana Send-to-Asana 400: drop unsupported string tags (FDL No.10/…

### DIFF
--- a/netlify/functions/asana-task-create.mts
+++ b/netlify/functions/asana-task-create.mts
@@ -269,16 +269,23 @@ export default async (req: Request, context: Context): Promise<Response> => {
       ? `[${surface.prefix}:${input.priority.toUpperCase()}] ${input.name}`
       : `[${surface.prefix}] ${input.name}`;
 
-  const tags = ['mlro-surface', input.source];
-  if (input.category) tags.push(input.category);
-  if (input.priority) tags.push(input.priority);
-
+  // Tags intentionally omitted. Asana's API requires numeric tag GIDs
+  // for each entry; we were previously passing string names
+  // ('mlro-surface', 'screening', 'compliance_edd', etc.) which Asana
+  // rejects with a 400 "Not a recognized ID" error. The same categorical
+  // info reaches the MLRO two other ways: (1) the surface prefix +
+  // priority embedded in the task title, and (2) the structured block
+  // in buildTaskNotes() which already includes source/category/priority
+  // as searchable text. Restoring real tags would require provisioning
+  // them in each Asana workspace and piping their GIDs through env
+  // vars — avoid that path until we actually need tag-based Asana
+  // views, because we JUST reduced env vars to fit the AWS Lambda
+  // 4 KB limit on the functions bundle.
   const result = await createAsanaTask({
     name: title,
     notes: buildTaskNotes(input, surface.projectName),
     projects: [projectGid],
     due_on: input.dueOn,
-    tags,
   });
 
   if (!result.ok) {


### PR DESCRIPTION
…2025 Art.24)

Send to Asana failed on every row with Asana API 400:
  tags: [0]: Not a recognized ID: mlro-surface
  tags: [1]: Not a recognized ID: screening
  tags: [2]: Not a recognized ID: compliance_edd

The handler was passing human-readable category strings as Asana task tags. Asana's /tasks endpoint requires each tag in the tags[] array to be a numeric Asana tag GID (e.g. "1203456789012345"), not a descriptive string. Every Send-to-Asana click therefore 400'd after 4 retry attempts.

Fix: drop the tags[] array entirely. The same categorical signal still reaches the MLRO through two unchanged channels:
  1. The task title prefix — "[surface:PRIORITY] name"
  2. buildTaskNotes() structured block, which already writes the source, category, priority and full compliance-report context into the task description (searchable in Asana's UI).

Restoring real tag support would require provisioning tags in each Asana workspace, capturing their GIDs, and piping them through env vars — avoided here because we just cut Netlify env vars down to fit the AWS Lambda 4 KB limit on the functions bundle (the same limit that was blocking every deploy). Re-adding a TAG_* family of env vars would reverse that work for a non-critical feature. If tag-based Asana views become needed, prefer one JSON env var (ASANA_TAG_GIDS='{"mlro_surface":"123","screening":"456"}') over individual per-tag vars.

Regulatory basis: FDL No.(10)/2025 Art.24 (10-year audit retention — Send-to-Asana is the primary MLRO hand-off for compliance findings; the action must succeed so the audit trail is persisted in Asana, not stuck in the browser).

Cannot verify locally (no node on PATH). Change is a simple property removal on an existing createAsanaTask call; no type signatures move. Netlify build + tests run on PR open.