### PR TITLE
PR-2/PR-3: Ongoing screening & LSEG World-Check One parity

### DIFF
--- a/compliance-suite.js
+++ b/compliance-suite.js
@@ -22,6 +22,33 @@ window.csFormatDateInput = function (el) {
   el.value = v;
 };
 
+// Display helper — pretty-print canonical entity types for MLRO-facing UI
+// and Asana sync output. Maps both the new canonical values
+// ('individual' / 'organisation' / 'unspecified') and the legacy strings
+// ('Individual' / 'Company' / 'legal_entity') to a single display form so
+// the screen never shows raw lowercase tokens to auditors.
+window.prettyEntityType = function (raw) {
+  if (raw === null || raw === undefined) return '—';
+  const s = String(raw).trim();
+  if (!s) return '—';
+  const canonical = s.toLowerCase().replace(/\s+/g, '_');
+  switch (canonical) {
+    case 'individual':
+      return 'Individual';
+    case 'organisation':
+    case 'organization':
+    case 'legal_entity':
+    case 'company':
+      return 'Organisation';
+    case 'unspecified':
+      return 'Unspecified';
+    default:
+      // Unknown value — pass through with a sentence-case tidy so the
+      // MLRO sees the original token but not a lower-case leak.
+      return s.charAt(0).toUpperCase() + s.slice(1);
+  }
+};
+
 (function (global) {
   'use strict';
 
@@ -2528,7 +2555,7 @@ window.csFormatDateInput = function (el) {
           const st = a.status || 'Pending';
           const col = st==='Approved'||st==='Completed' ? 'var(--green)' : st==='Rejected' ? 'var(--red)' : 'var(--amber)';
           const name = a.customerName||a.entityName||'—';
-          const type = a.customerType||a.entityType||'—';
+          const type = window.prettyEntityType(a.customerType||a.entityType);
           const risk = a.riskRating||'—';
           const date = a.createdAt ? new Date(a.createdAt).toLocaleDateString('en-GB') : '—';
           return '<div style="padding:10px 14px;border-radius:4px;border:1px solid var(--border);background:var(--surface2);margin-bottom:6px;display:flex;align-items:center;justify-content:space-between;gap:10px">'
@@ -2785,7 +2812,7 @@ window.csFormatDateInput = function (el) {
       const title = `[MGMT-APPROVAL] ${a.customerName||a.entityName||'Unknown'} — ${a.status||'Pending'}`;
       const notes = [
         `Customer: ${a.customerName||a.entityName||'—'}`,
-        `Type: ${a.customerType||a.entityType||'—'}`,
+        `Type: ${window.prettyEntityType(a.customerType||a.entityType)}`,
         `Risk Rating: ${a.riskRating||'—'}`,
         `Status: ${a.status||'Pending'}`,
         `Reviewed By: ${a.reviewedBy||a.approvedBy||'—'}`,
@@ -3288,7 +3315,11 @@ window.csFormatDateInput = function (el) {
           <div><span class="lbl" id="tfs2-dob-label">Date of Birth / Registration</span><input type="text" id="tfs2-dob" placeholder="dd/mm/yyyy" oninput="csFormatDateInput(this)" maxlength="10"/></div>
         </div>
         <div class="row" style="display:grid;grid-template-columns:1fr 1fr;gap:10px">
-          <div><span class="lbl">Alternate names / aliases</span><input id="tfs2-altnames" placeholder="Comma-separated. Up to 20."/></div>
+          <div>
+            <span class="lbl">Alternate names / aliases</span>
+            <input id="tfs2-altnames" placeholder="Comma-separated. Up to 20." oninput="if(typeof updateTfs2AltNamesWarning==='function')updateTfs2AltNamesWarning()"/>
+            <div id="tfs2-altnames-warn" hidden style="color:var(--amber,#f5a623);font-size:11px;margin-top:4px"></div>
+          </div>
           <div><span class="lbl" id="tfs2-pob-label">Place of birth</span><input id="tfs2-pob" placeholder="City, country"/></div>
         </div>
         <div class="row" style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:10px">
@@ -3506,7 +3537,12 @@ window.csFormatDateInput = function (el) {
   // metadata: count, next-run countdown, and a link to the Asana routines
   // board where the MLRO can read the per-subject detail.
   const TFS2_BANNER_DISMISS_KEY = 'hawkeye.ongoingBannerDismissed.session';
-  let tfs2BannerTimer = null;
+  const TFS2_BANNER_REFRESH_MS = 300000;      // Regular refresh — 5 min
+  const TFS2_BANNER_COUNTDOWN_MS = 60000;     // Countdown tick — 1 min
+  const TFS2_BANNER_RETRY_BACKOFF_MS = [2000, 4000, 8000, 16000]; // then give up
+  let tfs2BannerCountdownTimer = null;
+  let tfs2BannerRefreshTimer = null;
+  let tfs2BannerRetryTimer = null;
 
   function isTfs2BannerDismissedThisSession() {
     try { return sessionStorage.getItem(TFS2_BANNER_DISMISS_KEY) === '1'; }
@@ -3515,12 +3551,64 @@ window.csFormatDateInput = function (el) {
   function dismissTfs2BannerForSession() {
     try { sessionStorage.setItem(TFS2_BANNER_DISMISS_KEY, '1'); } catch (_e) { /* ignore */ }
   }
+  function clearTfs2BannerTimers() {
+    if (tfs2BannerCountdownTimer) { clearInterval(tfs2BannerCountdownTimer); tfs2BannerCountdownTimer = null; }
+    if (tfs2BannerRefreshTimer)   { clearInterval(tfs2BannerRefreshTimer);   tfs2BannerRefreshTimer   = null; }
+    if (tfs2BannerRetryTimer)     { clearTimeout(tfs2BannerRetryTimer);      tfs2BannerRetryTimer     = null; }
+  }
   global.suite2DismissOngoingBanner = function() {
     dismissTfs2BannerForSession();
     const banner = document.getElementById('tfs2-ongoing-banner');
     if (banner) banner.hidden = true;
-    if (tfs2BannerTimer) { clearInterval(tfs2BannerTimer); tfs2BannerTimer = null; }
+    clearTfs2BannerTimers();
   };
+
+  // PR-3 fix #1 — server-side opt-in sync. The live TFS2 form saves records
+  // to localStorage; this helper propagates the ongoing-screening flag to
+  // the backend opt-in store so the /api/ongoing-screening-status count
+  // is consistent across devices. Non-blocking: failures are logged to the
+  // console and do not abort the local save (the banner still shows the
+  // local count as a fallback). FDL Art.29-safe: only subject name +
+  // entity type + flag are sent, never hit details.
+  function readHawkeyeBearerToken() {
+    try {
+      return (
+        localStorage.getItem('hawkeye.watchlist.adminToken') ||
+        localStorage.getItem('hawkeye.brain.token') ||
+        ''
+      );
+    } catch (_e) { return ''; }
+  }
+  async function syncTfs2OptInToBackend(record) {
+    if (!record || !record.screenedName) return;
+    const token = readHawkeyeBearerToken();
+    if (!token) return; // Unauthenticated → local-only. User-visible no-op.
+    const body = {
+      subjectName: String(record.screenedName || '').slice(0, 200),
+      subjectId: record.id ? String(record.id).slice(0, 128) : undefined,
+      entityType: record.entityType || 'individual',
+      ongoingScreening: !!record.ongoingScreening,
+    };
+    try {
+      await fetch('/api/ongoing-screening-optin', {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer ' + token,
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+      // Nudge the banner to re-read the authoritative count right away
+      // rather than waiting for the 5-minute refresh tick.
+      if (typeof global.wireTfs2OngoingScreeningBanner === 'function') {
+        setTimeout(global.wireTfs2OngoingScreeningBanner, 250);
+      }
+    } catch (_e) {
+      // Swallowed — banner falls back to the local count.
+    }
+  }
+  global.syncTfs2OptInToBackend = syncTfs2OptInToBackend;
 
   function countTfs2OngoingSubjects() {
     try {
@@ -3565,7 +3653,13 @@ window.csFormatDateInput = function (el) {
     if (!banner) return;
     if (isTfs2BannerDismissedThisSession()) { banner.hidden = true; return; }
 
-    const subjectCount = countTfs2OngoingSubjects();
+    // Prefer the server-side aggregate when available so the count is
+    // consistent across devices for the same MLRO team. Fall back to the
+    // local TFS2 record count when the endpoint couldn't respond — it still
+    // accurately reflects what the current browser has opted in.
+    const serverCount = payload && typeof payload.subjectCount === 'number' ? payload.subjectCount : null;
+    const localCount = countTfs2OngoingSubjects();
+    const subjectCount = serverCount !== null ? serverCount : localCount;
     const lastRun = payload && payload.lastRun ? payload.lastRun : null;
     const nextRunAt = payload && payload.nextRunAt ? payload.nextRunAt : null;
     const asanaUrl = payload && payload.routinesProjectUrl ? payload.routinesProjectUrl : null;
@@ -3589,34 +3683,69 @@ window.csFormatDateInput = function (el) {
     banner.hidden = false;
 
     // Tick the countdown once per minute until the banner is re-rendered
-    // or dismissed. Cleared on dismiss + on the next render.
-    if (tfs2BannerTimer) { clearInterval(tfs2BannerTimer); tfs2BannerTimer = null; }
+    // or dismissed. Cleared on dismiss + on the next render. Separate from
+    // the 5-minute refresh timer so a network-slow refresh never delays
+    // the visible countdown.
+    if (tfs2BannerCountdownTimer) { clearInterval(tfs2BannerCountdownTimer); tfs2BannerCountdownTimer = null; }
     if (nextRunAt) {
-      tfs2BannerTimer = setInterval(function() {
+      tfs2BannerCountdownTimer = setInterval(function() {
         if (nextRunEl) nextRunEl.textContent = 'in ' + formatTfs2Countdown(nextRunAt);
-      }, 60000);
+      }, TFS2_BANNER_COUNTDOWN_MS);
     }
   }
 
-  async function wireTfs2OngoingScreeningBanner() {
-    const banner = document.getElementById('tfs2-ongoing-banner');
-    if (!banner) return;
-    if (isTfs2BannerDismissedThisSession()) { banner.hidden = true; return; }
-    // Paint the local-only state first so the count appears instantly even
-    // if the endpoint is slow. Backend data fills in on arrival.
-    applyTfs2BannerPayload({ lastRun: null, nextRunAt: null, routinesProjectUrl: null });
+  async function fetchTfs2Status() {
     try {
       const res = await fetch('/api/ongoing-screening-status', {
         method: 'GET',
         headers: { Accept: 'application/json' },
       });
-      if (!res.ok) return;
+      if (!res.ok) return { ok: false, status: res.status };
       const payload = await res.json().catch(function(){ return null; });
-      if (payload && payload.ok) applyTfs2BannerPayload(payload);
+      if (payload && payload.ok) return { ok: true, payload: payload };
+      return { ok: false, status: 0 };
     } catch (_e) {
-      // Network failure — leave the local-only paint in place. The MLRO
-      // still sees the subject count and the "08:00 UTC daily" schedule.
+      return { ok: false, status: 0 };
     }
+  }
+  async function refreshTfs2Banner(attempt) {
+    if (isTfs2BannerDismissedThisSession()) return;
+    const result = await fetchTfs2Status();
+    if (result.ok) {
+      applyTfs2BannerPayload(result.payload);
+      // Schedule the next regular refresh. Clears any pending retry.
+      if (tfs2BannerRetryTimer) { clearTimeout(tfs2BannerRetryTimer); tfs2BannerRetryTimer = null; }
+      if (tfs2BannerRefreshTimer) { clearInterval(tfs2BannerRefreshTimer); tfs2BannerRefreshTimer = null; }
+      tfs2BannerRefreshTimer = setInterval(function(){ refreshTfs2Banner(0); }, TFS2_BANNER_REFRESH_MS);
+      return;
+    }
+    // Failure path — exponential backoff up to four attempts, then give up
+    // and rely on the next 5-minute scheduled refresh. The banner keeps the
+    // local-only paint so the MLRO still sees the subject count.
+    const nextAttempt = typeof attempt === 'number' ? attempt : 0;
+    if (nextAttempt < TFS2_BANNER_RETRY_BACKOFF_MS.length) {
+      const delay = TFS2_BANNER_RETRY_BACKOFF_MS[nextAttempt];
+      if (tfs2BannerRetryTimer) clearTimeout(tfs2BannerRetryTimer);
+      tfs2BannerRetryTimer = setTimeout(function(){ refreshTfs2Banner(nextAttempt + 1); }, delay);
+    } else {
+      // Out of retries — fall back to the 5-minute scheduled refresh so the
+      // banner recovers automatically once the endpoint comes back.
+      if (!tfs2BannerRefreshTimer) {
+        tfs2BannerRefreshTimer = setInterval(function(){ refreshTfs2Banner(0); }, TFS2_BANNER_REFRESH_MS);
+      }
+    }
+  }
+  async function wireTfs2OngoingScreeningBanner() {
+    const banner = document.getElementById('tfs2-ongoing-banner');
+    if (!banner) return;
+    if (isTfs2BannerDismissedThisSession()) { banner.hidden = true; clearTfs2BannerTimers(); return; }
+    // Clear any timers left over from a previous render before starting
+    // fresh ones so duplicate intervals don't accumulate each re-render.
+    clearTfs2BannerTimers();
+    // Paint the local-only state first so the count appears instantly even
+    // if the endpoint is slow. Backend data fills in on arrival.
+    applyTfs2BannerPayload({ lastRun: null, nextRunAt: null, routinesProjectUrl: null });
+    refreshTfs2Banner(0);
   }
   global.wireTfs2OngoingScreeningBanner = wireTfs2OngoingScreeningBanner;
 
@@ -3774,19 +3903,58 @@ window.csFormatDateInput = function (el) {
       adverseMediaDeep: !!(document.getElementById('tfs2-check-adverse-deep')?.checked),
     };
   }
+  // PR-2 altNames parser — returns at most 20 names per the backend cap in
+  // netlify/functions/screening-save.mts. Truncation is user-visible: the
+  // UI surfaces #tfs2-altnames-warn inline and any submit-time toast so the
+  // MLRO can never silently lose a subject alias (FDL Art.20-21 — the CO
+  // must see that an input exceeded the cap, not discover it during audit).
   function parseTfs2AltNames(raw) {
-    if (!raw || typeof raw !== 'string') return [];
-    return raw
+    const result = parseTfs2AltNamesDetailed(raw);
+    return result.names;
+  }
+  function parseTfs2AltNamesDetailed(raw) {
+    if (!raw || typeof raw !== 'string') return { names: [], total: 0, overflow: false, oversizedCount: 0 };
+    const tokens = raw
       .split(/[,;\n]/)
       .map(function(s){ return s.trim(); })
-      .filter(function(s){ return s.length > 0 && s.length <= 200; })
-      .slice(0, 20);
+      .filter(function(s){ return s.length > 0; });
+    const oversized = tokens.filter(function(s){ return s.length > 200; }).length;
+    const valid = tokens.filter(function(s){ return s.length <= 200; });
+    const names = valid.slice(0, 20);
+    return {
+      names: names,
+      total: tokens.length,
+      overflow: valid.length > 20,
+      oversizedCount: oversized,
+    };
   }
+  function updateTfs2AltNamesWarning() {
+    const input = document.getElementById('tfs2-altnames');
+    const warn  = document.getElementById('tfs2-altnames-warn');
+    if (!input || !warn) return;
+    const parsed = parseTfs2AltNamesDetailed(input.value);
+    const parts = [];
+    if (parsed.overflow) {
+      parts.push('Only the first 20 names will be kept (you provided ' + parsed.total + ').');
+    }
+    if (parsed.oversizedCount > 0) {
+      parts.push(parsed.oversizedCount + ' name(s) exceed the 200-char limit and will be dropped.');
+    }
+    if (parts.length > 0) {
+      warn.textContent = '⚠ ' + parts.join(' ');
+      warn.hidden = false;
+    } else {
+      warn.textContent = '';
+      warn.hidden = true;
+    }
+  }
+  global.updateTfs2AltNamesWarning = updateTfs2AltNamesWarning;
 
   global.suite2OpenTFSForm = function() {
     document.getElementById('tfs2-edit-idx').value = '-1';
     ['tfs2-name','tfs2-reviewer','tfs2-notes','tfs2-fp-evidence','tfs2-pnmr-ref','tfs2-ffr-ref','tfs2-cnmr-ref'].forEach(id=>{const e=document.getElementById(id);if(e)e.value='';});
     ['tfs2-altnames','tfs2-pob','tfs2-country-location','tfs2-case-id','tfs2-group'].forEach(id=>{const e=document.getElementById(id);if(e)e.value='';});
+    const _altWarn = document.getElementById('tfs2-altnames-warn'); if (_altWarn) { _altWarn.textContent=''; _altWarn.hidden = true; }
     ['tfs2-fp-basis','tfs2-tx-suspended','tfs2-pnmr-status','tfs2-frozen','tfs2-ffr','tfs2-cnmr-status','tfs2-supervisor','tfs2-mlro','tfs2-mgmt'].forEach(id=>{const e=document.getElementById(id);if(e)e.value='';});
     ['tfs2-list-uae','tfs2-list-un'].forEach(id=>{const e=document.getElementById(id);if(e)e.checked=true;});
     ['tfs2-list-ofac','tfs2-list-eu','tfs2-list-uk','tfs2-list-interpol','tfs2-list-adverse','tfs2-list-pep'].forEach(id=>{const e=document.getElementById(id);if(e)e.checked=true;});
@@ -4055,7 +4223,17 @@ window.csFormatDateInput = function (el) {
       idNumber: document.getElementById('tfs2-idnumber')?.value?.trim() || '',
       // PR-2 LSEG World-Check One parity fields. All optional — trimmed,
       // capped, and omitted-as-blank preserved so legacy records round-trip.
-      altNames: parseTfs2AltNames(document.getElementById('tfs2-altnames')?.value || ''),
+      altNames: (function() {
+        const raw = document.getElementById('tfs2-altnames')?.value || '';
+        const parsed = parseTfs2AltNamesDetailed(raw);
+        if (parsed.overflow && typeof toast === 'function') {
+          toast('Only the first 20 alternate names were saved (you provided ' + parsed.total + ').', 'warning', 6000);
+        }
+        if (parsed.oversizedCount > 0 && typeof toast === 'function') {
+          toast(parsed.oversizedCount + ' alternate name(s) exceeded the 200-char limit and were dropped.', 'warning', 6000);
+        }
+        return parsed.names;
+      })(),
       pob: document.getElementById('tfs2-pob')?.value?.trim() || '',
       countryLocation: document.getElementById('tfs2-country-location')?.value?.trim() || '',
       caseId: document.getElementById('tfs2-case-id')?.value?.trim() || '',
@@ -4100,6 +4278,11 @@ window.csFormatDateInput = function (el) {
     };
     if (editIdx>=0) { events[editIdx]=record; } else { events.unshift(record); }
     save(SK2.TFS2, events);
+    // PR-3 fix #1 — propagate the opt-in flag to the server so the status
+    // banner sees the same count across devices. Non-blocking.
+    if (typeof syncTfs2OptInToBackend === 'function') {
+      try { syncTfs2OptInToBackend(record); } catch (_e) { /* local-only fallback */ }
+    }
     document.getElementById('tfs2Modal').classList.remove('open');
     if (outcome==='Confirmed Match') toast('🔴 CONFIRMED MATCH saved — ensure freeze, FFR, and CNMR obligations are met within deadlines','error');
     else if (outcome==='Partial Match') toast('🟡 PARTIAL MATCH saved — PNMR must be filed within 5 business days','info');
@@ -4158,7 +4341,7 @@ window.csFormatDateInput = function (el) {
           return '\n\n' + lines.join('\n');
         }
         var syncNotes = 'TFS Screening Event: ' + record.id
-          + '\nEntity: ' + name + ' (' + (record.entityType||'') + ')'
+          + '\nEntity: ' + name + ' (' + window.prettyEntityType(record.entityType) + ')'
           + (record.country ? '\nCountry: ' + record.country : '')
           + (record.idNumber ? '\nID: ' + record.idNumber : '')
           + '\nEvent Type: ' + record.eventType
@@ -4191,8 +4374,21 @@ window.csFormatDateInput = function (el) {
   global.suite2DeleteTFS = function(idx) {
     if (!confirm('Delete this TFS screening event?')) return;
     const events = load(SK2.TFS2)||[];
+    const removed = events[idx];
     events.splice(idx,1);
     save(SK2.TFS2, events);
+    // PR-3 fix #1 — if the deleted record was on ongoing screening, opt it out
+    // on the server so the aggregate count stays accurate.
+    if (removed && removed.ongoingScreening === true && typeof syncTfs2OptInToBackend === 'function') {
+      try {
+        syncTfs2OptInToBackend({
+          id: removed.id,
+          screenedName: removed.screenedName,
+          entityType: removed.entityType,
+          ongoingScreening: false,
+        });
+      } catch (_e) { /* local-only fallback */ }
+    }
     renderTFS2();
   };
 

--- a/compliance-suite.js
+++ b/compliance-suite.js
@@ -3585,13 +3585,42 @@ window.prettyEntityType = function (raw) {
       );
     } catch (_e) { return ''; }
   }
+  // Deterministic fingerprint for cross-device opt-in de-duplication.
+  // Uses FNV-1a over normalised (name|dob|idNumber) so:
+  //   - the SAME subject saved on two MLRO devices → same key → count=1
+  //   - DIFFERENT subjects with the same name but distinct DOB/ID →
+  //     different keys (disambiguates)
+  // Non-cryptographic by design — the output is a dedup key, not a secret.
+  // Unicode-safe via charCodeAt (covers Arabic / CJK characters for UAE
+  // clientele).
+  function computeTfs2SubjectFingerprint(record) {
+    if (!record) return '';
+    const name = String(record.screenedName || '').trim().toLowerCase().replace(/\s+/g, ' ');
+    const dob = String(record.dob || '').trim();
+    const idNumber = String(record.idNumber || '').trim().toLowerCase();
+    const parts = name + '|' + dob + '|' + idNumber;
+    if (!name && !dob && !idNumber) return '';
+    let h = 2166136261 >>> 0;                   // FNV offset basis
+    for (let i = 0; i < parts.length; i++) {
+      h ^= parts.charCodeAt(i);
+      h = Math.imul(h, 16777619);                // FNV prime
+    }
+    return 'tfs2:' + (h >>> 0).toString(16).padStart(8, '0');
+  }
+  global.computeTfs2SubjectFingerprint = computeTfs2SubjectFingerprint;
+
   async function syncTfs2OptInToBackend(record) {
     if (!record || !record.screenedName) return;
     const token = readHawkeyeBearerToken();
     if (!token) return; // Unauthenticated → local-only. User-visible no-op.
+    // Cross-device stable key. Falls back to undefined (server canonicalises
+    // by name) when we cannot build a fingerprint — e.g. a record with no
+    // name, no DOB and no ID, which should never reach here because save
+    // requires a name.
+    const fingerprint = computeTfs2SubjectFingerprint(record);
     const body = {
       subjectName: String(record.screenedName || '').slice(0, 200),
-      subjectId: record.id ? String(record.id).slice(0, 128) : undefined,
+      subjectId: fingerprint || undefined,
       entityType: record.entityType || 'individual',
       ongoingScreening: !!record.ongoingScreening,
     };
@@ -4282,12 +4311,37 @@ window.prettyEntityType = function (raw) {
       ],
       mandatoryListsScreened: uaeChecked && unChecked,
     };
+    // Capture the prior state BEFORE overwriting so we can opt-out a stale
+    // fingerprint when the identifying fields (name / DOB / idNumber) change
+    // during an edit. Without this the old server entry would be orphaned
+    // and the cross-device count would over-report by one.
+    const priorRecord = editIdx >= 0 ? events[editIdx] : null;
     if (editIdx>=0) { events[editIdx]=record; } else { events.unshift(record); }
     save(SK2.TFS2, events);
     // PR-3 fix #1 — propagate the opt-in flag to the server so the status
     // banner sees the same count across devices. Non-blocking.
     if (typeof syncTfs2OptInToBackend === 'function') {
-      try { syncTfs2OptInToBackend(record); } catch (_e) { /* local-only fallback */ }
+      try {
+        // Opt-out a stale fingerprint first, only when it actually changed
+        // AND the prior record was on ongoing screening. Identical
+        // fingerprints need no opt-out — the new POST is an idempotent
+        // upsert in that case.
+        if (priorRecord && priorRecord.ongoingScreening === true) {
+          const priorFp = computeTfs2SubjectFingerprint(priorRecord);
+          const nextFp  = computeTfs2SubjectFingerprint(record);
+          if (priorFp && nextFp && priorFp !== nextFp) {
+            syncTfs2OptInToBackend({
+              id: priorRecord.id,
+              screenedName: priorRecord.screenedName,
+              dob: priorRecord.dob,
+              idNumber: priorRecord.idNumber,
+              entityType: priorRecord.entityType,
+              ongoingScreening: false,
+            });
+          }
+        }
+        syncTfs2OptInToBackend(record);
+      } catch (_e) { /* local-only fallback */ }
     }
     document.getElementById('tfs2Modal').classList.remove('open');
     if (outcome==='Confirmed Match') toast('🔴 CONFIRMED MATCH saved — ensure freeze, FFR, and CNMR obligations are met within deadlines','error');
@@ -4384,12 +4438,16 @@ window.prettyEntityType = function (raw) {
     events.splice(idx,1);
     save(SK2.TFS2, events);
     // PR-3 fix #1 — if the deleted record was on ongoing screening, opt it out
-    // on the server so the aggregate count stays accurate.
+    // on the server so the aggregate count stays accurate. The sync path
+    // derives a deterministic fingerprint from name|dob|idNumber so the
+    // DELETE hits the SAME canonical key the opt-in POST created.
     if (removed && removed.ongoingScreening === true && typeof syncTfs2OptInToBackend === 'function') {
       try {
         syncTfs2OptInToBackend({
           id: removed.id,
           screenedName: removed.screenedName,
+          dob: removed.dob,
+          idNumber: removed.idNumber,
           entityType: removed.entityType,
           ongoingScreening: false,
         });

--- a/compliance-suite.js
+++ b/compliance-suite.js
@@ -3571,8 +3571,14 @@ window.prettyEntityType = function (raw) {
   // local count as a fallback). FDL Art.29-safe: only subject name +
   // entity type + flag are sent, never hit details.
   function readHawkeyeBearerToken() {
+    // Prefer the new canonical JWT key; fall back to the legacy mirror
+    // that auth-gate.js still writes for backward compatibility, then
+    // the older brain-token key for the backend-to-backend hex bearer
+    // case (setup wizard, orchestrator). Returns '' when no session —
+    // caller treats empty as "unauthenticated, local-only mode".
     try {
       return (
+        localStorage.getItem('hawkeye.session.jwt') ||
         localStorage.getItem('hawkeye.watchlist.adminToken') ||
         localStorage.getItem('hawkeye.brain.token') ||
         ''

--- a/compliance-suite.js
+++ b/compliance-suite.js
@@ -3173,6 +3173,32 @@ window.csFormatDateInput = function (el) {
 
     el.innerHTML = `
     <div class="card" style="margin-bottom:1.2rem">
+      <!-- PR-3 Ongoing-Screening status banner. Populated by
+           wireTfs2OngoingScreeningBanner() after each render; hidden
+           until it has something meaningful to show (subjects on
+           re-screen OR a recorded last-run). -->
+      <div id="tfs2-ongoing-banner" data-role="ongoing-screening-banner" hidden
+        style="display:flex;flex-wrap:wrap;gap:12px;align-items:center;justify-content:space-between;background:var(--surface2);border:1px solid var(--border);border-left:3px solid var(--gold);border-radius:4px;padding:10px 14px;margin-bottom:1rem;font-size:12px">
+        <div style="display:flex;align-items:center;gap:10px">
+          <span aria-hidden="true" style="width:8px;height:8px;border-radius:50%;background:var(--gold);display:inline-block"></span>
+          <span>
+            <strong data-field="subjectCount">0</strong>
+            <span style="color:var(--muted)">subjects on daily re-screen ·</span>
+            next run
+            <strong data-field="nextRun">—</strong>
+            <span style="color:var(--muted)">· 08:00 UTC daily</span>
+          </span>
+        </div>
+        <div style="display:flex;align-items:center;gap:10px;color:var(--muted)" data-slot="last-run">
+          <span data-field="lastRunText">Awaiting first run</span>
+          <a data-field="asanaLink" href="#" target="_blank" rel="noopener"
+             style="color:var(--azure,#a855f7);text-decoration:none" hidden>Open Asana report →</a>
+          <button type="button" data-action="suite2DismissOngoingBanner"
+            aria-label="Dismiss banner for this session"
+            style="background:transparent;border:0;color:var(--muted);font-size:14px;cursor:pointer;padding:0 4px">×</button>
+        </div>
+      </div>
+
       <div class="top-bar">
         <span class="sec-title">TFS Workflow — Full 4-Outcome Process</span>
         <span style="font-size:11px;color:var(--muted)">Cabinet Decision No.(74) of 2020 | EOCN Executive Office TFS Guidance</span>
@@ -3234,19 +3260,83 @@ window.csFormatDateInput = function (el) {
         <div style="font-size:11px;color:var(--muted);margin-bottom:1rem;font-family:'Montserrat',sans-serif">Cabinet Decision No.(74) of 2020 | EOCN TFS Guidance | Mandatory: UAE Local Terrorist List + UNSC Consolidated List</div>
         <input type="hidden" id="tfs2-edit-idx" value="-1">
 
-        <div class="row" style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:10px">
-          <div><span class="lbl">Name Screened *</span><input id="tfs2-name" placeholder="Full legal name of individual or entity"/></div>
-          <div><span class="lbl">Entity Type *</span>
-            <select id="tfs2-entity-type"><option value="Individual">Individual</option><option value="Company">Company</option></select>
+        <!-- Entity-type tabs (PR-2) — LSEG World-Check One parity.
+             Vessel intentionally deferred pending goAML mapping decision. -->
+        <div><span class="lbl">Entity Type *</span>
+          <div id="tfs2-entity-tabs" role="tablist" aria-label="Entity type" style="display:grid;grid-template-columns:repeat(3,1fr);gap:6px;margin-top:4px">
+            <button type="button" role="tab" data-action="suite2SelectEntityType" data-arg="individual"
+              id="tfs2-tab-individual" aria-selected="true"
+              style="background:var(--surface2);border:2px solid var(--border);color:var(--text);font-size:12px;padding:10px 6px;border-radius:3px;cursor:pointer">
+              👤 Individual
+            </button>
+            <button type="button" role="tab" data-action="suite2SelectEntityType" data-arg="organisation"
+              id="tfs2-tab-organisation" aria-selected="false"
+              style="background:var(--surface2);border:2px solid var(--border);color:var(--text);font-size:12px;padding:10px 6px;border-radius:3px;cursor:pointer">
+              🏢 Organisation
+            </button>
+            <button type="button" role="tab" data-action="suite2SelectEntityType" data-arg="unspecified"
+              id="tfs2-tab-unspecified" aria-selected="false"
+              style="background:var(--surface2);border:2px solid var(--border);color:var(--text);font-size:12px;padding:10px 6px;border-radius:3px;cursor:pointer">
+              ❔ Unspecified
+            </button>
           </div>
-          <div><span class="lbl">Date of Birth / Registration</span><input type="text" id="tfs2-dob" placeholder="dd/mm/yyyy" oninput="csFormatDateInput(this)" maxlength="10"/></div>
+          <input type="hidden" id="tfs2-entity-type" value="individual"/>
+        </div>
+
+        <div class="row" style="display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-top:10px">
+          <div><span class="lbl" id="tfs2-name-label">Name Screened *</span><input id="tfs2-name" placeholder="Full legal name of individual or entity"/></div>
+          <div><span class="lbl" id="tfs2-dob-label">Date of Birth / Registration</span><input type="text" id="tfs2-dob" placeholder="dd/mm/yyyy" oninput="csFormatDateInput(this)" maxlength="10"/></div>
+        </div>
+        <div class="row" style="display:grid;grid-template-columns:1fr 1fr;gap:10px">
+          <div><span class="lbl">Alternate names / aliases</span><input id="tfs2-altnames" placeholder="Comma-separated. Up to 20."/></div>
+          <div><span class="lbl" id="tfs2-pob-label">Place of birth</span><input id="tfs2-pob" placeholder="City, country"/></div>
         </div>
         <div class="row" style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:10px">
           <div><span class="lbl">Screening Event Type *</span>
             <select id="tfs2-event"><option>New Customer Onboarding</option><option>Periodic Rescreening</option><option>List Update Trigger</option><option>Transaction Pre-Approval</option><option>Supplier/Refinery Onboarding</option><option>UBO Screening</option><option>Ad Hoc Review</option></select>
           </div>
-          <div><span class="lbl">Country</span><input id="tfs2-country" placeholder="e.g. UAE, Iran, Russia"/></div>
-          <div><span class="lbl">ID / Register No.</span><input id="tfs2-idnumber" placeholder="Passport, EID, Trade License"/></div>
+          <div><span class="lbl">Country (nationality / incorporation)</span><input id="tfs2-country" placeholder="e.g. UAE, Iran, Russia"/></div>
+          <div><span class="lbl">Country location (residence / operation)</span><input id="tfs2-country-location" placeholder="Where the subject lives / operates"/></div>
+        </div>
+        <div class="row" style="display:grid;grid-template-columns:1fr 1fr;gap:10px">
+          <div><span class="lbl">Case ID</span><input id="tfs2-case-id" placeholder="CASE-YYYY-NNNN"/></div>
+          <div><span class="lbl">Group / portfolio</span><input id="tfs2-group" placeholder="e.g. Project Falcon — counterparties"/></div>
+        </div>
+
+        <!-- Identifications — multi-entry (PR-2 LSEG WC-One parity). Render
+             one editable row; add more via the + button. Serialised to the
+             identifications[] array on save. ID / Register No. below is
+             the legacy single-value field; it is still accepted by the
+             backend and mirrored into the first identifications row on
+             submit when that row is blank. -->
+        <div style="margin-top:10px">
+          <span class="lbl">Identification (multi-entry)</span>
+          <div id="tfs2-ids" style="display:flex;flex-direction:column;gap:6px;margin-top:4px"></div>
+          <button type="button" data-action="suite2AddIdentificationRow"
+            style="margin-top:6px;background:var(--surface2);border:1px solid var(--border);color:var(--text);font-size:11px;padding:6px 10px;border-radius:3px;cursor:pointer">
+            + Add another ID
+          </button>
+        </div>
+
+        <div class="row" style="display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-top:10px">
+          <div><span class="lbl">ID / Register No. (legacy — first ID row)</span><input id="tfs2-idnumber" placeholder="Passport, EID, Trade License"/></div>
+          <div>
+            <span class="lbl">Ongoing Screening</span>
+            <label style="display:flex;align-items:center;gap:8px;font-size:12px;margin-top:6px;cursor:pointer;padding:8px;background:var(--surface2);border:1px solid var(--border);border-radius:3px">
+              <input type="checkbox" id="tfs2-ongoing-screening" style="width:auto"/>
+              <span>Re-screen daily at 08:00 UTC · FATF Rec 10 · FDL Art.20-21</span>
+            </label>
+          </div>
+        </div>
+
+        <!-- Check types (PR-2) — which screening engines to run for this subject -->
+        <div style="margin-top:10px">
+          <span class="lbl">Check Types</span>
+          <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:6px;background:var(--surface2);padding:10px;border-radius:3px;border:1px solid var(--border);margin-top:4px">
+            <label style="display:flex;align-items:center;gap:8px;font-size:12px;cursor:pointer"><input type="checkbox" id="tfs2-check-worldcheck" style="width:auto" checked/> World-Check</label>
+            <label style="display:flex;align-items:center;gap:8px;font-size:12px;cursor:pointer"><input type="checkbox" id="tfs2-check-passport" style="width:auto"/> Passport verification</label>
+            <label style="display:flex;align-items:center;gap:8px;font-size:12px;cursor:pointer"><input type="checkbox" id="tfs2-check-adverse-deep" style="width:auto"/> Adverse-Media Deep Scan</label>
+          </div>
         </div>
         <div><span class="lbl">Lists Screened (tick all that apply)</span>
           <div style="display:grid;grid-template-columns:1fr 1fr;gap:6px;background:var(--surface2);padding:10px;border-radius:3px;border:1px solid var(--border);margin-top:4px">
@@ -3409,12 +3499,308 @@ window.csFormatDateInput = function (el) {
   };
 
   global.renderTFS2 = renderTFS2;
+
+  // ── Ongoing-Screening status banner (PR-3) ────────────────────────────
+  // Populates #tfs2-ongoing-banner after each render. Does NOT show subject
+  // names, IDs, or hit details — FDL Art.29 (no tipping off). Only aggregate
+  // metadata: count, next-run countdown, and a link to the Asana routines
+  // board where the MLRO can read the per-subject detail.
+  const TFS2_BANNER_DISMISS_KEY = 'hawkeye.ongoingBannerDismissed.session';
+  let tfs2BannerTimer = null;
+
+  function isTfs2BannerDismissedThisSession() {
+    try { return sessionStorage.getItem(TFS2_BANNER_DISMISS_KEY) === '1'; }
+    catch (_e) { return false; }
+  }
+  function dismissTfs2BannerForSession() {
+    try { sessionStorage.setItem(TFS2_BANNER_DISMISS_KEY, '1'); } catch (_e) { /* ignore */ }
+  }
+  global.suite2DismissOngoingBanner = function() {
+    dismissTfs2BannerForSession();
+    const banner = document.getElementById('tfs2-ongoing-banner');
+    if (banner) banner.hidden = true;
+    if (tfs2BannerTimer) { clearInterval(tfs2BannerTimer); tfs2BannerTimer = null; }
+  };
+
+  function countTfs2OngoingSubjects() {
+    try {
+      const events = load(SK2.TFS2) || [];
+      if (!Array.isArray(events)) return 0;
+      // Dedupe by subject name so one person with multiple events counts once.
+      const names = new Set();
+      events.forEach(function(e) {
+        if (e && e.ongoingScreening === true) {
+          const key = (e.screenedName || '').trim().toLowerCase();
+          if (key) names.add(key);
+        }
+      });
+      return names.size;
+    } catch (_e) { return 0; }
+  }
+
+  function formatTfs2Countdown(toIso) {
+    if (!toIso) return '—';
+    const ms = new Date(toIso).getTime() - Date.now();
+    if (!isFinite(ms) || ms <= 0) return 'imminent';
+    const h = Math.floor(ms / 3600000);
+    const m = Math.floor((ms % 3600000) / 60000);
+    if (h >= 1) return h + 'h ' + String(m).padStart(2, '0') + 'm';
+    const s = Math.floor((ms % 60000) / 1000);
+    return m + 'm ' + String(s).padStart(2, '0') + 's';
+  }
+
+  function formatTfs2LastRun(lastRun) {
+    if (!lastRun || !lastRun.ranAt) return 'Awaiting first run';
+    let when = lastRun.ranAt;
+    try {
+      const d = new Date(lastRun.ranAt);
+      if (!isNaN(d.getTime())) when = d.toUTCString().replace('GMT', 'UTC');
+    } catch (_e) { /* fall through */ }
+    const note = lastRun.note && typeof lastRun.note === 'string' ? ' · ' + lastRun.note : '';
+    return 'Last run ' + when + note;
+  }
+
+  function applyTfs2BannerPayload(payload) {
+    const banner = document.getElementById('tfs2-ongoing-banner');
+    if (!banner) return;
+    if (isTfs2BannerDismissedThisSession()) { banner.hidden = true; return; }
+
+    const subjectCount = countTfs2OngoingSubjects();
+    const lastRun = payload && payload.lastRun ? payload.lastRun : null;
+    const nextRunAt = payload && payload.nextRunAt ? payload.nextRunAt : null;
+    const asanaUrl = payload && payload.routinesProjectUrl ? payload.routinesProjectUrl : null;
+
+    // Nothing meaningful to show yet — keep it hidden so an empty-state
+    // banner does not create visual noise on fresh installs.
+    if (subjectCount === 0 && !lastRun) { banner.hidden = true; return; }
+
+    const subjectEl  = banner.querySelector('[data-field="subjectCount"]');
+    const nextRunEl  = banner.querySelector('[data-field="nextRun"]');
+    const lastTextEl = banner.querySelector('[data-field="lastRunText"]');
+    const asanaEl    = banner.querySelector('[data-field="asanaLink"]');
+    if (subjectEl)  subjectEl.textContent  = String(subjectCount);
+    if (nextRunEl)  nextRunEl.textContent  = 'in ' + formatTfs2Countdown(nextRunAt);
+    if (lastTextEl) lastTextEl.textContent = formatTfs2LastRun(lastRun);
+    if (asanaEl) {
+      if (asanaUrl) { asanaEl.setAttribute('href', asanaUrl); asanaEl.hidden = false; }
+      else          { asanaEl.removeAttribute('href');         asanaEl.hidden = true; }
+    }
+
+    banner.hidden = false;
+
+    // Tick the countdown once per minute until the banner is re-rendered
+    // or dismissed. Cleared on dismiss + on the next render.
+    if (tfs2BannerTimer) { clearInterval(tfs2BannerTimer); tfs2BannerTimer = null; }
+    if (nextRunAt) {
+      tfs2BannerTimer = setInterval(function() {
+        if (nextRunEl) nextRunEl.textContent = 'in ' + formatTfs2Countdown(nextRunAt);
+      }, 60000);
+    }
+  }
+
+  async function wireTfs2OngoingScreeningBanner() {
+    const banner = document.getElementById('tfs2-ongoing-banner');
+    if (!banner) return;
+    if (isTfs2BannerDismissedThisSession()) { banner.hidden = true; return; }
+    // Paint the local-only state first so the count appears instantly even
+    // if the endpoint is slow. Backend data fills in on arrival.
+    applyTfs2BannerPayload({ lastRun: null, nextRunAt: null, routinesProjectUrl: null });
+    try {
+      const res = await fetch('/api/ongoing-screening-status', {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+      });
+      if (!res.ok) return;
+      const payload = await res.json().catch(function(){ return null; });
+      if (payload && payload.ok) applyTfs2BannerPayload(payload);
+    } catch (_e) {
+      // Network failure — leave the local-only paint in place. The MLRO
+      // still sees the subject count and the "08:00 UTC daily" schedule.
+    }
+  }
+  global.wireTfs2OngoingScreeningBanner = wireTfs2OngoingScreeningBanner;
+
+  // ── Entity-type tabs (PR-2) ───────────────────────────────────────────
+  // Valid canonical values for the tabs. Vessel intentionally omitted until
+  // the goAML mapping decision is made (CLAUDE.md Regulatory Domain Knowledge).
+  const TFS2_ENTITY_TYPES = ['individual','organisation','unspecified'];
+  // Legacy values that might live on older saved screening events. Mirrored
+  // by src/domain/constants.ts > ENTITY_TYPE_LEGACY_ALIASES — keep in sync.
+  const TFS2_ENTITY_TYPE_ALIASES = {
+    'Individual': 'individual',
+    'Company': 'organisation',
+    'legal_entity': 'organisation',
+    'organization': 'organisation',
+    'INDIVIDUAL': 'individual',
+    'ORGANISATION': 'organisation',
+    'ORGANIZATION': 'organisation',
+    'UNSPECIFIED': 'unspecified',
+  };
+  function normaliseTfs2EntityType(raw) {
+    if (typeof raw !== 'string') return 'individual';
+    const trimmed = raw.trim();
+    if (!trimmed) return 'individual';
+    if (TFS2_ENTITY_TYPES.indexOf(trimmed) !== -1) return trimmed;
+    if (Object.prototype.hasOwnProperty.call(TFS2_ENTITY_TYPE_ALIASES, trimmed)) {
+      return TFS2_ENTITY_TYPE_ALIASES[trimmed];
+    }
+    return 'individual';
+  }
+  function applyTfs2EntityTypeUi(value) {
+    const canonical = normaliseTfs2EntityType(value);
+    const hidden = document.getElementById('tfs2-entity-type');
+    if (hidden) hidden.value = canonical;
+    TFS2_ENTITY_TYPES.forEach(function(t) {
+      const btn = document.getElementById('tfs2-tab-'+t);
+      if (!btn) return;
+      const selected = t === canonical;
+      btn.setAttribute('aria-selected', selected ? 'true' : 'false');
+      btn.style.background = selected ? 'var(--gold, #f5a623)22' : 'var(--surface2)';
+      btn.style.borderColor = selected ? 'var(--gold, #f5a623)' : 'var(--border)';
+    });
+    // Label swap — same inputs, different prompts per entity type.
+    const nameLbl = document.getElementById('tfs2-name-label');
+    const dobLbl  = document.getElementById('tfs2-dob-label');
+    const pobLbl  = document.getElementById('tfs2-pob-label');
+    if (canonical === 'organisation') {
+      if (nameLbl) nameLbl.textContent = 'Legal / trading name *';
+      if (dobLbl)  dobLbl.textContent  = 'Registration / incorporation date';
+      if (pobLbl)  pobLbl.textContent  = 'Place of incorporation';
+    } else if (canonical === 'unspecified') {
+      if (nameLbl) nameLbl.textContent = 'Raw name / subject text *';
+      if (dobLbl)  dobLbl.textContent  = 'Date of birth / registration (if known)';
+      if (pobLbl)  pobLbl.textContent  = 'Place of birth (if known)';
+    } else {
+      if (nameLbl) nameLbl.textContent = 'Full name *';
+      if (dobLbl)  dobLbl.textContent  = 'Date of birth';
+      if (pobLbl)  pobLbl.textContent  = 'Place of birth';
+    }
+    // Ongoing-screening is only meaningful when we have a stable target.
+    const ongoing = document.getElementById('tfs2-ongoing-screening');
+    if (ongoing) {
+      if (canonical === 'unspecified') {
+        ongoing.checked = false;
+        ongoing.disabled = true;
+        ongoing.title = 'Ongoing screening requires a stable subject identity.';
+      } else {
+        ongoing.disabled = false;
+        ongoing.removeAttribute('title');
+      }
+    }
+  }
+  global.suite2SelectEntityType = function(value) {
+    applyTfs2EntityTypeUi(value);
+  };
+
+  // ── Identification multi-entry rows (PR-2) ────────────────────────────
+  const TFS2_ID_TYPES = [
+    { v: 'passport',      l: 'Passport' },
+    { v: 'national_id',   l: 'National ID' },
+    { v: 'emirates_id',   l: 'Emirates ID' },
+    { v: 'trade_licence', l: 'Trade Licence' },
+    { v: 'driver_licence',l: 'Driver Licence' },
+    { v: 'tax_id',        l: 'Tax ID' },
+    { v: 'lei',           l: 'LEI' },
+    { v: 'other',         l: 'Other' },
+  ];
+  function buildTfs2IdRow(record) {
+    const rec = record || { type: 'passport', number: '', issuer: '' };
+    const wrap = document.createElement('div');
+    wrap.className = 'tfs2-id-row';
+    wrap.style.cssText = 'display:grid;grid-template-columns:1fr 1fr 1fr auto;gap:6px;align-items:center';
+    const sel = document.createElement('select');
+    sel.className = 'tfs2-id-type';
+    TFS2_ID_TYPES.forEach(function(o){
+      const opt = document.createElement('option');
+      opt.value = o.v;
+      opt.textContent = o.l;
+      if (o.v === rec.type) opt.selected = true;
+      sel.appendChild(opt);
+    });
+    const num = document.createElement('input');
+    num.className = 'tfs2-id-number';
+    num.placeholder = 'ID / reference number';
+    num.maxLength = 64;
+    num.value = rec.number || '';
+    const iss = document.createElement('input');
+    iss.className = 'tfs2-id-issuer';
+    iss.placeholder = 'Issuing country / authority';
+    iss.maxLength = 64;
+    iss.value = rec.issuer || '';
+    const rm = document.createElement('button');
+    rm.type = 'button';
+    rm.textContent = '✕';
+    rm.title = 'Remove this ID';
+    rm.style.cssText = 'background:var(--surface2);border:1px solid var(--border);color:var(--text);font-size:11px;padding:6px 10px;border-radius:3px;cursor:pointer';
+    rm.addEventListener('click', function() {
+      if (wrap.parentNode) wrap.parentNode.removeChild(wrap);
+    });
+    wrap.appendChild(sel);
+    wrap.appendChild(num);
+    wrap.appendChild(iss);
+    wrap.appendChild(rm);
+    return wrap;
+  }
+  global.suite2AddIdentificationRow = function(record) {
+    const host = document.getElementById('tfs2-ids');
+    if (!host) return;
+    host.appendChild(buildTfs2IdRow(record));
+  };
+  function clearTfs2IdRows() {
+    const host = document.getElementById('tfs2-ids');
+    if (host) host.innerHTML = '';
+  }
+  function readTfs2Identifications() {
+    const rows = document.querySelectorAll('#tfs2-ids .tfs2-id-row');
+    const out = [];
+    rows.forEach(function(row) {
+      const t = row.querySelector('.tfs2-id-type');
+      const n = row.querySelector('.tfs2-id-number');
+      const i = row.querySelector('.tfs2-id-issuer');
+      const number = n && typeof n.value === 'string' ? n.value.trim() : '';
+      if (!number) return;
+      out.push({
+        type: t ? t.value : 'other',
+        number: number,
+        issuer: i && typeof i.value === 'string' && i.value.trim() ? i.value.trim() : undefined,
+      });
+    });
+    return out;
+  }
+  function readTfs2CheckTypes() {
+    return {
+      worldCheck:       !!(document.getElementById('tfs2-check-worldcheck')?.checked),
+      passport:         !!(document.getElementById('tfs2-check-passport')?.checked),
+      adverseMediaDeep: !!(document.getElementById('tfs2-check-adverse-deep')?.checked),
+    };
+  }
+  function parseTfs2AltNames(raw) {
+    if (!raw || typeof raw !== 'string') return [];
+    return raw
+      .split(/[,;\n]/)
+      .map(function(s){ return s.trim(); })
+      .filter(function(s){ return s.length > 0 && s.length <= 200; })
+      .slice(0, 20);
+  }
+
   global.suite2OpenTFSForm = function() {
     document.getElementById('tfs2-edit-idx').value = '-1';
     ['tfs2-name','tfs2-reviewer','tfs2-notes','tfs2-fp-evidence','tfs2-pnmr-ref','tfs2-ffr-ref','tfs2-cnmr-ref'].forEach(id=>{const e=document.getElementById(id);if(e)e.value='';});
+    ['tfs2-altnames','tfs2-pob','tfs2-country-location','tfs2-case-id','tfs2-group'].forEach(id=>{const e=document.getElementById(id);if(e)e.value='';});
     ['tfs2-fp-basis','tfs2-tx-suspended','tfs2-pnmr-status','tfs2-frozen','tfs2-ffr','tfs2-cnmr-status','tfs2-supervisor','tfs2-mlro','tfs2-mgmt'].forEach(id=>{const e=document.getElementById(id);if(e)e.value='';});
     ['tfs2-list-uae','tfs2-list-un'].forEach(id=>{const e=document.getElementById(id);if(e)e.checked=true;});
     ['tfs2-list-ofac','tfs2-list-eu','tfs2-list-uk','tfs2-list-interpol','tfs2-list-adverse','tfs2-list-pep'].forEach(id=>{const e=document.getElementById(id);if(e)e.checked=true;});
+    // Check types: default World-Check on, deep scans off.
+    const wc = document.getElementById('tfs2-check-worldcheck'); if (wc) wc.checked = true;
+    const pp = document.getElementById('tfs2-check-passport');   if (pp) pp.checked = false;
+    const am = document.getElementById('tfs2-check-adverse-deep'); if (am) am.checked = false;
+    // Ongoing screening: off by default — explicit opt-in only.
+    const os = document.getElementById('tfs2-ongoing-screening'); if (os) { os.checked = false; os.disabled = false; }
+    // Identifications: seed with one empty row.
+    clearTfs2IdRows();
+    global.suite2AddIdentificationRow();
+    // Default entity type.
+    applyTfs2EntityTypeUi('individual');
     document.getElementById('tfs2-date').value = today();
     document.getElementById('tfs2-outcome').value = '';
     document.getElementById('tfs2-freeze-dt').value = '';
@@ -3432,10 +3818,38 @@ window.csFormatDateInput = function (el) {
     suite2OpenTFSForm();
     document.getElementById('tfs2-edit-idx').value = idx;
     document.getElementById('tfs2-name').value = e.screenedName||'';
-    if (document.getElementById('tfs2-entity-type')) document.getElementById('tfs2-entity-type').value = e.entityType||'Individual';
+    // Restore entity-type tab state via the normalising helper so legacy
+    // "Individual" / "Company" / "legal_entity" values snap to the canonical
+    // individual / organisation set.
+    applyTfs2EntityTypeUi(e.entityType || 'individual');
     if (document.getElementById('tfs2-dob')) document.getElementById('tfs2-dob').value = e.dob||'';
     if (document.getElementById('tfs2-country')) document.getElementById('tfs2-country').value = e.country||'';
     if (document.getElementById('tfs2-idnumber')) document.getElementById('tfs2-idnumber').value = e.idNumber||'';
+    // PR-2 new fields — all optional, backfill empties for legacy records.
+    const altEl    = document.getElementById('tfs2-altnames');
+    const pobEl    = document.getElementById('tfs2-pob');
+    const clocEl   = document.getElementById('tfs2-country-location');
+    const caseEl   = document.getElementById('tfs2-case-id');
+    const groupEl  = document.getElementById('tfs2-group');
+    if (altEl)   altEl.value   = Array.isArray(e.altNames) ? e.altNames.join(', ') : (e.altNames || '');
+    if (pobEl)   pobEl.value   = e.pob || '';
+    if (clocEl)  clocEl.value  = e.countryLocation || '';
+    if (caseEl)  caseEl.value  = e.caseId || '';
+    if (groupEl) groupEl.value = e.group || '';
+    // Identifications — rebuild from the record, or seed with a single row.
+    clearTfs2IdRows();
+    if (Array.isArray(e.identifications) && e.identifications.length > 0) {
+      e.identifications.forEach(function(rec){ global.suite2AddIdentificationRow(rec); });
+    } else {
+      global.suite2AddIdentificationRow();
+    }
+    // Check types — default World-Check on when the record lacks them.
+    const ct = (e.checkTypes && typeof e.checkTypes === 'object') ? e.checkTypes : { worldCheck: true, passport: false, adverseMediaDeep: false };
+    const wc = document.getElementById('tfs2-check-worldcheck');   if (wc) wc.checked = !!ct.worldCheck;
+    const pp = document.getElementById('tfs2-check-passport');     if (pp) pp.checked = !!ct.passport;
+    const amd = document.getElementById('tfs2-check-adverse-deep'); if (amd) amd.checked = !!ct.adverseMediaDeep;
+    // Ongoing screening — preserve prior opt-in.
+    const os = document.getElementById('tfs2-ongoing-screening'); if (os) os.checked = !!e.ongoingScreening;
     document.getElementById('tfs2-event').value = e.eventType||'';
     document.getElementById('tfs2-date').value = e.screeningDate||today();
     document.getElementById('tfs2-reviewer').value = e.reviewedBy||'';
@@ -3452,7 +3866,7 @@ window.csFormatDateInput = function (el) {
 
   global.suite2RunScreening = async function() {
     var name = document.getElementById('tfs2-name')?.value?.trim();
-    var entityType = document.getElementById('tfs2-entity-type')?.value || 'Individual';
+    var entityType = normaliseTfs2EntityType(document.getElementById('tfs2-entity-type')?.value);
     var country = document.getElementById('tfs2-country')?.value?.trim() || '';
     var idNumber = document.getElementById('tfs2-idnumber')?.value?.trim() || '';
     if (!name) { toast('Enter the name to screen', 'error'); return; }
@@ -3633,10 +4047,22 @@ window.csFormatDateInput = function (el) {
     const record = {
       id: editIdx>=0 ? events[editIdx].id : `TFS2-${Date.now()}`,
       screenedName: name,
-      entityType: document.getElementById('tfs2-entity-type')?.value || 'Individual',
+      // Canonical PR-2 entity type — always one of individual / organisation /
+      // unspecified (legacy "Individual" / "Company" normalised at read).
+      entityType: normaliseTfs2EntityType(document.getElementById('tfs2-entity-type')?.value),
       dob: document.getElementById('tfs2-dob')?.value || '',
       country: document.getElementById('tfs2-country')?.value?.trim() || '',
       idNumber: document.getElementById('tfs2-idnumber')?.value?.trim() || '',
+      // PR-2 LSEG World-Check One parity fields. All optional — trimmed,
+      // capped, and omitted-as-blank preserved so legacy records round-trip.
+      altNames: parseTfs2AltNames(document.getElementById('tfs2-altnames')?.value || ''),
+      pob: document.getElementById('tfs2-pob')?.value?.trim() || '',
+      countryLocation: document.getElementById('tfs2-country-location')?.value?.trim() || '',
+      caseId: document.getElementById('tfs2-case-id')?.value?.trim() || '',
+      group: document.getElementById('tfs2-group')?.value?.trim() || '',
+      identifications: readTfs2Identifications(),
+      checkTypes: readTfs2CheckTypes(),
+      ongoingScreening: !!(document.getElementById('tfs2-ongoing-screening')?.checked),
       eventType: document.getElementById('tfs2-event').value,
       listsScreened: lists.join(' | '),
       screeningDate: document.getElementById('tfs2-date').value,
@@ -4541,6 +4967,11 @@ window.csFormatDateInput = function (el) {
     global.renderTFS2 = function() {
       origRenderTFS2();
       setTimeout(patchTFS2Render, 100);
+      // PR-3 — populate the ongoing-screening status banner after each
+      // render. Non-blocking: failures degrade to a local-only paint.
+      if (typeof global.wireTfs2OngoingScreeningBanner === 'function') {
+        setTimeout(global.wireTfs2OngoingScreeningBanner, 120);
+      }
     };
   }
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -51,6 +51,17 @@
   status = 200
   force = true
 
+# Ongoing-Screening opt-in endpoint (PR-3 follow-up). POST-only, Bearer-auth,
+# rate-limited to 60 writes/IP/min. Maintains the canonical opt-in store read
+# by /api/ongoing-screening-status so the banner count is cross-device
+# consistent. Never stores hit details — only subject name + entity type +
+# last-seen timestamp (FDL Art.29 minimum-data principle).
+[[redirects]]
+  from = "/api/ongoing-screening-optin"
+  to = "/.netlify/functions/ongoing-screening-optin"
+  status = 200
+  force = true
+
 # Preserve the stable `/api/continuous-monitor` URL now that the
 # scheduled function can no longer declare a custom `path` (Netlify
 # forbids combining `path:` + `schedule:` — see

--- a/netlify.toml
+++ b/netlify.toml
@@ -40,6 +40,17 @@
   status = 200
   force = true
 
+# Ongoing-Screening status banner endpoint (PR-3). Read-only GET that
+# powers the in-app banner on the screening command page. Rate-limited
+# to 30 req/IP/min. Never returns subject identities — FDL No.(10)/2025
+# Art.29 (no tipping off). Regulatory basis: FDL Art.20-21 (CO
+# situational awareness), Art.24 (audit trail).
+[[redirects]]
+  from = "/api/ongoing-screening-status"
+  to = "/.netlify/functions/ongoing-screening-status"
+  status = 200
+  force = true
+
 # Preserve the stable `/api/continuous-monitor` URL now that the
 # scheduled function can no longer declare a custom `path` (Netlify
 # forbids combining `path:` + `schedule:` — see

--- a/netlify/functions/ongoing-screening-optin.mts
+++ b/netlify/functions/ongoing-screening-optin.mts
@@ -1,0 +1,272 @@
+/**
+ * Ongoing Screening Opt-In endpoint (PR-3 / finding #1 + #3).
+ *
+ * POST /api/ongoing-screening-optin
+ *   body = {
+ *     subjectName: string,           // required, >=1 char, <=200 chars
+ *     subjectId?: string,            // optional, client-stable id; falls
+ *                                    // back to a canonicalised name hash
+ *                                    // when absent
+ *     entityType: "individual" | "organisation" | "unspecified",
+ *     ongoingScreening: boolean,     // true = opt in, false = opt out
+ *   }
+ *   → { ok: true, count }
+ *
+ * Why this exists: the client-side TFS2 records live in localStorage and
+ * are per-browser. Without a server-side opt-in store, the banner cannot
+ * show a consistent "N subjects on daily re-screen" count across devices
+ * for the same MLRO team. This endpoint maintains a single blob
+ * (ongoing-screening-opt-ins / "current") with CAS-safe updates so the
+ * status endpoint can answer authoritatively.
+ *
+ * FDL Art.29 — no tipping off. The store intentionally holds only the
+ * minimum needed to count and de-dupe subjects (name + entity type +
+ * last-seen timestamp). Hit details and screening results are NEVER
+ * written here — those remain in the screening-events store guarded by
+ * four-eyes approval.
+ *
+ * Security design:
+ *   - Bearer-token auth via the shared authenticate middleware (same
+ *     contract as /api/screening/save).
+ *   - Rate-limited to 60 writes/IP/minute to prevent a malicious or
+ *     buggy client from inflating the count via rapid toggles.
+ *   - CAS envelope via setJSON { onlyIfMatch } on getWithMetadata — the
+ *     read-modify-write pattern used across src/services for every
+ *     durable store.
+ *   - Never reflects the payload back verbatim. Returns count only.
+ *
+ * Regulatory basis:
+ *   - FDL No.(10)/2025 Art.20-21 — CO situational awareness across
+ *     all the devices the MLRO team uses.
+ *   - FDL No.(10)/2025 Art.24 — 10-yr retention (CAS-envelope write).
+ *   - FDL No.(10)/2025 Art.29 — no tipping off (minimum-data store).
+ *   - FATF Rec 10 — ongoing CDD (the opt-in is the MLRO's active
+ *     commitment to re-screen).
+ */
+import type { Config, Context } from '@netlify/functions';
+import { getStore } from '@netlify/blobs';
+import { authenticate } from './middleware/auth.mts';
+import { checkRateLimit } from './middleware/rate-limit.mts';
+import {
+  normaliseEntityType,
+  type EntityTypeSupported,
+} from '../../src/domain/constants';
+
+const STORE_NAME = 'ongoing-screening-opt-ins';
+const STORE_KEY = 'current';
+const MAX_BODY_SIZE = 4 * 1024;
+const MAX_CAS_ATTEMPTS = 5;
+const MAX_STORE_SUBJECTS = 10_000;
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin':
+    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://hawkeye-sterling-v2.netlify.app',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+  'Access-Control-Max-Age': '600',
+  Vary: 'Origin',
+} as const;
+
+interface OptInRecord {
+  subjectName: string;
+  entityType: EntityTypeSupported;
+  lastSeenAt: string;
+}
+
+export interface OptInStoreEnvelope {
+  version: 1;
+  updatedAt: string;
+  subjects: Record<string, OptInRecord>;
+}
+
+interface ValidatedBody {
+  key: string;
+  subjectName: string;
+  entityType: EntityTypeSupported;
+  ongoingScreening: boolean;
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return Response.json(body, {
+    ...init,
+    headers: { ...CORS_HEADERS, ...(init.headers ?? {}) },
+  });
+}
+
+export function canonicaliseKey(subjectId: string | undefined, subjectName: string): string {
+  const id = typeof subjectId === 'string' ? subjectId.trim() : '';
+  if (id.length > 0) return 'id:' + id.slice(0, 128).toLowerCase();
+  const name = subjectName.trim().toLowerCase().replace(/\s+/g, ' ');
+  return 'name:' + name.slice(0, 200);
+}
+
+function validateBody(
+  raw: unknown
+): { ok: true; value: ValidatedBody } | { ok: false; error: string } {
+  if (!raw || typeof raw !== 'object') return { ok: false, error: 'body must be a JSON object' };
+  const o = raw as Record<string, unknown>;
+
+  if (typeof o.subjectName !== 'string' || o.subjectName.trim().length === 0) {
+    return { ok: false, error: 'subjectName is required' };
+  }
+  if (o.subjectName.length > 200) return { ok: false, error: 'subjectName too long (max 200)' };
+
+  if (o.subjectId !== undefined && (typeof o.subjectId !== 'string' || o.subjectId.length > 128)) {
+    return { ok: false, error: 'subjectId must be a string up to 128 chars' };
+  }
+
+  const entityType = normaliseEntityType(o.entityType);
+  if (entityType === null) {
+    return { ok: false, error: 'entityType must be individual | organisation | unspecified' };
+  }
+
+  if (typeof o.ongoingScreening !== 'boolean') {
+    return { ok: false, error: 'ongoingScreening must be a boolean' };
+  }
+
+  return {
+    ok: true,
+    value: {
+      key: canonicaliseKey(typeof o.subjectId === 'string' ? o.subjectId : undefined, o.subjectName),
+      subjectName: o.subjectName.trim(),
+      entityType,
+      ongoingScreening: o.ongoingScreening,
+    },
+  };
+}
+
+export function applyOptIn(
+  prior: OptInStoreEnvelope | null,
+  body: ValidatedBody,
+  now: Date = new Date(),
+): OptInStoreEnvelope {
+  const subjects: Record<string, OptInRecord> =
+    prior && prior.subjects && typeof prior.subjects === 'object' ? { ...prior.subjects } : {};
+
+  if (body.ongoingScreening) {
+    // Enforce the safety cap defensively — this should never trip under
+    // normal use (a tenant with >10k ongoing-screening subjects has bigger
+    // problems than a count-off-by-one), but it prevents pathological
+    // growth from a buggy client loop.
+    const existing = subjects[body.key];
+    const size = Object.keys(subjects).length;
+    if (!existing && size >= MAX_STORE_SUBJECTS) {
+      return prior ?? { version: 1, updatedAt: now.toISOString(), subjects };
+    }
+    subjects[body.key] = {
+      subjectName: body.subjectName,
+      entityType: body.entityType,
+      lastSeenAt: now.toISOString(),
+    };
+  } else {
+    delete subjects[body.key];
+  }
+
+  return {
+    version: 1,
+    updatedAt: now.toISOString(),
+    subjects,
+  };
+}
+
+interface BlobStoreWithCas {
+  getWithMetadata: (
+    key: string,
+    opts: { type: 'json' },
+  ) => Promise<{ data: OptInStoreEnvelope | null; etag?: string } | null>;
+  setJSON: (key: string, value: unknown, opts?: { onlyIfMatch?: string }) => Promise<unknown>;
+}
+
+async function writeWithCas(body: ValidatedBody): Promise<{ ok: boolean; count?: number; error?: string }> {
+  let store: BlobStoreWithCas;
+  try {
+    store = getStore({ name: STORE_NAME, consistency: 'strong' }) as unknown as BlobStoreWithCas;
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : 'blob store unavailable' };
+  }
+  for (let attempt = 0; attempt < MAX_CAS_ATTEMPTS; attempt++) {
+    let current: OptInStoreEnvelope | null = null;
+    let etag: string | undefined;
+    try {
+      const read = await store.getWithMetadata(STORE_KEY, { type: 'json' });
+      if (read && read.data && typeof read.data === 'object') {
+        current = read.data;
+        etag = read.etag;
+      }
+    } catch {
+      current = null;
+      etag = undefined;
+    }
+    const next = applyOptIn(current, body);
+    try {
+      await store.setJSON(STORE_KEY, next, etag ? { onlyIfMatch: etag } : undefined);
+      return { ok: true, count: Object.keys(next.subjects).length };
+    } catch (err) {
+      // Retry on CAS miss; bail on any other error after logging nothing
+      // sensitive back to the caller.
+      const msg = err instanceof Error ? err.message : '';
+      if (!/412|precondition/i.test(msg) && attempt === MAX_CAS_ATTEMPTS - 1) {
+        return { ok: false, error: 'store write failed' };
+      }
+    }
+  }
+  return { ok: false, error: 'CAS contention exceeded max attempts' };
+}
+
+export default async (req: Request, context: Context): Promise<Response> => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+  }
+  if (req.method !== 'POST') {
+    return jsonResponse({ ok: false, error: 'Method not allowed.' }, { status: 405 });
+  }
+
+  const rl = await checkRateLimit(req, {
+    max: 60,
+    windowMs: 60_000,
+    clientIp: context.ip,
+    namespace: 'ongoing-screening-optin',
+  });
+  if (rl) return rl;
+
+  const auth = authenticate(req);
+  if (!auth.ok) {
+    return jsonResponse({ ok: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const lenHeader = req.headers.get('content-length');
+  if (lenHeader && Number(lenHeader) > MAX_BODY_SIZE) {
+    return jsonResponse({ ok: false, error: 'Body too large' }, { status: 413 });
+  }
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return jsonResponse({ ok: false, error: 'Body must be valid JSON' }, { status: 400 });
+  }
+
+  const validated = validateBody(raw);
+  if (!validated.ok) {
+    return jsonResponse({ ok: false, error: validated.error }, { status: 400 });
+  }
+
+  const result = await writeWithCas(validated.value);
+  if (!result.ok) {
+    return jsonResponse({ ok: false, error: result.error ?? 'store write failed' }, { status: 500 });
+  }
+  return jsonResponse({ ok: true, count: result.count ?? 0 });
+};
+
+export const config: Config = {
+  method: ['POST', 'OPTIONS'],
+};
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+
+export const __test__ = {
+  canonicaliseKey,
+  validateBody,
+  applyOptIn,
+};

--- a/netlify/functions/ongoing-screening-optin.mts
+++ b/netlify/functions/ongoing-screening-optin.mts
@@ -202,12 +202,19 @@ async function writeWithCas(body: ValidatedBody): Promise<{ ok: boolean; count?:
       await store.setJSON(STORE_KEY, next, etag ? { onlyIfMatch: etag } : undefined);
       return { ok: true, count: Object.keys(next.subjects).length };
     } catch (err) {
-      // Retry on CAS miss; bail on any other error after logging nothing
-      // sensitive back to the caller.
+      // CAS-miss → refetch + retry. Any other error → bail immediately with
+      // a generic message so the caller never sees stack traces or storage
+      // internals (opaque-error principle).
       const msg = err instanceof Error ? err.message : '';
-      if (!/412|precondition/i.test(msg) && attempt === MAX_CAS_ATTEMPTS - 1) {
+      const isCasMiss = /412|precondition/i.test(msg);
+      if (!isCasMiss) {
         return { ok: false, error: 'store write failed' };
       }
+      // CAS miss on the final attempt — give up cleanly.
+      if (attempt === MAX_CAS_ATTEMPTS - 1) {
+        return { ok: false, error: 'CAS contention exceeded max attempts' };
+      }
+      // Otherwise fall through to the next iteration of the for-loop.
     }
   }
   return { ok: false, error: 'CAS contention exceeded max attempts' };

--- a/netlify/functions/ongoing-screening-status.mts
+++ b/netlify/functions/ongoing-screening-status.mts
@@ -8,6 +8,8 @@
  *       timestamp: "2026-04-21T...",
  *       schedule: "0 8 * * *",
  *       nextRunAt: "2026-04-22T08:00:00.000Z",
+ *       subjectCount: number | null,     // null iff the opt-in store
+ *                                        // is unavailable or empty
  *       lastRun: null | {
  *         ranAt: "2026-04-21T08:00:00.123Z",
  *         routineId: "ongoing-screening-daily",
@@ -58,6 +60,8 @@ import { checkRateLimit } from './middleware/rate-limit.mts';
 import { resolveAsanaProjectGid } from '../../src/services/asanaModuleProjects';
 
 const AUDIT_STORE = 'ongoing-screening-audit';
+const OPT_IN_STORE = 'ongoing-screening-opt-ins';
+const OPT_IN_KEY = 'current';
 const ROUTINE_ID = 'ongoing-screening-daily';
 // Mirrored from ongoing-screening-daily-cron.mts `schedule` field. Keep in sync.
 const SCHEDULE_CRON = '0 8 * * *';
@@ -133,6 +137,23 @@ async function listAuditKeys(store: ReturnType<typeof getStore>): Promise<string
   return out;
 }
 
+interface OptInEnvelope {
+  version?: number;
+  subjects?: Record<string, unknown>;
+}
+
+async function readOptInCount(): Promise<number | null> {
+  try {
+    const store = getStore(OPT_IN_STORE);
+    const payload = (await store.get(OPT_IN_KEY, { type: 'json' })) as OptInEnvelope | null;
+    if (!payload || typeof payload !== 'object') return null;
+    if (!payload.subjects || typeof payload.subjects !== 'object') return 0;
+    return Object.keys(payload.subjects).length;
+  } catch {
+    return null;
+  }
+}
+
 async function findLatestRun(): Promise<LastRun | null> {
   let store: ReturnType<typeof getStore>;
   try {
@@ -183,7 +204,7 @@ export default async (req: Request, context: Context): Promise<Response> => {
   if (rl) return rl;
 
   const now = new Date();
-  const lastRun = await findLatestRun();
+  const [lastRun, subjectCount] = await Promise.all([findLatestRun(), readOptInCount()]);
   const routinesProjectGid = resolveAsanaProjectGid('routines');
   const routinesProjectUrl = routinesProjectGid
     ? `https://app.asana.com/0/${routinesProjectGid}`
@@ -195,6 +216,7 @@ export default async (req: Request, context: Context): Promise<Response> => {
       timestamp: now.toISOString(),
       schedule: SCHEDULE_CRON,
       nextRunAt: computeNextRunAt(now),
+      subjectCount,
       lastRun,
       routinesProjectGid,
       routinesProjectUrl,

--- a/netlify/functions/ongoing-screening-status.mts
+++ b/netlify/functions/ongoing-screening-status.mts
@@ -145,10 +145,8 @@ interface OptInEnvelope {
 async function readOptInCount(): Promise<number | null> {
   try {
     const store = getStore(OPT_IN_STORE);
-    const payload = (await store.get(OPT_IN_KEY, { type: 'json' })) as OptInEnvelope | null;
-    if (!payload || typeof payload !== 'object') return null;
-    if (!payload.subjects || typeof payload.subjects !== 'object') return 0;
-    return Object.keys(payload.subjects).length;
+    const payload = (await store.get(OPT_IN_KEY, { type: 'json' })) as unknown;
+    return countSubjectsInEnvelope(payload);
   } catch {
     return null;
   }
@@ -233,6 +231,17 @@ export const config: Config = {
 // Test harness
 // ---------------------------------------------------------------------------
 
+// Pure, synchronous view of the opt-in count logic so it can be
+// unit-tested without spinning up Netlify Blobs in tests. The runtime
+// path (readOptInCount) composes store.get with this function.
+export function countSubjectsInEnvelope(payload: unknown): number | null {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
+  const env = payload as OptInEnvelope;
+  if (!env.subjects || typeof env.subjects !== 'object' || Array.isArray(env.subjects)) return 0;
+  return Object.keys(env.subjects).length;
+}
+
 export const __test__ = {
   computeNextRunAt,
+  countSubjectsInEnvelope,
 };

--- a/netlify/functions/ongoing-screening-status.mts
+++ b/netlify/functions/ongoing-screening-status.mts
@@ -1,0 +1,216 @@
+/**
+ * Ongoing Screening Status — read-only status endpoint powering the
+ * in-app status banner (PR-3).
+ *
+ * GET /api/ongoing-screening-status
+ *   → {
+ *       ok: true,
+ *       timestamp: "2026-04-21T...",
+ *       schedule: "0 8 * * *",
+ *       nextRunAt: "2026-04-22T08:00:00.000Z",
+ *       lastRun: null | {
+ *         ranAt: "2026-04-21T08:00:00.123Z",
+ *         routineId: "ongoing-screening-daily",
+ *         note: "No anomalies detected this run.",
+ *         projectGid: "1201234567890123" | null
+ *       },
+ *       routinesProjectGid: "1201234567890123" | null,
+ *       routinesProjectUrl: "https://app.asana.com/0/1201234567890123" | null
+ *     }
+ *
+ * Why this exists: the MLRO opening the screening command needs to
+ * know — at a glance — that the daily ongoing-screening cron
+ * actually ran, when, and where to go to see the output. Without
+ * this, the "subjects are being re-screened" claim is invisible
+ * until someone clicks into Asana to check. That is the FDL
+ * Art.20-21 "situational awareness" failure mode we are preventing.
+ *
+ * Security design:
+ *   - No auth required. Returns only metadata already visible to
+ *     anyone who opens the MLRO UI (the routines Asana project GID
+ *     is already exposed in the app bundle via /api/env-check, and
+ *     lastRun timestamp / note is non-sensitive).
+ *   - Rate limited (30 req / IP / minute) — the banner auto-refreshes,
+ *     so it polls; the limit keeps this from being abused as a
+ *     generic availability probe.
+ *   - Never returns subject identities, hit details, or any data
+ *     about WHOM has been screened. Absence of those is part of
+ *     FDL Art.29 "no tipping off" — even the existence of an
+ *     ongoing-screening programme on a named subject must not leak.
+ *
+ * Regulatory basis:
+ *   - FDL No.10/2025 Art.20-21 — CO situational awareness.
+ *     The banner surfaces whether the daily routine fired, which is
+ *     the evidence the CO needs that ongoing monitoring is live.
+ *   - FDL No.10/2025 Art.24 — 10-yr audit retention.
+ *     This endpoint reads (never writes) the ongoing-screening-audit
+ *     blob store; the write-side is routineRunner.
+ *   - FATF Rec 10 — ongoing CDD.
+ *     Exposing the "last run" date to the CO is table-stakes evidence
+ *     of the ongoing CDD control being active.
+ *   - FDL No.10/2025 Art.29 — no tipping off.
+ *     This endpoint deliberately does NOT expose subject counts,
+ *     subject IDs, or per-subject delta details.
+ */
+import type { Config, Context } from '@netlify/functions';
+import { getStore } from '@netlify/blobs';
+import { checkRateLimit } from './middleware/rate-limit.mts';
+import { resolveAsanaProjectGid } from '../../src/services/asanaModuleProjects';
+
+const AUDIT_STORE = 'ongoing-screening-audit';
+const ROUTINE_ID = 'ongoing-screening-daily';
+// Mirrored from ongoing-screening-daily-cron.mts `schedule` field. Keep in sync.
+const SCHEDULE_CRON = '0 8 * * *';
+const SCHEDULE_HOUR_UTC = 8;
+const SCHEDULE_MIN_UTC = 0;
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin':
+    process.env.HAWKEYE_ALLOWED_ORIGIN ?? 'https://hawkeye-sterling-v2.netlify.app',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Access-Control-Max-Age': '600',
+  Vary: 'Origin',
+} as const;
+
+interface AuditEntry {
+  routineId?: string;
+  recordedAt?: string;
+  note?: string;
+  projectGid?: string | null;
+}
+
+interface LastRun {
+  ranAt: string;
+  routineId: string;
+  note: string;
+  projectGid: string | null;
+}
+
+function computeNextRunAt(now: Date): string {
+  // Next 08:00 UTC after `now`. If `now` is before today's 08:00 UTC,
+  // use today; else tomorrow.
+  const candidate = new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate(),
+      SCHEDULE_HOUR_UTC,
+      SCHEDULE_MIN_UTC,
+      0,
+      0,
+    ),
+  );
+  if (candidate.getTime() <= now.getTime()) {
+    candidate.setUTCDate(candidate.getUTCDate() + 1);
+  }
+  return candidate.toISOString();
+}
+
+async function listAuditKeys(store: ReturnType<typeof getStore>): Promise<string[]> {
+  const out: string[] = [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const iter = (store as any).list({ paginate: true }) as AsyncIterable<{
+    blobs?: Array<{ key: string }>;
+  }>;
+  try {
+    for await (const page of iter) {
+      for (const b of page.blobs ?? []) out.push(b.key);
+    }
+  } catch {
+    // Older blob client may not support paginate iterator — fall back to single call.
+    try {
+      const single = (await (
+        store as unknown as {
+          list: () => Promise<{ blobs: Array<{ key: string }> }>;
+        }
+      ).list()) as { blobs: Array<{ key: string }> };
+      for (const b of single.blobs ?? []) out.push(b.key);
+    } catch {
+      return [];
+    }
+  }
+  return out;
+}
+
+async function findLatestRun(): Promise<LastRun | null> {
+  let store: ReturnType<typeof getStore>;
+  try {
+    store = getStore(AUDIT_STORE);
+  } catch {
+    return null;
+  }
+  const keys = await listAuditKeys(store);
+  if (keys.length === 0) return null;
+  // Keys are `YYYY-MM-DD/<epochMs>.json` (see src/services/routineRunner.ts)
+  // so a lex sort is already chronological. Fall back to recordedAt when
+  // a record's key doesn't match the expected shape.
+  keys.sort();
+  const newest = keys[keys.length - 1];
+  const payload = (await store.get(newest, { type: 'json' })) as AuditEntry | null;
+  if (!payload || typeof payload !== 'object') return null;
+  return {
+    ranAt:
+      typeof payload.recordedAt === 'string' && payload.recordedAt.length > 0
+        ? payload.recordedAt
+        : new Date().toISOString(),
+    routineId: typeof payload.routineId === 'string' ? payload.routineId : ROUTINE_ID,
+    note: typeof payload.note === 'string' ? payload.note : '',
+    projectGid:
+      typeof payload.projectGid === 'string' && payload.projectGid.length > 0
+        ? payload.projectGid
+        : null,
+  };
+}
+
+export default async (req: Request, context: Context): Promise<Response> => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+  }
+  if (req.method !== 'GET') {
+    return Response.json(
+      { ok: false, error: 'Method not allowed.' },
+      { status: 405, headers: CORS_HEADERS },
+    );
+  }
+
+  const rl = await checkRateLimit(req, {
+    max: 30,
+    windowMs: 60_000,
+    clientIp: context.ip,
+    namespace: 'ongoing-screening-status',
+  });
+  if (rl) return rl;
+
+  const now = new Date();
+  const lastRun = await findLatestRun();
+  const routinesProjectGid = resolveAsanaProjectGid('routines');
+  const routinesProjectUrl = routinesProjectGid
+    ? `https://app.asana.com/0/${routinesProjectGid}`
+    : null;
+
+  return Response.json(
+    {
+      ok: true,
+      timestamp: now.toISOString(),
+      schedule: SCHEDULE_CRON,
+      nextRunAt: computeNextRunAt(now),
+      lastRun,
+      routinesProjectGid,
+      routinesProjectUrl,
+    },
+    { headers: CORS_HEADERS },
+  );
+};
+
+export const config: Config = {
+  method: ['GET', 'OPTIONS'],
+};
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+
+export const __test__ = {
+  computeNextRunAt,
+};

--- a/netlify/functions/screening-save.mts
+++ b/netlify/functions/screening-save.mts
@@ -6,10 +6,35 @@
  *     // Subject identity
  *     subjectName: string,
  *     subjectId?: string,            // echoed back from /api/screening/run
- *     entityType: "individual" | "legal_entity",
+ *     entityType: "individual" | "organisation" | "unspecified",
+ *                                    // legacy values ("legal_entity",
+ *                                    // "Individual", "Company") are accepted
+ *                                    // and normalised on write.
  *     dob?: string,                  // dd/mm/yyyy
  *     country?: string,
  *     idNumber?: string,
+ *
+ *     // ── LSEG World-Check One parity — all optional (PR-2) ──
+ *     altNames?: string[],           // up to 20 alternate names / aliases
+ *     pob?: string,                  // place of birth
+ *     countryLocation?: string,      // residence / operating country
+ *     caseId?: string,               // customer-case reference
+ *     group?: string,                // workflow / portfolio grouping
+ *     identifications?: Array<{
+ *       type: "passport" | "national_id" | "emirates_id"
+ *           | "trade_licence" | "driver_licence" | "tax_id"
+ *           | "lei" | "other",
+ *       number: string,
+ *       issuer?: string,             // issuing country / authority
+ *     }>,
+ *     checkTypes?: {
+ *       worldCheck: boolean,
+ *       passport: boolean,
+ *       adverseMediaDeep: boolean,
+ *     },
+ *     ongoingScreening?: boolean,    // opts subject into the daily
+ *                                    // ongoing-screening cron (FATF Rec 10,
+ *                                    // FDL Art.20-21 — ongoing CDD).
  *
  *     // Event classification
  *     eventType: "new_customer_onboarding" | "periodic_review"
@@ -77,6 +102,11 @@ import {
   type ResolvedIdentity,
   type SerialisedWatchlist,
 } from '../../src/services/screeningWatchlist';
+import {
+  ENTITY_TYPES_SUPPORTED,
+  normaliseEntityType,
+  type EntityTypeSupported,
+} from '../../src/domain/constants';
 
 const EVENTS_STORE = 'screening-events';
 const WATCHLIST_STORE = 'screening-watchlist';
@@ -105,7 +135,9 @@ function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
 // Types
 // ---------------------------------------------------------------------------
 
-const ENTITY_TYPES = ['individual', 'legal_entity'] as const;
+// Canonical entity-type list lives in src/domain/constants.ts; the
+// legacy two-value enum (`individual | legal_entity`) is accepted via
+// ENTITY_TYPE_LEGACY_ALIASES so pre-PR saves continue to round-trip.
 const EVENT_TYPES = [
   'new_customer_onboarding',
   'periodic_review',
@@ -123,9 +155,32 @@ const OUTCOMES = [
   'confirmed_match',
 ] as const;
 const RISK_TIERS = ['high', 'medium', 'low'] as const;
+const ID_TYPES_SUPPORTED = [
+  'passport',
+  'national_id',
+  'emirates_id',
+  'trade_licence',
+  'driver_licence',
+  'tax_id',
+  'lei',
+  'other',
+] as const;
 
-type EntityType = (typeof ENTITY_TYPES)[number];
+type EntityType = EntityTypeSupported;
 type EventType = (typeof EVENT_TYPES)[number];
+type IdType = (typeof ID_TYPES_SUPPORTED)[number];
+
+export interface IdentificationRecord {
+  type: IdType;
+  number: string;
+  issuer?: string;
+}
+
+export interface CheckTypeFlags {
+  worldCheck: boolean;
+  passport: boolean;
+  adverseMediaDeep: boolean;
+}
 type Classification = (typeof CLASSIFICATIONS)[number];
 type Outcome = (typeof OUTCOMES)[number];
 type RiskTier = (typeof RISK_TIERS)[number];
@@ -138,6 +193,15 @@ export interface ScreeningEvent {
   dob?: string;
   country?: string;
   idNumber?: string;
+  // LSEG World-Check One parity — all optional, introduced in PR-2.
+  altNames?: string[];
+  pob?: string;
+  countryLocation?: string;
+  caseId?: string;
+  group?: string;
+  identifications?: IdentificationRecord[];
+  checkTypes?: CheckTypeFlags;
+  ongoingScreening?: boolean;
   eventType: EventType;
   listsScreened: string[];
   overallTopScore: number;
@@ -192,8 +256,15 @@ function validateInput(
     return { ok: false, error: 'subjectId must be a string up to 128 chars' };
   }
 
-  if (!ENTITY_TYPES.includes(o.entityType as EntityType)) {
-    return { ok: false, error: 'entityType must be "individual" | "legal_entity"' };
+  const normalisedEntityType = normaliseEntityType(o.entityType);
+  if (normalisedEntityType === null) {
+    return {
+      ok: false,
+      error:
+        'entityType must be one of: ' +
+        ENTITY_TYPES_SUPPORTED.join(' | ') +
+        ' (legacy values "individual" / "legal_entity" / "Individual" / "Company" are accepted and normalised)',
+    };
   }
 
   let dob: string | undefined;
@@ -213,6 +284,103 @@ function validateInput(
   }
   if (o.idNumber !== undefined && (typeof o.idNumber !== 'string' || o.idNumber.length > 64)) {
     return { ok: false, error: 'idNumber must be a string up to 64 chars' };
+  }
+
+  // ── PR-2 LSEG World-Check One parity — all optional, defensively validated.
+  let altNames: string[] | undefined;
+  if (o.altNames !== undefined) {
+    if (!Array.isArray(o.altNames)) return { ok: false, error: 'altNames must be an array' };
+    if (o.altNames.length > 20) return { ok: false, error: 'altNames has max 20 entries' };
+    const cleaned: string[] = [];
+    for (const n of o.altNames) {
+      if (typeof n !== 'string') return { ok: false, error: 'altNames entries must be strings' };
+      const trimmed = n.trim();
+      if (trimmed.length === 0) continue;
+      if (trimmed.length > 200) return { ok: false, error: 'altNames entry too long (max 200)' };
+      cleaned.push(trimmed);
+    }
+    altNames = cleaned.length > 0 ? cleaned : undefined;
+  }
+
+  if (o.pob !== undefined && (typeof o.pob !== 'string' || o.pob.length > 128)) {
+    return { ok: false, error: 'pob must be a string up to 128 chars' };
+  }
+  if (
+    o.countryLocation !== undefined &&
+    (typeof o.countryLocation !== 'string' || o.countryLocation.length > 64)
+  ) {
+    return { ok: false, error: 'countryLocation must be a string up to 64 chars' };
+  }
+  if (o.caseId !== undefined && (typeof o.caseId !== 'string' || o.caseId.length > 64)) {
+    return { ok: false, error: 'caseId must be a string up to 64 chars' };
+  }
+  if (o.group !== undefined && (typeof o.group !== 'string' || o.group.length > 128)) {
+    return { ok: false, error: 'group must be a string up to 128 chars' };
+  }
+
+  let identifications: IdentificationRecord[] | undefined;
+  if (o.identifications !== undefined) {
+    if (!Array.isArray(o.identifications)) {
+      return { ok: false, error: 'identifications must be an array' };
+    }
+    if (o.identifications.length > 10) {
+      return { ok: false, error: 'identifications has max 10 entries' };
+    }
+    const parsed: IdentificationRecord[] = [];
+    for (const raw of o.identifications) {
+      if (!raw || typeof raw !== 'object') {
+        return { ok: false, error: 'identifications entries must be objects' };
+      }
+      const rec = raw as Record<string, unknown>;
+      if (!ID_TYPES_SUPPORTED.includes(rec.type as IdType)) {
+        return {
+          ok: false,
+          error: 'identifications.type must be one of: ' + ID_TYPES_SUPPORTED.join(', '),
+        };
+      }
+      if (typeof rec.number !== 'string' || rec.number.trim().length === 0) {
+        return { ok: false, error: 'identifications.number is required' };
+      }
+      if (rec.number.length > 64) {
+        return { ok: false, error: 'identifications.number too long (max 64)' };
+      }
+      if (
+        rec.issuer !== undefined &&
+        (typeof rec.issuer !== 'string' || rec.issuer.length > 64)
+      ) {
+        return { ok: false, error: 'identifications.issuer must be a string up to 64 chars' };
+      }
+      parsed.push({
+        type: rec.type as IdType,
+        number: rec.number.trim(),
+        issuer:
+          typeof rec.issuer === 'string' && rec.issuer.trim().length > 0
+            ? rec.issuer.trim()
+            : undefined,
+      });
+    }
+    identifications = parsed.length > 0 ? parsed : undefined;
+  }
+
+  let checkTypes: CheckTypeFlags | undefined;
+  if (o.checkTypes !== undefined) {
+    if (!o.checkTypes || typeof o.checkTypes !== 'object' || Array.isArray(o.checkTypes)) {
+      return { ok: false, error: 'checkTypes must be an object' };
+    }
+    const ct = o.checkTypes as Record<string, unknown>;
+    checkTypes = {
+      worldCheck: ct.worldCheck === true,
+      passport: ct.passport === true,
+      adverseMediaDeep: ct.adverseMediaDeep === true,
+    };
+  }
+
+  let ongoingScreening: boolean | undefined;
+  if (o.ongoingScreening !== undefined) {
+    if (typeof o.ongoingScreening !== 'boolean') {
+      return { ok: false, error: 'ongoingScreening must be a boolean' };
+    }
+    ongoingScreening = o.ongoingScreening;
   }
 
   if (!EVENT_TYPES.includes(o.eventType as EventType)) {
@@ -364,10 +532,19 @@ function validateInput(
     input: {
       subjectName: o.subjectName.trim(),
       subjectId: typeof o.subjectId === 'string' ? o.subjectId.trim() : '',
-      entityType: o.entityType as EntityType,
+      entityType: normalisedEntityType,
       dob,
       country: typeof o.country === 'string' ? o.country.trim() : undefined,
       idNumber: typeof o.idNumber === 'string' ? o.idNumber.trim() : undefined,
+      altNames,
+      pob: typeof o.pob === 'string' ? o.pob.trim() : undefined,
+      countryLocation:
+        typeof o.countryLocation === 'string' ? o.countryLocation.trim() : undefined,
+      caseId: typeof o.caseId === 'string' ? o.caseId.trim() : undefined,
+      group: typeof o.group === 'string' ? o.group.trim() : undefined,
+      identifications,
+      checkTypes,
+      ongoingScreening,
       eventType: o.eventType as EventType,
       listsScreened: (o.listsScreened as string[]).map((l) => l.trim()),
       overallTopScore: o.overallTopScore,

--- a/src/domain/constants.ts
+++ b/src/domain/constants.ts
@@ -371,9 +371,66 @@ export const PF_ANNUAL_TRAINING_HOURS = 4;
  */
 export const PF_RISK_ASSESSMENT_MAX_AGE_DAYS = 400;
 
+// ─── Screening entity types ─────────────────────────────────────────────────
+
+/**
+ * Canonical entity types for the screening command. Expanded from the
+ * historical two-value set (`individual` / `legal_entity`) to match
+ * LSEG World-Check One's subject taxonomy. Vessel intentionally
+ * deferred — the goAML natural-person / legal-entity schema has no
+ * vessel node and rushing a mapping would mask the decision.
+ *
+ * Regulatory basis:
+ *   FDL No.10/2025 Art.20-21 (screening situational awareness)
+ *   FDL No.10/2025 Art.24    (10-yr retention of screening records)
+ *   FATF Rec 10              (ongoing CDD — subject classification)
+ */
+export const ENTITY_TYPES_SUPPORTED = ['individual', 'organisation', 'unspecified'] as const;
+export type EntityTypeSupported = (typeof ENTITY_TYPES_SUPPORTED)[number];
+
+/**
+ * Legacy aliases — values written by older screens or earlier API
+ * contracts that must still round-trip after the upgrade. Kept as a
+ * separate map (rather than inlined in the supported list) so the
+ * canonical UI always writes the new value and the alias table is
+ * read-only compatibility surface.
+ */
+export const ENTITY_TYPE_LEGACY_ALIASES: Readonly<Record<string, EntityTypeSupported>> = {
+  // Old server-side contract (netlify/functions/screening-save.mts pre-PR)
+  legal_entity: 'organisation',
+  // Old TFS modal dropdown values (compliance-suite.js pre-PR)
+  Individual: 'individual',
+  Company: 'organisation',
+  // Belt-and-braces: case-insensitive canonical forms
+  INDIVIDUAL: 'individual',
+  ORGANISATION: 'organisation',
+  ORGANIZATION: 'organisation',
+  organization: 'organisation',
+  UNSPECIFIED: 'unspecified',
+};
+
+/**
+ * Normalise any incoming entityType value to the canonical form.
+ * Returns `null` when the value is not recognised — callers MUST
+ * reject on null rather than coerce silently (FDL Art.20-21: the
+ * MLRO must see unknown inputs, not a coerced guess).
+ */
+export function normaliseEntityType(raw: unknown): EntityTypeSupported | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  if ((ENTITY_TYPES_SUPPORTED as readonly string[]).includes(trimmed)) {
+    return trimmed as EntityTypeSupported;
+  }
+  if (Object.prototype.hasOwnProperty.call(ENTITY_TYPE_LEGACY_ALIASES, trimmed)) {
+    return ENTITY_TYPE_LEGACY_ALIASES[trimmed]!;
+  }
+  return null;
+}
+
 // ─── Version ────────────────────────────────────────────────────────────────
 
 /** Last regulatory update date — update when any constant changes */
-export const REGULATORY_CONSTANTS_VERSION = '2026-04-15';
+export const REGULATORY_CONSTANTS_VERSION = '2026-04-21';
 export const REGULATORY_CONSTANTS_NOTES =
-  'Updated: record retention 5yr→10yr (MoE DPMS Guidance), STR filing to "without delay" (FIU), asset freeze to immediate (EOCN TFS Guidance July 2025), Cabinet Res 156/2025 PF deep-dive constants (review cadence, escalation score, strategic-goods declaration deadline, pause-and-report duration, designation lists, end-use red flags, annual training hours). FDL No.10/2025, Cabinet Res 134/2025, 74/2020, 156/2025, 71/2024, 109/2023.';
+  'Updated: record retention 5yr→10yr (MoE DPMS Guidance), STR filing to "without delay" (FIU), asset freeze to immediate (EOCN TFS Guidance July 2025), Cabinet Res 156/2025 PF deep-dive constants (review cadence, escalation score, strategic-goods declaration deadline, pause-and-report duration, designation lists, end-use red flags, annual training hours). 2026-04-21: added ENTITY_TYPES_SUPPORTED (individual / organisation / unspecified) + legacy alias map for the screening command upgrade — LSEG WC-One parity, vessel deferred pending goAML mapping. FDL No.10/2025, Cabinet Res 134/2025, 74/2020, 156/2025, 71/2024, 109/2023.';

--- a/tests/constants.test.ts
+++ b/tests/constants.test.ts
@@ -316,3 +316,46 @@ describe('Supply Chain Risk Points', () => {
     );
   });
 });
+
+// PR-2 — LSEG World-Check One parity for entity types. Vessel intentionally
+// absent here; when the goAML mapping decision is made, add it to the
+// canonical list and extend these tests.
+describe('Screening entity types (PR-2)', () => {
+  it('canonical list is exactly [individual, organisation, unspecified]', async () => {
+    const { ENTITY_TYPES_SUPPORTED } = await import('../src/domain/constants');
+    expect([...ENTITY_TYPES_SUPPORTED]).toEqual(['individual', 'organisation', 'unspecified']);
+  });
+
+  it('normaliseEntityType passes canonical values through', async () => {
+    const { normaliseEntityType } = await import('../src/domain/constants');
+    expect(normaliseEntityType('individual')).toBe('individual');
+    expect(normaliseEntityType('organisation')).toBe('organisation');
+    expect(normaliseEntityType('unspecified')).toBe('unspecified');
+  });
+
+  it('normaliseEntityType maps legacy server-side "legal_entity" to "organisation"', async () => {
+    const { normaliseEntityType } = await import('../src/domain/constants');
+    expect(normaliseEntityType('legal_entity')).toBe('organisation');
+  });
+
+  it('normaliseEntityType maps legacy TFS dropdown values', async () => {
+    const { normaliseEntityType } = await import('../src/domain/constants');
+    expect(normaliseEntityType('Individual')).toBe('individual');
+    expect(normaliseEntityType('Company')).toBe('organisation');
+  });
+
+  it('normaliseEntityType accepts US spelling and canonicalises', async () => {
+    const { normaliseEntityType } = await import('../src/domain/constants');
+    expect(normaliseEntityType('organization')).toBe('organisation');
+    expect(normaliseEntityType('ORGANIZATION')).toBe('organisation');
+  });
+
+  it('normaliseEntityType returns null for unknown values (no silent coercion)', async () => {
+    const { normaliseEntityType } = await import('../src/domain/constants');
+    expect(normaliseEntityType('robot')).toBeNull();
+    expect(normaliseEntityType('')).toBeNull();
+    expect(normaliseEntityType(undefined)).toBeNull();
+    expect(normaliseEntityType(null)).toBeNull();
+    expect(normaliseEntityType(42)).toBeNull();
+  });
+});

--- a/tests/ongoingScreeningOptInEndpoint.test.ts
+++ b/tests/ongoingScreeningOptInEndpoint.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for netlify/functions/ongoing-screening-optin.mts — exercises the
+ * pure validateBody + applyOptIn + canonicaliseKey helpers via __test__.
+ * No Netlify runtime, no HTTP, no Blobs. The CAS + auth wiring is smoke-
+ * tested in deployment.
+ *
+ * Regulatory basis: FDL No.10/2025 Art.20-21 (CO situational awareness
+ * across devices), Art.24 (CAS-envelope audit trail), Art.29 (no tipping
+ * off — store holds only name + entity type + timestamp), FATF Rec 10
+ * (ongoing CDD — opt-in is the MLRO's active commitment to re-screen).
+ */
+import { describe, it, expect } from 'vitest';
+
+// @ts-expect-error — .mts file has no type declarations at test time
+import { __test__ } from '../netlify/functions/ongoing-screening-optin.mts';
+
+const { canonicaliseKey, validateBody, applyOptIn } = __test__ as {
+  canonicaliseKey: (subjectId: string | undefined, subjectName: string) => string;
+  validateBody: (raw: unknown) =>
+    | { ok: true; value: { key: string; subjectName: string; entityType: string; ongoingScreening: boolean } }
+    | { ok: false; error: string };
+  applyOptIn: (
+    prior:
+      | { version: 1; updatedAt: string; subjects: Record<string, { subjectName: string; entityType: string; lastSeenAt: string }> }
+      | null,
+    body: { key: string; subjectName: string; entityType: string; ongoingScreening: boolean },
+    now?: Date,
+  ) => {
+    version: 1;
+    updatedAt: string;
+    subjects: Record<string, { subjectName: string; entityType: string; lastSeenAt: string }>;
+  };
+};
+
+describe('ongoing-screening-optin — canonicaliseKey', () => {
+  it('prefers subjectId when present', () => {
+    expect(canonicaliseKey('SUBJ-001', 'Jane Doe')).toBe('id:subj-001');
+  });
+
+  it('falls back to normalised name when subjectId is empty', () => {
+    expect(canonicaliseKey(undefined, '  Jane   A.  Doe  ')).toBe('name:jane a. doe');
+  });
+
+  it('de-dupes case and whitespace variants to the same key', () => {
+    expect(canonicaliseKey(undefined, 'JANE DOE')).toBe(canonicaliseKey(undefined, 'jane doe'));
+  });
+});
+
+describe('ongoing-screening-optin — validateBody', () => {
+  const base = () => ({
+    subjectName: 'Jane Doe',
+    entityType: 'individual',
+    ongoingScreening: true,
+  });
+
+  it('accepts a canonical body', () => {
+    const r = validateBody(base());
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value.subjectName).toBe('Jane Doe');
+      expect(r.value.entityType).toBe('individual');
+      expect(r.value.ongoingScreening).toBe(true);
+    }
+  });
+
+  it('normalises legacy entity types via the shared alias map', () => {
+    const r1 = validateBody({ ...base(), entityType: 'Company' });
+    const r2 = validateBody({ ...base(), entityType: 'legal_entity' });
+    expect(r1.ok).toBe(true);
+    expect(r2.ok).toBe(true);
+    if (r1.ok) expect(r1.value.entityType).toBe('organisation');
+    if (r2.ok) expect(r2.value.entityType).toBe('organisation');
+  });
+
+  it('rejects missing / empty subjectName', () => {
+    const r = validateBody({ ...base(), subjectName: '  ' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects oversized subjectName', () => {
+    const r = validateBody({ ...base(), subjectName: 'x'.repeat(201) });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects unknown entityType (no silent coercion)', () => {
+    const r = validateBody({ ...base(), entityType: 'robot' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects non-boolean ongoingScreening', () => {
+    const r = validateBody({ ...base(), ongoingScreening: 'yes' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects oversized subjectId', () => {
+    const r = validateBody({ ...base(), subjectId: 'x'.repeat(129) });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects non-object bodies', () => {
+    expect(validateBody(null).ok).toBe(false);
+    expect(validateBody('string').ok).toBe(false);
+    expect(validateBody(undefined).ok).toBe(false);
+  });
+});
+
+describe('ongoing-screening-optin — applyOptIn', () => {
+  const now = new Date('2026-04-21T08:30:00.000Z');
+  const body = (overrides: Record<string, unknown> = {}) => ({
+    key: 'name:jane doe',
+    subjectName: 'Jane Doe',
+    entityType: 'individual' as const,
+    ongoingScreening: true,
+    ...overrides,
+  });
+
+  it('inserts a new opt-in into an empty store', () => {
+    const next = applyOptIn(null, body(), now);
+    expect(Object.keys(next.subjects).length).toBe(1);
+    expect(next.subjects['name:jane doe'].subjectName).toBe('Jane Doe');
+    expect(next.subjects['name:jane doe'].lastSeenAt).toBe('2026-04-21T08:30:00.000Z');
+  });
+
+  it('updates lastSeenAt on an existing opt-in (idempotent upsert)', () => {
+    const prior = applyOptIn(null, body(), new Date('2026-04-20T00:00:00.000Z'));
+    const next = applyOptIn(prior, body(), now);
+    expect(Object.keys(next.subjects).length).toBe(1);
+    expect(next.subjects['name:jane doe'].lastSeenAt).toBe('2026-04-21T08:30:00.000Z');
+  });
+
+  it('removes the entry when ongoingScreening is false', () => {
+    const prior = applyOptIn(null, body(), now);
+    const next = applyOptIn(prior, body({ ongoingScreening: false }), now);
+    expect(Object.keys(next.subjects).length).toBe(0);
+    expect(next.subjects['name:jane doe']).toBeUndefined();
+  });
+
+  it('tolerates opt-out on an empty store (idempotent)', () => {
+    const next = applyOptIn(null, body({ ongoingScreening: false }), now);
+    expect(Object.keys(next.subjects).length).toBe(0);
+  });
+
+  it('keeps independent entries for different keys', () => {
+    const prior = applyOptIn(null, body({ key: 'name:alice', subjectName: 'Alice' }), now);
+    const next = applyOptIn(prior, body({ key: 'name:bob', subjectName: 'Bob' }), now);
+    expect(Object.keys(next.subjects).length).toBe(2);
+  });
+
+  it('returns a new object (no mutation of the prior envelope)', () => {
+    const prior = applyOptIn(null, body(), now);
+    const before = Object.keys(prior.subjects).length;
+    applyOptIn(prior, body({ key: 'name:alice', subjectName: 'Alice' }), now);
+    expect(Object.keys(prior.subjects).length).toBe(before);
+  });
+});

--- a/tests/ongoingScreeningStatusEndpoint.test.ts
+++ b/tests/ongoingScreeningStatusEndpoint.test.ts
@@ -12,8 +12,9 @@ import { describe, it, expect } from 'vitest';
 // @ts-expect-error — .mts file has no type declarations at test time
 import { __test__ } from '../netlify/functions/ongoing-screening-status.mts';
 
-const { computeNextRunAt } = __test__ as {
+const { computeNextRunAt, countSubjectsInEnvelope } = __test__ as {
   computeNextRunAt: (now: Date) => string;
+  countSubjectsInEnvelope: (raw: unknown) => number | null;
 };
 
 describe('ongoing-screening-status — computeNextRunAt', () => {
@@ -56,5 +57,36 @@ describe('ongoing-screening-status — computeNextRunAt', () => {
     expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
     // And it must parse back to a valid Date.
     expect(Number.isNaN(new Date(result).getTime())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// countSubjectsInEnvelope — covers the opt-in store defensive decoder.
+// ---------------------------------------------------------------------------
+
+describe('ongoing-screening-status — countSubjectsInEnvelope', () => {
+  it('returns null on null / undefined / primitive / array payloads', () => {
+    expect(countSubjectsInEnvelope(null)).toBeNull();
+    expect(countSubjectsInEnvelope(undefined)).toBeNull();
+    expect(countSubjectsInEnvelope('')).toBeNull();
+    expect(countSubjectsInEnvelope(42)).toBeNull();
+    expect(countSubjectsInEnvelope([])).toBeNull();
+    expect(countSubjectsInEnvelope([{ subjects: {} }])).toBeNull();
+  });
+
+  it('returns 0 when subjects is absent or not a plain object', () => {
+    expect(countSubjectsInEnvelope({})).toBe(0);
+    expect(countSubjectsInEnvelope({ version: 1 })).toBe(0);
+    expect(countSubjectsInEnvelope({ subjects: null })).toBe(0);
+    expect(countSubjectsInEnvelope({ subjects: 'nope' })).toBe(0);
+    expect(countSubjectsInEnvelope({ subjects: [] })).toBe(0);
+  });
+
+  it('counts the keys of the subjects map', () => {
+    expect(countSubjectsInEnvelope({ subjects: {} })).toBe(0);
+    expect(countSubjectsInEnvelope({ subjects: { a: {}, b: {} } })).toBe(2);
+    const big: Record<string, unknown> = {};
+    for (let i = 0; i < 50; i++) big['k' + i] = {};
+    expect(countSubjectsInEnvelope({ subjects: big })).toBe(50);
   });
 });

--- a/tests/ongoingScreeningStatusEndpoint.test.ts
+++ b/tests/ongoingScreeningStatusEndpoint.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tests for netlify/functions/ongoing-screening-status.mts — exercises
+ * the pure computeNextRunAt helper via __test__. No Netlify runtime, no
+ * HTTP, no Blobs. The full handler is integration-tested in the UI
+ * smoke test once deployed.
+ *
+ * Regulatory: FDL No.10/2025 Art.20-21 (CO situational awareness),
+ * Art.24 (audit retention of routine runs), FATF Rec 10 (ongoing CDD).
+ */
+import { describe, it, expect } from 'vitest';
+
+// @ts-expect-error — .mts file has no type declarations at test time
+import { __test__ } from '../netlify/functions/ongoing-screening-status.mts';
+
+const { computeNextRunAt } = __test__ as {
+  computeNextRunAt: (now: Date) => string;
+};
+
+describe('ongoing-screening-status — computeNextRunAt', () => {
+  it('returns today at 08:00 UTC when called before today’s 08:00 UTC', () => {
+    const now = new Date('2026-04-21T05:30:00.000Z');
+    expect(computeNextRunAt(now)).toBe('2026-04-21T08:00:00.000Z');
+  });
+
+  it('returns tomorrow at 08:00 UTC when called at today’s 08:00 UTC exactly', () => {
+    // The cron fires at 08:00:00 so the *next* run must be tomorrow.
+    const now = new Date('2026-04-21T08:00:00.000Z');
+    expect(computeNextRunAt(now)).toBe('2026-04-22T08:00:00.000Z');
+  });
+
+  it('returns tomorrow at 08:00 UTC when called after today’s 08:00 UTC', () => {
+    const now = new Date('2026-04-21T14:00:00.000Z');
+    expect(computeNextRunAt(now)).toBe('2026-04-22T08:00:00.000Z');
+  });
+
+  it('rolls into the next month correctly', () => {
+    // 2026-04-30 23:59 UTC → next run is 2026-05-01 08:00 UTC
+    const now = new Date('2026-04-30T23:59:00.000Z');
+    expect(computeNextRunAt(now)).toBe('2026-05-01T08:00:00.000Z');
+  });
+
+  it('rolls into the next year correctly', () => {
+    const now = new Date('2026-12-31T23:59:00.000Z');
+    expect(computeNextRunAt(now)).toBe('2027-01-01T08:00:00.000Z');
+  });
+
+  it('handles leap-day → next-day transition', () => {
+    // 2028 is a leap year; 2028-02-29 09:00 UTC → next run is 2028-03-01 08:00 UTC.
+    const now = new Date('2028-02-29T09:00:00.000Z');
+    expect(computeNextRunAt(now)).toBe('2028-03-01T08:00:00.000Z');
+  });
+
+  it('returns a valid ISO 8601 timestamp', () => {
+    const now = new Date('2026-04-21T10:00:00.000Z');
+    const result = computeNextRunAt(now);
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    // And it must parse back to a valid Date.
+    expect(Number.isNaN(new Date(result).getTime())).toBe(false);
+  });
+});

--- a/tests/prettyEntityType.test.ts
+++ b/tests/prettyEntityType.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for the global window.prettyEntityType display helper defined at
+ * the top of compliance-suite.js. This helper is exercised across three
+ * display sites (approval queue row, approval notes, TFS Asana sync note)
+ * so the MLRO and auditors never see a raw lowercase canonical token.
+ *
+ * Regulatory basis: FDL No.10/2025 Art.20-21 (CO-facing output quality
+ * is part of situational awareness — lower-case enum leaks look like
+ * incomplete data to auditors).
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+type PrettyEntityType = (raw: unknown) => string;
+
+let prettyEntityType: PrettyEntityType;
+
+beforeAll(() => {
+  // compliance-suite.js is a browser IIFE-wrapped script — we only need
+  // the tiny global helper defined at the top (before the first IIFE).
+  // Instead of pulling in the whole 5700-line file (which assumes DOM),
+  // we extract just the helper definition and eval it against a minimal
+  // window shim.
+  const path = join(__dirname, '..', 'compliance-suite.js');
+  const src = readFileSync(path, 'utf8');
+  const start = src.indexOf('window.prettyEntityType = function');
+  expect(start).toBeGreaterThan(-1);
+  // The helper ends at the matching closing };  Find it by tracking braces.
+  let depth = 0;
+  let inString: string | null = null;
+  let i = src.indexOf('{', start);
+  let end = -1;
+  for (; i < src.length; i++) {
+    const c = src[i];
+    if (inString) {
+      if (c === '\\') { i++; continue; }
+      if (c === inString) inString = null;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === '`') { inString = c; continue; }
+    if (c === '{') depth++;
+    else if (c === '}') {
+      depth--;
+      if (depth === 0) {
+        // Expect `};` immediately after the closing brace.
+        end = i + 2;
+        break;
+      }
+    }
+  }
+  expect(end).toBeGreaterThan(start);
+  const helperSrc = src.slice(start, end);
+  const sandbox: { window: { prettyEntityType?: PrettyEntityType } } = { window: {} };
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  const runner = new Function('window', helperSrc + '\nreturn window.prettyEntityType;');
+  prettyEntityType = runner(sandbox.window) as PrettyEntityType;
+  expect(typeof prettyEntityType).toBe('function');
+});
+
+describe('prettyEntityType — canonical tokens', () => {
+  it('individual → Individual', () => {
+    expect(prettyEntityType('individual')).toBe('Individual');
+  });
+  it('organisation → Organisation', () => {
+    expect(prettyEntityType('organisation')).toBe('Organisation');
+  });
+  it('unspecified → Unspecified', () => {
+    expect(prettyEntityType('unspecified')).toBe('Unspecified');
+  });
+});
+
+describe('prettyEntityType — legacy tokens', () => {
+  it('Individual (capitalised legacy) → Individual', () => {
+    expect(prettyEntityType('Individual')).toBe('Individual');
+  });
+  it('Company (legacy TFS dropdown) → Organisation', () => {
+    expect(prettyEntityType('Company')).toBe('Organisation');
+  });
+  it('legal_entity (legacy server contract) → Organisation', () => {
+    expect(prettyEntityType('legal_entity')).toBe('Organisation');
+  });
+  it('organization (US spelling) → Organisation', () => {
+    expect(prettyEntityType('organization')).toBe('Organisation');
+  });
+});
+
+describe('prettyEntityType — empty / unknown', () => {
+  it('empty string → em-dash', () => {
+    expect(prettyEntityType('')).toBe('—');
+  });
+  it('whitespace → em-dash', () => {
+    expect(prettyEntityType('   ')).toBe('—');
+  });
+  it('null → em-dash', () => {
+    expect(prettyEntityType(null)).toBe('—');
+  });
+  it('undefined → em-dash', () => {
+    expect(prettyEntityType(undefined)).toBe('—');
+  });
+  it('unknown value passes through in sentence case', () => {
+    expect(prettyEntityType('robot')).toBe('Robot');
+  });
+});

--- a/tests/prettyEntityType.test.ts
+++ b/tests/prettyEntityType.test.ts
@@ -105,3 +105,95 @@ describe('prettyEntityType — empty / unknown', () => {
     expect(prettyEntityType('robot')).toBe('Robot');
   });
 });
+
+// ---------------------------------------------------------------------------
+// computeTfs2SubjectFingerprint — cross-device opt-in dedup key
+// ---------------------------------------------------------------------------
+//
+// Regulatory basis: FDL No.(10)/2025 Art.20-21 (the MLRO must see an
+// accurate cross-device count; a per-browser ID would inflate the count
+// and make the banner meaningless).
+
+type Fingerprint = (record: unknown) => string;
+let computeFingerprint: Fingerprint;
+
+describe('computeTfs2SubjectFingerprint', () => {
+  beforeAll(() => {
+    // Extract the real helper from compliance-suite.js so any drift in the
+    // FNV-1a implementation breaks these tests immediately. The function is
+    // declared inside an IIFE but also exposed as global.
+    // computeTfs2SubjectFingerprint, so we pluck it via the same sandboxed-
+    // Function pattern used by the prettyEntityType extractor above.
+    const path = join(__dirname, '..', 'compliance-suite.js');
+    const src = readFileSync(path, 'utf8');
+    const start = src.indexOf('function computeTfs2SubjectFingerprint');
+    expect(start).toBeGreaterThan(-1);
+    let depth = 0;
+    let inString: string | null = null;
+    let i = src.indexOf('{', start);
+    let end = -1;
+    for (; i < src.length; i++) {
+      const c = src[i];
+      if (inString) {
+        if (c === '\\') { i++; continue; }
+        if (c === inString) inString = null;
+        continue;
+      }
+      if (c === '"' || c === "'" || c === '`') { inString = c; continue; }
+      if (c === '{') depth++;
+      else if (c === '}') {
+        depth--;
+        if (depth === 0) { end = i + 1; break; }
+      }
+    }
+    expect(end).toBeGreaterThan(start);
+    const helperSrc = src.slice(start, end);
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval
+    const runner = new Function(helperSrc + '\nreturn computeTfs2SubjectFingerprint;');
+    computeFingerprint = runner() as Fingerprint;
+    expect(typeof computeFingerprint).toBe('function');
+  });
+
+  it('is deterministic for the same input', () => {
+    const rec = { screenedName: 'Jane Doe', dob: '15/01/1980', idNumber: 'P12345' };
+    expect(computeFingerprint(rec)).toBe(computeFingerprint(rec));
+  });
+
+  it('same subject on two devices → same fingerprint', () => {
+    const a = { screenedName: '  Jane  Doe  ', dob: '15/01/1980', idNumber: 'p12345' };
+    const b = { screenedName: 'Jane Doe',     dob: '15/01/1980', idNumber: 'P12345' };
+    expect(computeFingerprint(a)).toBe(computeFingerprint(b));
+  });
+
+  it('different DOB → different fingerprints even with same name', () => {
+    const a = { screenedName: 'Jane Doe', dob: '15/01/1980', idNumber: '' };
+    const b = { screenedName: 'Jane Doe', dob: '16/01/1980', idNumber: '' };
+    expect(computeFingerprint(a)).not.toBe(computeFingerprint(b));
+  });
+
+  it('different idNumber → different fingerprints even with same name', () => {
+    const a = { screenedName: 'Jane Doe', dob: '', idNumber: 'P12345' };
+    const b = { screenedName: 'Jane Doe', dob: '', idNumber: 'P67890' };
+    expect(computeFingerprint(a)).not.toBe(computeFingerprint(b));
+  });
+
+  it('returns empty string when no identifying data at all', () => {
+    expect(computeFingerprint({})).toBe('');
+    expect(computeFingerprint({ screenedName: '   ' })).toBe('');
+    expect(computeFingerprint(null)).toBe('');
+  });
+
+  it('is Unicode-safe (Arabic name)', () => {
+    const rec = { screenedName: 'محمد الراشد', dob: '01/01/1970', idNumber: '' };
+    const fp = computeFingerprint(rec);
+    expect(fp).toMatch(/^tfs2:[0-9a-f]{8}$/);
+    // Same input → same hash
+    expect(computeFingerprint({ ...rec })).toBe(fp);
+  });
+
+  it('starts with the tfs2: namespace', () => {
+    const fp = computeFingerprint({ screenedName: 'Test Subject' });
+    expect(fp.startsWith('tfs2:')).toBe(true);
+    expect(fp.length).toBe('tfs2:'.length + 8);
+  });
+});

--- a/tests/screeningSaveEndpoint.test.ts
+++ b/tests/screeningSaveEndpoint.test.ts
@@ -79,10 +79,101 @@ describe('screening-save — validateInput', () => {
     expect(r.ok).toBe(false);
   });
 
-  it('accepts legal_entity', () => {
+  // PR-2: legacy "legal_entity" is accepted and normalised to the new
+  // canonical "organisation" value. See src/domain/constants.ts →
+  // ENTITY_TYPE_LEGACY_ALIASES for the full alias table.
+  it('accepts legacy legal_entity and normalises to organisation', () => {
     const r = validateInput({ ...baseInput(), entityType: 'legal_entity' });
     expect(r.ok).toBe(true);
-    if (r.ok) expect(r.input.entityType).toBe('legal_entity');
+    if (r.ok) expect(r.input.entityType).toBe('organisation');
+  });
+
+  it('accepts canonical organisation', () => {
+    const r = validateInput({ ...baseInput(), entityType: 'organisation' });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.input.entityType).toBe('organisation');
+  });
+
+  it('accepts canonical unspecified', () => {
+    const r = validateInput({ ...baseInput(), entityType: 'unspecified' });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.input.entityType).toBe('unspecified');
+  });
+
+  it('accepts legacy TFS dropdown values (Individual / Company) and normalises', () => {
+    const ind = validateInput({ ...baseInput(), entityType: 'Individual' });
+    expect(ind.ok).toBe(true);
+    if (ind.ok) expect(ind.input.entityType).toBe('individual');
+
+    const org = validateInput({ ...baseInput(), entityType: 'Company' });
+    expect(org.ok).toBe(true);
+    if (org.ok) expect(org.input.entityType).toBe('organisation');
+  });
+
+  it('accepts US-spelling "organization" and normalises to organisation', () => {
+    const r = validateInput({ ...baseInput(), entityType: 'organization' });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.input.entityType).toBe('organisation');
+  });
+
+  // PR-2: new optional LSEG World-Check One parity fields round-trip.
+  it('round-trips the new PR-2 optional fields', () => {
+    const r = validateInput({
+      ...baseInput(),
+      altNames: [' Jane A. Doe ', 'J. Doe', ''],
+      pob: 'Abu Dhabi, AE',
+      countryLocation: 'AE',
+      caseId: 'CASE-2026-0412',
+      group: 'Project Falcon',
+      identifications: [
+        { type: 'passport', number: 'P12345678', issuer: 'AE' },
+        { type: 'emirates_id', number: '784-1980-1234567-0' },
+      ],
+      checkTypes: { worldCheck: true, passport: false, adverseMediaDeep: true },
+      ongoingScreening: true,
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.input.altNames).toEqual(['Jane A. Doe', 'J. Doe']);
+      expect(r.input.pob).toBe('Abu Dhabi, AE');
+      expect(r.input.countryLocation).toBe('AE');
+      expect(r.input.caseId).toBe('CASE-2026-0412');
+      expect(r.input.group).toBe('Project Falcon');
+      expect(r.input.identifications).toEqual([
+        { type: 'passport', number: 'P12345678', issuer: 'AE' },
+        { type: 'emirates_id', number: '784-1980-1234567-0', issuer: undefined },
+      ]);
+      expect(r.input.checkTypes).toEqual({
+        worldCheck: true,
+        passport: false,
+        adverseMediaDeep: true,
+      });
+      expect(r.input.ongoingScreening).toBe(true);
+    }
+  });
+
+  it('rejects identifications with an unsupported type', () => {
+    const r = validateInput({
+      ...baseInput(),
+      identifications: [{ type: 'astrological_chart', number: 'ABC' }],
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('identifications.type');
+  });
+
+  it('rejects identifications with no number', () => {
+    const r = validateInput({
+      ...baseInput(),
+      identifications: [{ type: 'passport', number: '   ' }],
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('identifications.number');
+  });
+
+  it('rejects ongoingScreening that is not a boolean', () => {
+    const r = validateInput({ ...baseInput(), ongoingScreening: 'yes' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('ongoingScreening');
   });
 
   // ---- DoB ----


### PR DESCRIPTION
## Summary

This PR implements two major compliance features:

**PR-2**: Expands the TFS2 screening form to match LSEG World-Check One's subject taxonomy and data model, introducing canonical entity types (`individual` / `organisation` / `unspecified`) with full backward compatibility for legacy values.

**PR-3**: Adds a real-time ongoing-screening status banner that surfaces to the MLRO whether the daily re-screening cron has executed, when it will next run, and how many subjects are enrolled—enabling situational awareness required by FDL Art.20-21 and FATF Rec 10.

## Key Changes

### Entity Type Canonicalisation
- **New canonical types**: `individual`, `organisation`, `unspecified` (replacing the historical `individual` / `legal_entity` binary)
- **Backward compatibility**: Legacy values (`Company`, `legal_entity`, `Individual`, `organization`) are automatically normalised on write via `normaliseEntityType()` in `src/domain/constants.ts`
- **Display helper**: New `window.prettyEntityType()` function ensures the MLRO UI never shows raw lowercase tokens—all three display sites (approval queue, approval notes, Asana sync) use it to render human-readable labels
- **Tests**: Full coverage in `tests/constants.test.ts` and `tests/prettyEntityType.test.ts`

### TFS2 Form Expansion (PR-2)
- **Entity-type tabs**: Replaced the dropdown with three button tabs (`👤 Individual`, `🏢 Organisation`, `❔ Unspecified`) for better UX parity with World-Check One
- **New optional fields**:
  - Alternate names / aliases (up to 20, comma-separated)
  - Place of birth
  - Country location (residence / operation, distinct from nationality)
  - Case ID and group / portfolio
  - Multi-entry identification records (type + number + issuer) with a legacy fallback to the single `idNumber` field
  - Check-type flags (World-Check, Passport verification, Adverse-Media Deep Scan)
  - **Ongoing Screening checkbox**: Opts the subject into the daily 08:00 UTC re-screening cron (FATF Rec 10, FDL Art.20-21)
- **Form layout**: Reorganised into a cleaner grid with better label semantics
- **Backward compatibility**: All new fields are optional; existing records continue to round-trip

### Ongoing-Screening Status Banner (PR-3)
- **New endpoint** `POST /api/ongoing-screening-optin`: Syncs the client-side ongoing-screening flag to a server-side opt-in store (CAS-envelope protected, rate-limited to 60 writes/IP/min)
- **New endpoint** `GET /api/ongoing-screening-status`: Returns aggregate metadata (subject count, next-run countdown, last-run timestamp, Asana project link) without exposing subject identities or hit details (FDL Art.29 compliance)
- **Banner UI**: Displays in the TFS2 command page showing:
  - Count of subjects on daily re-screen
  - Next scheduled run time (08:00 UTC daily)
  - Last run timestamp and link to the Asana routines board
  - Session-dismissible via `sessionStorage`
- **Auto-refresh**: Polls the status endpoint every 5 minutes; countdown ticks every 1 minute
- **Deduplication**: Client-side fingerprinting via `computeTfs2SubjectFingerprint()` (FNV-1a hash of name|dob|idNumber) ensures the same subject saved on two MLRO devices counts as one
- **Tests**: Comprehensive unit tests in `tests/ongoingScreeningOptInEndpoint.test.ts` and `tests/ongoingScreeningStatusEndpoint.test.ts`

### Backend Integration
- **screening-save.mts**: Updated to accept and normalise the new entity types and optional PR-2 fields; validates identifications array and check-type flags
- **netlify.toml**: Added routing for the two new endpoints with appropriate CORS headers and rate-limiting rules

https://claude.ai/code/session_015WaFwxwS73gREKVYrCrn46